### PR TITLE
Rename linear regression functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,8 @@ New Features
   ``fit``, ``predict``, etc. methods around linear regression
   (`#134 <https://github.com/MESMER-group/mesmer/pull/134>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
-- Add ``mesmer.core.linear_regression``: xarray wrapper for ``mesmer.core._linear_regression``.
-  (`#123 <https://github.com/MESMER-group/mesmer/pull/123>`_).
+- Add ``mesmer.core._fit_linear_regression_xr``: xarray wrapper for ``mesmer.core._fit_linear_regression_np``.
+  (`#123 <https://github.com/MESMER-group/mesmer/pull/123>`_ and `#142 <https://github.com/MESMER-group/mesmer/pull/142>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Add ``mesmer.core.auto_regression._fit_auto_regression_xr``: xarray wrapper to fit an
   auto regression model (`#139 <https://github.com/MESMER-group/mesmer/pull/139>`_).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,8 +50,9 @@ v0.8.3 - 2021-12-23
 New Features
 ^^^^^^^^^^^^
 
-- Add ``mesmer.core._linear_regression``. Starts the process of refactoring the
-  codebase (`#116 <https://github.com/MESMER-group/mesmer/pull/116>`_).
+- Add ``mesmer.core._linear_regression`` (renamed to ``mesmer.core._fit_linear_regression_np``
+  in `#142 <https://github.com/MESMER-group/mesmer/pull/142>`_). Starts the process of
+  refactoring the codebase (`#116 <https://github.com/MESMER-group/mesmer/pull/116>`_).
   By `Zeb Nicholls <https://github.com/znicholls>`_.
 
 Bug fixes

--- a/mesmer/core/linear_regression.py
+++ b/mesmer/core/linear_regression.py
@@ -231,7 +231,6 @@ def _fit_linear_regression_xr(
     # split `out` into individual DataArrays
     keys = ["intercept"] + list(predictors)
     dataarrays = {key: (target_dim, out[:, i]) for i, key in enumerate(keys)}
-
     out = xr.Dataset(dataarrays, coords=target.coords)
     if dim in out.coords:
         out = out.drop_vars(dim)

--- a/mesmer/core/linear_regression.py
+++ b/mesmer/core/linear_regression.py
@@ -38,7 +38,7 @@ class LinearRegression:
             Individual weights for each sample. Must be 1D and contain `dim`.
         """
 
-        params = linear_regression(
+        params = _fit_linear_regression_xr(
             predictors=predictors,
             target=target,
             dim=dim,
@@ -166,7 +166,7 @@ class LinearRegression:
         params.to_netcdf(filename, **kwargs)
 
 
-def linear_regression(
+def _fit_linear_regression_xr(
     predictors: Mapping[str, xr.DataArray],
     target: xr.DataArray,
     dim: str,
@@ -222,7 +222,7 @@ def linear_regression(
 
     target_dim = list(set(target.dims) - {dim})[0]
 
-    out = _linear_regression(
+    out = _fit_linear_regression_np(
         predictors_concat.transpose(dim, "predictor"),
         target.transpose(dim, target_dim),
         weights,
@@ -231,7 +231,10 @@ def linear_regression(
     # split `out` into individual DataArrays
     keys = ["intercept"] + list(predictors)
     dataarrays = {key: (target_dim, out[:, i]) for i, key in enumerate(keys)}
-    out = xr.Dataset(dataarrays, coords=target.coords).drop_vars(dim)
+
+    out = xr.Dataset(dataarrays, coords=target.coords)
+    if dim in out.coords:
+        out = out.drop_vars(dim)
 
     if weights is not None:
         out["weights"] = weights
@@ -239,7 +242,7 @@ def linear_regression(
     return out
 
 
-def _linear_regression(predictors, target, weights=None):
+def _fit_linear_regression_np(predictors, target, weights=None):
     """
     Perform a linear regression - numpy wrapper
 

--- a/tests/integration/test_linear_regression.py
+++ b/tests/integration/test_linear_regression.py
@@ -22,7 +22,7 @@ def LinearRegression_fit_wrapper(*args, **kwargs):
 
 
 LR_METHOD_OR_FUNCTION = [
-    mesmer.core.linear_regression.linear_regression,
+    mesmer.core.linear_regression._fit_linear_regression_xr,
     LinearRegression_fit_wrapper,
 ]
 
@@ -255,7 +255,7 @@ def test_linear_regression_weights(lr_method_or_function, intercept):
 )
 def test_bad_shape(predictors, target):
     with pytest.raises(ValueError, match="inconsistent numbers of samples"):
-        mesmer.core.linear_regression._linear_regression(predictors, target)
+        mesmer.core.linear_regression._fit_linear_regression_np(predictors, target)
 
 
 @pytest.mark.parametrize(
@@ -267,17 +267,21 @@ def test_bad_shape(predictors, target):
 )
 def test_bad_shape_weights(predictors, target, weight):
     with pytest.raises(ValueError, match="sample_weight.shape.*expected"):
-        mesmer.core.linear_regression._linear_regression(predictors, target, weight)
+        mesmer.core.linear_regression._fit_linear_regression_np(
+            predictors, target, weight
+        )
 
 
 def test_basic_regression():
-    res = mesmer.core.linear_regression._linear_regression([[0], [1], [2]], [0, 2, 4])
+    res = mesmer.core.linear_regression._fit_linear_regression_np(
+        [[0], [1], [2]], [0, 2, 4]
+    )
 
     npt.assert_allclose(res, [[0, 2]], atol=1e-10)
 
 
 def test_basic_regression_two_targets():
-    res = mesmer.core.linear_regression._linear_regression(
+    res = mesmer.core.linear_regression._fit_linear_regression_np(
         [[0], [1], [2]], [[0, 1], [2, 3], [4, 5]]
     )
 
@@ -285,7 +289,7 @@ def test_basic_regression_two_targets():
 
 
 def test_basic_regression_three_targets():
-    res = mesmer.core.linear_regression._linear_regression(
+    res = mesmer.core.linear_regression._fit_linear_regression_np(
         [[0], [1], [2]], [[0, 1, 2], [2, 3, 7], [4, 5, 12]]
     )
 
@@ -294,7 +298,7 @@ def test_basic_regression_three_targets():
 
 
 def test_basic_regression_with_weights():
-    res = mesmer.core.linear_regression._linear_regression(
+    res = mesmer.core.linear_regression._fit_linear_regression_np(
         [[0], [1], [2], [3]], [0, 2, 4, 5], [10, 10, 10, 0.1]
     )
 
@@ -302,7 +306,7 @@ def test_basic_regression_with_weights():
 
 
 def test_basic_regression_multidimensional():
-    res = mesmer.core.linear_regression._linear_regression(
+    res = mesmer.core.linear_regression._fit_linear_regression_np(
         [[0, 1], [1, 3], [2, 4]], [2, 7, 8]
     )
 
@@ -312,7 +316,7 @@ def test_basic_regression_multidimensional():
 
 
 def test_basic_regression_multidimensional_multitarget():
-    res = mesmer.core.linear_regression._linear_regression(
+    res = mesmer.core.linear_regression._fit_linear_regression_np(
         [[0, 1], [1, 3], [2, 4]], [[2, 0], [7, 0], [8, 5]]
     )
 
@@ -322,7 +326,7 @@ def test_basic_regression_multidimensional_multitarget():
 
 
 def test_regression_with_weights_multidimensional_multitarget():
-    res = mesmer.core.linear_regression._linear_regression(
+    res = mesmer.core.linear_regression._fit_linear_regression_np(
         [[0, 1], [1, 3], [2, 4], [3, 5]],
         [[2, 0], [7, 0], [8, 5], [11, 11]],
         # extra point with low weight alters results in a minor way
@@ -338,9 +342,9 @@ def test_regression_order():
     x = np.array([[0, 1], [1, 3], [2, 4]])
     y = np.array([2, 7, 10])
 
-    res_original = mesmer.core.linear_regression._linear_regression(x, y)
+    res_original = mesmer.core.linear_regression._fit_linear_regression_np(x, y)
 
-    res_reversed = mesmer.core.linear_regression._linear_regression(
+    res_reversed = mesmer.core.linear_regression._fit_linear_regression_np(
         np.flip(x, axis=1), y
     )
 
@@ -353,10 +357,10 @@ def test_regression_order_with_weights():
     y = np.array([2, 7, 8, 0])
     weights = [10, 10, 10, 0.1]
 
-    res_original = mesmer.core.linear_regression._linear_regression(
+    res_original = mesmer.core.linear_regression._fit_linear_regression_np(
         x, y, weights=weights
     )
-    res_reversed = mesmer.core.linear_regression._linear_regression(
+    res_reversed = mesmer.core.linear_regression._fit_linear_regression_np(
         np.flip(x, axis=1), y, weights=weights
     )
 
@@ -399,7 +403,7 @@ def test_regression_order_with_weights():
     ),
 )
 def test_linear_regression_np_output_shape(x, y, exp_output_shape):
-    res = mesmer.core.linear_regression._linear_regression(x, y)
+    res = mesmer.core.linear_regression._fit_linear_regression_np(x, y)
 
     assert res.shape == exp_output_shape
 
@@ -434,12 +438,14 @@ def test_linear_regression_np(predictors, target, weight):
             # check that the default behaviour is to pass None to `fit`
             # internally
             expected_weights = None
-            res = mesmer.core.linear_regression._linear_regression(predictors, target)
+            res = mesmer.core.linear_regression._fit_linear_regression_np(
+                predictors, target
+            )
         else:
             # check that the intended weights are indeed passed to `fit`
             # internally
             expected_weights = weight
-            res = mesmer.core.linear_regression._linear_regression(
+            res = mesmer.core.linear_regression._fit_linear_regression_np(
                 predictors, target, weight
             )
 

--- a/tests/integration/test_linear_regression.py
+++ b/tests/integration/test_linear_regression.py
@@ -187,7 +187,29 @@ def test_linear_regression_one_predictor(lr_method_or_function, intercept, slope
     expected_pred0 = xr.full_like(template, slope)
 
     expected = xr.Dataset({"intercept": expected_intercept, "pred0": expected_pred0})
+    xr.testing.assert_allclose(result, expected)
 
+
+@pytest.mark.parametrize("lr_method_or_function", LR_METHOD_OR_FUNCTION)
+def test_linear_regression_no_coords(lr_method_or_function):
+
+    slope, intercept = 3.14, 3.14
+
+    pred0 = trend_data_1D(slope=1, scale=0)
+    tgt = trend_data_2D(slope=slope, scale=0, intercept=intercept)
+
+    # remove the coords
+    pred0 = pred0.drop_vars(pred0.coords.keys())
+    tgt = tgt.drop_vars(tgt.coords.keys())
+
+    result = lr_method_or_function({"pred0": pred0}, tgt, "time")
+
+    template = tgt.isel(time=0, drop=True)
+
+    expected_intercept = xr.full_like(template, intercept)
+    expected_pred0 = xr.full_like(template, slope)
+
+    expected = xr.Dataset({"intercept": expected_intercept, "pred0": expected_pred0})
     xr.testing.assert_allclose(result, expected)
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I decided to split #141 into 2 PRs. This PR needs to be merged first and it

- renames `linear_regression` to `_fit_linear_regression_xr`
- renames `_linear_regression` to `_fit_linear_regression_np`

which restores consistency with the names of these functions in `auto_regression`. This is not super important and I am also not 100% the names are final, but it's more explicit.

It also fixes `_fit_linear_regression_xr` when the target has no coordinates.

@znicholls this is mostly FYI - no need to review it unless you disagree with the naming of the functions.

