### PR TITLE
add __init__.py for core

### DIFF
--- a/mesmer/__init__.py
+++ b/mesmer/__init__.py
@@ -13,10 +13,4 @@ del get_versions
 
 # flake8: noqa
 
-# import subpackages (so that if I import mesmer, I can directly access e.g., io content
-# by calling e.g., mesmer.io.load_const())
 from . import calibrate_mesmer, create_emulations, io, utils
-
-# like this could directly access all functions (i.e., if I import mesmer, I can
-# directly access fcts, e.g., mesmer.load_const() decided against it for now to keep the
-# package structure more visible) from .io import *

--- a/mesmer/core/__init__.py
+++ b/mesmer/core/__init__.py
@@ -1,0 +1,1 @@
+from . import linear_regression

--- a/mesmer/core/__init__.py
+++ b/mesmer/core/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from . import linear_regression


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Added `mesmer/core/__init__.py` which was missing. I did not add it to `mesmer/__init__.py` for now as it's still not public.
