### PR TITLE
git: ignore .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# vscode folder
+.vscode


### PR DESCRIPTION
I am testing vscode so I'd need to ignore their config folder.