### PR TITLE
setup: only package mesmer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ REQUIREMENTS_EXTRAS = {
 
 SOURCE_DIR = "mesmer"
 
-PACKAGES = find_packages()
+PACKAGES = find_packages(include={"mesmer*"})
 PACKAGE_DATA = {}
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #122

I double checked - the tests folder was not found as a package because it did not contain a __init__.py file. This makes it explicit.


```bash
tar -tvf dist/mesmer-emulator-*.tar.gz
python -m zipfile --list dist/mesmer_emulator-0.8.2-py3-none-any.whl
```