### PR TITLE
GH actions: concurrency

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -7,6 +7,10 @@ on:
       - 'v*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linting-and-docs:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Should abort the GH action workflow when a new commit is pushed.
