### PR TITLE
docs: pin python version

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - python>=3.7
+  - python=3.9
   - black
   - cartopy
   - cython


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

python 3.10 is not yet ready, pin to py39