### PR TITLE
Speed up geodist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,10 +29,10 @@ Internal Changes
 
  - Refactor and speed up of the Gaspari-Cohn function and the calculation of the great
    circle distance (`#85 <https://github.com/MESMER-group/mesmer/pull/85>`_,
-   `#86 <https://github.com/MESMER-group/mesmer/pull/86>`_).
+   `#88 <https://github.com/MESMER-group/mesmer/pull/88>`_).
    By `Mathias Hauser <https://github.com/mathause>`_.
  - The geopy package is no longer a dependency of mesmer
-   (`#86 <https://github.com/MESMER-group/mesmer/pull/86>`_).
+   (`#88 <https://github.com/MESMER-group/mesmer/pull/88>`_).
    By `Mathias Hauser <https://github.com/mathause>`_.
 
 v0.8.1 - 2021-07-15

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,8 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 
  - Refactor and speed up of the Gaspari-Cohn function and the calculation of the great
-   circle distance (`#85 <https://github.com/MESMER-group/mesmer/pull/85>`_).
+   circle distance (`#85 <https://github.com/MESMER-group/mesmer/pull/85>`_,
+   `#86 <https://github.com/MESMER-group/mesmer/pull/86>`_).
    By `Mathias Hauser <https://github.com/mathause>`_.
 
 v0.8.1 - 2021-07-15

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,9 @@ Internal Changes
    circle distance (`#85 <https://github.com/MESMER-group/mesmer/pull/85>`_,
    `#86 <https://github.com/MESMER-group/mesmer/pull/86>`_).
    By `Mathias Hauser <https://github.com/mathause>`_.
+ - The geopy package is no longer a dependency of mesmer
+   (`#86 <https://github.com/MESMER-group/mesmer/pull/86>`_).
+   By `Mathias Hauser <https://github.com/mathause>`_.
 
 v0.8.1 - 2021-07-15
 -------------------

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - dask[complete]
   - flake8
   - gdal
-  - geopy
   - isort
   - netcdf4
   - numpy

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,6 @@ Required dependencies
 
 - Python (3.7 or later)
 - `dask <https://dask.org/>`__
-- `geopy <https://geopy.readthedocs.io/en/stable/>`__
 - `numpy <http://www.numpy.org/>`__
 - `pandas <https://pandas.pydata.org/>`__
 - `scikit-learn <https://scikit-learn.org/stable/>`__

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ cython
 dask[complete]
 flake8
 gdal
-geopy
 isort
 netcdf4
 numpy

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -12,8 +12,8 @@ import os
 
 import joblib
 import numpy as np
-import regionmask as regionmask
 import pyproj
+import regionmask as regionmask
 
 from ..utils.regionmaskcompat import mask_percentage
 from ..utils.xrcompat import infer_interval_breaks
@@ -105,7 +105,7 @@ def calc_geodist_exact(lon, lat):
         lt = np.tile(lat[i], n_points - (i + 1))
         ln = np.tile(lon[i], n_points - (i + 1))
 
-        geodist[i, i + 1:] = geod.inv(ln, lt, lon[i+1:], lat[i+1:])[2]
+        geodist[i, i + 1 :] = geod.inv(ln, lt, lon[i + 1 :], lat[i + 1 :])[2]
 
     # convert m to km
     geodist /= 1000

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -98,7 +98,7 @@ def calc_geodist_exact(lon, lat):
 
     geodist = np.zeros([n_points, n_points])
 
-    # calculate only the lower half of the triangle
+    # calculate only the upper right half of the triangle
     for i in range(n_points):
 
         # need to duplicate gridpoint (required by geod.inv)
@@ -109,7 +109,7 @@ def calc_geodist_exact(lon, lat):
 
     # convert m to km
     geodist /= 1000
-    # fill the upper half of the triangle (in-place)
+    # fill the lower left half of the triangle (in-place)
     geodist += np.transpose(geodist)
 
     return geodist

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -13,7 +13,7 @@ import os
 import joblib
 import numpy as np
 import regionmask as regionmask
-from geographiclib.geodesic import Geodesic
+import pyproj
 
 from ..utils.regionmaskcompat import mask_percentage
 from ..utils.xrcompat import infer_interval_breaks
@@ -87,23 +87,29 @@ def calc_geodist_exact(lon, lat):
         2D array of great circle distances.
     """
 
-    # semi-major axis and flattening according to WGS 84
-    g = Geodesic(6378.137, 1 / 298.257223563)
+    # ensure correct shape
+    lon, lat = np.asarray(lon), np.asarray(lat)
+    if lon.shape != lat.shape or lon.ndim != 1:
+        raise ValueError("lon and lat need to be 1D arrays of the same shape")
+
+    geod = pyproj.Geod(ellps="WGS84")
 
     n_points = len(lon)
 
     geodist = np.zeros([n_points, n_points])
 
-    # calculate only the upper half of the triangle
+    # calculate only the lower half of the triangle
     for i in range(n_points):
-        lt, ln = lat[i], lon[i]
-        for j in range(i + 1, n_points):
-            geodist[i, j] = g.Inverse(lt, ln, lat[j], lon[j], Geodesic.DISTANCE)["s12"]
 
-        if i % 200 == 0:
-            print("done with gp", i)
+        # need to duplicate gridpoint (required by geod.inv)
+        lt = np.tile(lat[i], n_points - (i + 1))
+        ln = np.tile(lon[i], n_points - (i + 1))
 
-    # fill the lower half of the triangle (in-place)
+        geodist[i, i + 1:] = geod.inv(ln, lt, lon[i+1:], lat[i+1:])[2]
+
+    # convert m to km
+    geodist /= 1000
+    # fill the upper half of the triangle (in-place)
     geodist += np.transpose(geodist)
 
     return geodist

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ CLASSIFIERS = [
 
 REQUIREMENTS_INSTALL = [
     "dask[complete]",
-    "geopy",
     "numpy",
     "pandas",
     "scikit-learn",

--- a/tests/integration/test_calibrate_mesmer.py
+++ b/tests/integration/test_calibrate_mesmer.py
@@ -29,6 +29,8 @@ def _check_dict(first, second, first_name, second_name):
             npt.assert_allclose(first_val, second_val)
         elif isinstance(first_val, xr.DataArray):
             xrt.assert_allclose(first_val, second_val)
+        elif np.issubdtype(np.array(first_val).dtype, np.number):
+            npt.assert_allclose(first_val, second_val)
         else:
             assert first_val == second_val, k
 

--- a/tests/test_phi_gc.py
+++ b/tests/test_phi_gc.py
@@ -82,6 +82,18 @@ def test_gaspari_cohn():
     values = np.arange(9).reshape(3, 3)
     assert gaspari_cohn(values).shape == (3, 3)
 
+def test_calc_geodist_exact_shape():
+
+    msg = "lon and lat need to be 1D arrays of the same shape"
+
+    # not the same shape
+    with pytest.raises(ValueError, match=msg):
+        calc_geodist_exact([0, 0], [0])
+
+    # not 1D
+    with pytest.raises(ValueError, match=msg):
+        calc_geodist_exact([[0, 0]], [[0, 0]])
+
 
 def test_calc_geodist_exact_equal():
     """test points with distance 0"""

--- a/tests/test_phi_gc.py
+++ b/tests/test_phi_gc.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from mesmer.io import (
     calc_geodist_exact,
@@ -81,6 +82,7 @@ def test_gaspari_cohn():
     # make sure shape is conserved
     values = np.arange(9).reshape(3, 3)
     assert gaspari_cohn(values).shape == (3, 3)
+
 
 def test_calc_geodist_exact_shape():
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

As suggested in https://github.com/MESMER-group/mesmer/issues/62#issuecomment-901352376 - speed up `calc_geodist_exact` considerably using pyproj. This allows to remove geopy from the list of dependencies. pyproj is a dependency of geopandas which is a dependency of regionmask - might be a good idea to explicitly list it but oh well.