### PR TITLE
Add keyword to AutoReg() to avoid Future Warning

### DIFF
--- a/mesmer/calibrate_mesmer/train_lv.py
+++ b/mesmer/calibrate_mesmer/train_lv.py
@@ -208,7 +208,6 @@ def train_lv_AR1_sci(params_lv, targs, y, wgt_scen_eq, aux, cfg):
                     AR1_model = AutoReg(
                         targ[scen][run, :, gp], lags=1, old_names=False
                     ).fit()
-                    # old_names=False temporarily needed to avoid Future Warning (in statsmodels 0.12.2)
                     AR1_int_runs[gp] += AR1_model.params[0] / nr_runs
                     AR1_coef_runs[gp] += AR1_model.params[1] / nr_runs
                     AR1_std_innovs_runs[gp] += (


### PR DESCRIPTION
In AutoReg().fit() call in train_lv() add keyword old_names=False to stop
Future Warning from appearing every time the function is called. The
Future Warning is part of statsmodels v 0.12.2 because parameter
names will change in the newer versions. The AR parameter estimates are
not affected by the introduction of this keyword.