### PR TITLE
fix a numpy and a xarray deprecation

### DIFF
--- a/mesmer/io/_load_cmipng.py
+++ b/mesmer/io/_load_cmipng.py
@@ -349,14 +349,14 @@ def load_cmipng_file(run_path, gen, scen):
             data = xr.open_mfdataset(
                 [run_path_hist, run_path_ssp_585, run_path_ssp_534over],
                 combine="by_coords",
-                concat_dim="time",
                 preprocess=preprocess_ssp534over,
             )
         else:  # for every other scenario
             run_path_ssp = run_path
             run_path_hist = run_path.replace(scen, "historical")
             data = xr.open_mfdataset(
-                [run_path_hist, run_path_ssp], combine="by_coords", concat_dim="time"
+                [run_path_hist, run_path_ssp],
+                combine="by_coords",
             )
 
         data = data.roll(lon=72, roll_coords=True)  # roll so land in center

--- a/mesmer/io/_load_cmipng.py
+++ b/mesmer/io/_load_cmipng.py
@@ -354,10 +354,7 @@ def load_cmipng_file(run_path, gen, scen):
         else:  # for every other scenario
             run_path_ssp = run_path
             run_path_hist = run_path.replace(scen, "historical")
-            data = xr.open_mfdataset(
-                [run_path_hist, run_path_ssp],
-                combine="by_coords",
-            )
+            data = xr.open_mfdataset([run_path_hist, run_path_ssp], combine="by_coords")
 
         data = data.roll(lon=72, roll_coords=True)  # roll so land in center
         data = data.assign_coords(

--- a/mesmer/utils/regionmaskcompat.py
+++ b/mesmer/utils/regionmaskcompat.py
@@ -25,7 +25,7 @@ def mask_percentage(regions, lon, lat, **kwargs):
     isnan = np.isnan(mask.values)
 
     numbers = np.unique(mask.values[~isnan])
-    numbers = numbers.astype(np.int)
+    numbers = numbers.astype(int)
 
     mask_sampled = list()
     for num in numbers:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Fix two regressions.

1. `concat_dim` has no influence on `"by_coords"` and now raises an error
2. `np.int` is an alias of `int`


