### PR TITLE
linting: exclude versioneer.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ exclude=
 profile=black
 default_section=THIRDPARTY
 known_first_party=mesmer
+extend_skip=versioneer.py
 
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,4 @@
-
+# fmt: off
 # Version: 0.19
 
 """The Versioneer - like a rocketeer, but for versions.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #83
 - [x] Passes `isort . && black . && flake8` :wink: 

Ah well black requires a `pyproject.toml` file for configuration. I am not sure if adding this file changes the behavior of ` python setup.py sdist bdist_wheel` so I just set `# fmt: off` in `versioneer.py`.

A alternative would be to use setuptools_scm for the versioning. xarray uses this and it looks kind of neat, but I haven't yet tested that in any project.