### PR TITLE
Fix typo in docstring

### DIFF
--- a/mesmer/calibrate_mesmer/train_utils.py
+++ b/mesmer/calibrate_mesmer/train_utils.py
@@ -24,7 +24,7 @@ def train_l_prepare_X_y_wgteq(preds, targs):
 
     Returns:
     - X (np.ndarray): empty array if none, else 2d array (sample,pred) of predictors
-    - y (np.ndarray): 3d array (sample,gp,targ) or targets
+    - y (np.ndarray): 3d array (sample,gp,targ) of targets
     - wgt_scen_eq (np.ndarray): 1d array (sample) of sample weights based on equal treatment of each scenario (if scen has more samples, each sample gets less weight)
 
     """


### PR DESCRIPTION
Fixes a typo in the docstring of `train_l_prepare_X_y_wgteq()` in `train_utils.py`. It seems slightly absurd to have an actual PR for this. But I changed this typo a while ago and it interfered with me being able to switch freely between branches. Doing a PR for it seemed the most straightforward solution to deal with this.