### PR TITLE
remove inline comments

### DIFF
--- a/mesmer/calibrate_mesmer/calibrate_mesmer.py
+++ b/mesmer/calibrate_mesmer/calibrate_mesmer.py
@@ -290,7 +290,8 @@ def _calibrate_and_draw_realisations(
         preds_lv = {"gvtas": gv_novolc_T_s}  # predictors_list
 
         # Create local variability due to global variability warming samples
-        # used for training the local variability module. Samples are cheap to create so not an issue to have here.
+        # used for training the local variability module. Samples are cheap to create so
+        # not an issue to have here.
         lv_gv_s = create_emus_lv(
             params_lv, preds_lv, cfg, save_emus=False, submethod="OLS"
         )
@@ -306,9 +307,10 @@ def _calibrate_and_draw_realisations(
 
         LOGGER.debug("Loading auxiliary files")
         aux = {}
+        # better results with default values L, but faster + less space needed
         aux["phi_gc"] = load_phi_gc(
             lon, lat, ls, cfg, L_start=1750, L_end=2000, L_interval=250
-        )  # better results with default values L, but like this much faster + less space needed
+        )
 
         LOGGER.debug("Finalising training of local variability module on derived data")
         targs_res_lv = {"tas": res_lv_s}

--- a/mesmer/calibrate_mesmer/train_gt.py
+++ b/mesmer/calibrate_mesmer/train_gt.py
@@ -124,9 +124,8 @@ def train_gt(var, targ, esm, time, cfg, save_params=True):
         elif params_gt["method"] == "LOWESS":
             params_gt["hist"] = gt_lowess_hist
 
-        scenarios_tr_f = list(
-            map(lambda x: x.replace("h-", ""), scenarios_tr)
-        )  # isolte future scen names
+        # isolate future scen names
+        scenarios_tr_f = list(map(lambda x: x.replace("h-", ""), scenarios_tr))
 
     else:
         idx_start_year_fut = 0  # because first year would be already in future
@@ -183,9 +182,9 @@ def train_gt_ic_LOWESS(var):
     av_var = np.mean(var, axis=0)
 
     # apply lowess smoother to further smooth the Tglob time series
-    frac_lowess = (
-        50 / nr_ts
-    )  # rather arbitrarily chosen value that gives a smooth enough trend,
+    # rather arbitrarily chosen value that gives a smooth enough trend,
+    frac_lowess = 50 / nr_ts
+
     # open to changes but if much smaller, var trend ends up very wiggly
     frac_lowess_name = "50/nr_ts"
 
@@ -243,19 +242,21 @@ def train_gt_ic_OLSVOLC(var, gt_lowess, time, cfg):
 
     if nr_ts != nr_aod_obs:
         raise ValueError(
-            f"The number of time steps of the variable ({nr_ts}) and the saod ({nr_aod_obs}) do not match."
+            f"The number of time steps of the variable ({nr_ts}) and the saod "
+            "({nr_aod_obs}) do not match."
         )
-    # extract global variability (which still includes volc eruptions) by removing smooth trend from Tglob in historic period
+    # extract global variability (which still includes volc eruptions) by removing
+    # smooth trend from Tglob in historic period
     gv_all_for_aod = np.zeros(nr_runs * nr_aod_obs)
     i = 0
     for run in np.arange(nr_runs):
         gv_all_for_aod[i : i + nr_aod_obs] = var[run] - gt_lowess
         i += nr_aod_obs
     # fit linear regression of gv to aod (because some ESMs react very strongly to volcanoes)
+    # no intercept to not artifically move the ts
     linreg_gv_volc = LinearRegression(fit_intercept=False).fit(
         aod_obs_all, gv_all_for_aod
-    )  # no intercept to not artifically
-    # move the ts
+    )
 
     # extract the saod coefficient
     coef_saod = linreg_gv_volc.coef_[0]

--- a/mesmer/calibrate_mesmer/train_utils.py
+++ b/mesmer/calibrate_mesmer/train_utils.py
@@ -42,9 +42,8 @@ def train_l_prepare_X_y_wgteq(preds, targs):
     pred_names = list(preds.keys())
 
     # identify characteristics of the predictors and the targets
-    targ = targs[
-        targ_name
-    ]  # predictors are not influenced by whether there is a single or there are multiple targets
+    # predictors are not influenced by whether there is a single or there are multiple targets
+    targ = targs[targ_name]
     scens = list(targ.keys())
 
     # assumption: nr_runs per scen and nr_ts for these runs can vary
@@ -70,17 +69,14 @@ def train_l_prepare_X_y_wgteq(preds, targs):
             s = 0  # index for samples
             pred_raw = preds[pred_name]  # values of predictor p
             for scen in scens:
-                if (
-                    len(pred_raw[scen].shape) == 2
-                ):  # if 1 time series per run for predictor (e.g., gv)
-                    k = (
-                        pred_raw[scen].shape[0] * pred_raw[scen].shape[1]
-                    )  # nr_runs*nr_ts for this specific scenario
+                # if 1 time series per run for predictor (e.g., gv)
+                if len(pred_raw[scen].shape) == 2:
+                    # nr_runs*nr_ts for this specific scenario
+                    k = pred_raw[scen].shape[0] * pred_raw[scen].shape[1]
                     X[s : s + k, p] = pred_raw[scen].flatten()
                     s += k
-                elif (
-                    len(pred_raw[scen].shape) == 1
-                ):  # if single time series as predictor (e.g. gt): repeat ts as many times as runs available
+                # if single time series as predictor (e.g. gt): repeat ts as many times as runs available
+                elif len(pred_raw[scen].shape) == 1:
                     nr_runs, nr_ts, nr_gps = targ[scen].shape
                     nr_samples_scen = nr_runs * nr_ts
                     X[s : s + nr_samples_scen, p] = np.tile(pred_raw[scen], nr_runs)
@@ -94,9 +90,8 @@ def train_l_prepare_X_y_wgteq(preds, targs):
         targ = targs[targ_name]
         s = 0
         for scen in scens:
-            k = (
-                targ[scen].shape[0] * targ[scen].shape[1]
-            )  # nr_runs*nr_ts for this scenario
+            # nr_runs * nr_ts for this scenario
+            k = targ[scen].shape[0] * targ[scen].shape[1]
             y[s : s + k, :, t] = targ[scen].reshape(k, -1)
             s += k
 

--- a/mesmer/create_emulations/create_emus_gv.py
+++ b/mesmer/create_emulations/create_emus_gv.py
@@ -176,10 +176,8 @@ def create_emus_gv_AR(params_gv, nr_emus_v, nr_ts_emus_v, seed):
             emus_gv[i, t] = (
                 ar_int
                 + sum(
-                    [
-                        ar_coefs[k] * emus_gv[i, t - ar_lags[k]]
-                        for k in np.arange(len(ar_lags))
-                    ]
+                    ar_coefs[k] * emus_gv[i, t - ar_lags[k]]
+                    for k in np.arange(len(ar_lags))
                 )
                 + innovs_emus_gv[i, t]
             )

--- a/mesmer/create_emulations/create_emus_lt.py
+++ b/mesmer/create_emulations/create_emus_lt.py
@@ -103,7 +103,8 @@ def create_emus_lt(params_lt, preds_lt, cfg, concat_h_f=False, save_emus=True):
         method_lt = method_lt + "_each_gp_sep"
     else:
         raise ValueError(
-            f"No such method ({params_lt['method_each_gp_sep']}) is currently implemented."
+            f"No such method ({params_lt['method_each_gp_sep']}) is currently "
+            "implemented."
         )
 
     create_emus_method_lt = create_emus_method_func_mapping[method_lt]

--- a/mesmer/create_emulations/create_emus_lv.py
+++ b/mesmer/create_emulations/create_emus_lv.py
@@ -175,7 +175,8 @@ def create_emus_lv_AR1_sci(emus_lv, params_lv, preds_lv, cfg):
             seed = seed_all_scens[scen]["lv"]
             nr_gps = len(params_lv["AR1_int"][targ])
 
-            # in case no emus_lv[scen] exist yet, initialize it. Otherwise build up on existing one
+            # in case no emus_lv[scen] exist yet, initialize it. Otherwise build up on
+            # existing one
             if len(emus_lv[scen]) == 0:
 
                 emus_lv[scen][targ] = np.zeros(nr_emus_v, nr_ts_emus_stoch_v, nr_gps)
@@ -195,7 +196,8 @@ def create_emus_lv_AR1_sci(emus_lv, params_lv, preds_lv, cfg):
             )
 
             print(
-                "Compute the contribution to emus_lv by the AR(1) process with the spatially correlated innovations"
+                "Compute the contribution to emus_lv by the AR(1) process with the "
+                "spatially correlated innovations"
             )
             emus_lv_tmp = np.zeros([nr_emus_v, nr_ts_emus_stoch_v + buffer, nr_gps])
             for t in np.arange(1, nr_ts_emus_stoch_v + buffer):

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -284,29 +284,25 @@ def load_regs_ls_wgt_lon_lat(reg_type, lon, lat):
     reg_dict["type"] = reg_type
     reg_dict["abbrevs"] = reg.abbrevs
     reg_dict["names"] = reg.names
-    reg_dict["grids"] = mask_percentage(
-        reg, lon["c"], lat["c"]
-    ).values  # have fraction of grid cells
-    reg_dict["grid_b"] = reg.mask(
-        lon["c"], lat["c"]
-    ).values  # not sure yet if needed: "binary" grid with each grid point assigned to single country
-    reg_dict[
-        "full"
-    ] = reg  # to be used for plotting outlines (mainly useful for srex regs)
+    # have fraction of grid cells
+    reg_dict["grids"] = mask_percentage(reg, lon["c"], lat["c"]).values
+    # not sure yet if needed: "binary" grid with each grid point assigned to single country
+    reg_dict["grid_b"] = reg.mask(lon["c"], lat["c"]).values
+    # to be used for plotting outlines (mainly useful for srex regs)
+    reg_dict["full"] = reg
 
     # obtain a (subsampled) land-sea mask
     ls = {}
-    ls["grid_raw"] = np.squeeze(
-        mask_percentage(
-            regionmask.defined_regions.natural_earth.land_110, lon["c"], lat["c"]
-        ).values
-    )
-    # gives fraction of land -> in extract_land() script decide above which land fraction threshold to consider a grid point as a land grid point
+    land_110 = regionmask.defined_regions.natural_earth.land_110
+
+    # gives fraction of land -> in extract_land() script decide above which land
+    # fraction threshold to consider a grid point as a land grid point
+    ls["grid_raw"] = np.squeeze(mask_percentage(land_110, lon["c"], lat["c"]).values)
 
     # remove Antarctica
     idx_ANT = np.where(lat["c"] < -60)[0]
     ls["grid_no_ANT"] = copy.deepcopy(ls["grid_raw"])
-    ls["grid_no_ANT"][idx_ANT] = 0  #
+    ls["grid_no_ANT"][idx_ANT] = 0
 
     # derive the weights
     lon["grid"], lat["grid"] = np.meshgrid(lon["c"], lat["c"])

--- a/mesmer/io/save_mesmer_bundle.py
+++ b/mesmer/io/save_mesmer_bundle.py
@@ -40,7 +40,8 @@ def save_mesmer_bundle(
         - ["method"] (applied method, str)
         - [xx] (additional keys depending on employed method)
     params_gv : dict
-        dictionary containing the calibrated parameters for the global variability emulations, keys relevant here
+        dictionary containing the calibrated parameters for the global variability
+        emulations, keys relevant here
 
         - ["targ"] (variable which is emulated, str)
         - ["esm"] (Earth System Model, str)

--- a/mesmer/utils/regionmaskcompat.py
+++ b/mesmer/utils/regionmaskcompat.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 
 
-def mask_percentage(regions, lon, lat):
+def mask_percentage(regions, lon, lat, **kwargs):
     """Sample with 10 times higher resolution.
 
     Notes
@@ -20,7 +20,7 @@ def mask_percentage(regions, lon, lat):
     lon_sampled = sample_coord(lon)
     lat_sampled = sample_coord(lat)
 
-    mask = regions.mask(lon_sampled, lat_sampled)
+    mask = regions.mask(lon_sampled, lat_sampled, **kwargs)
 
     isnan = np.isnan(mask.values)
 

--- a/mesmer/utils/select.py
+++ b/mesmer/utils/select.py
@@ -78,37 +78,35 @@ def extract_land(var, reg_dict, wgt, ls, threshold_land=0.25):
     ls["gp_l"] = ls["grid_no_ANT"][idx_l]
     ls["grid_l"] = copy.deepcopy(ls["grid_no_ANT"])
     ls["grid_l"][~idx_l] = 0
-    ls["idx_grid_l"] = (
-        ls["grid_l"] > threshold_land
-    )  # gives back a binary (boolean) mask to help with plotting
+    # gives back a binary (boolean) mask to help with plotting
+    ls["idx_grid_l"] = ls["grid_l"] > threshold_land
+    # masked array (ocean masked out)
     ls["grid_l_m"] = np.ma.masked_array(
         ls["grid_l"], mask=np.logical_not(ls["idx_grid_l"])
-    )  # masked array (ocean masked out)
-    ls["wgt_gp_l"] = (
-        wgt[idx_l] * ls["gp_l"]
-    )  # weights for land points: multiply weight by land fraction
+    )
+    # weights for land points: multiply weight by land fraction
+    ls["wgt_gp_l"] = wgt[idx_l] * ls["gp_l"]
 
     # extract the land points + weights from the region grids
     reg_dict["gps_l"] = reg_dict["grids"][:, idx_l]  # country is the first axis
-    reg_dict["wgt_gps_l"] = (
-        wgt[idx_l] * reg_dict["gps_l"]
-    )  # weights for regions (1st axis): region fraction * area weights
+    # weights for regions (1st axis): region fraction * area weights
+    reg_dict["wgt_gps_l"] = wgt[idx_l] * reg_dict["gps_l"]
+
     if reg_dict["type"] == "srex" or reg_dict["type"] == "ar6.land":
-        reg_dict["wgt_gps_l"] = (
-            reg_dict["wgt_gps_l"] * ls["gp_l"]
-        )  # * land fraction to account for coastal cells because SREX / ar6.land regions include ocean
-    reg_dict["gp_b_l"] = reg_dict["grid_b"][
-        idx_l
-    ]  # not sure if needed; extracts land from the "binary" mask
+        # multipyl by land fraction to account for coastal cells
+        # because SREX / ar6.land regions include ocean
+        reg_dict["wgt_gps_l"] = reg_dict["wgt_gps_l"] * ls["gp_l"]
+
+    # not sure if needed; extracts land from the "binary" mask
+    reg_dict["gp_b_l"] = reg_dict["grid_b"][idx_l]
 
     # extract the land points of the variable of interest
     var_l = {}
     for esm in var.keys():
         var_l[esm] = {}
         for scen in var[esm].keys():
-            var_l[esm][scen] = var[esm][scen][
-                :, :, idx_l
-            ]  # run is the first axis, followed by time
+            # run is the first axis, followed by time
+            var_l[esm][scen] = var[esm][scen][:, :, idx_l]
 
     return var_l, reg_dict, ls
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

Moves a number of inline comments to their own line - especially if this allows to have the code on one line instead of several, e.g.:

```diff
- if (
-     condition
- ): # this is a long comment
+ # this is a long comment
+ if condition:
```

I find this can (often) increase readability considerably. These lines are most likely a artifact of applying black.

I did this relatively fast, so there is more stuff that could be cleaned. I suggest to merge soon after #93. As the code is the same (unless I made an error) I added no tests.





