### PR TITLE
refactor stack_predictors_and_targets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ New Features
 Breaking changes
 ^^^^^^^^^^^^^^^^
 
+- The :py:func:`train_l_prepare_X_y_wgteq` was refactored and split into two functions:
+  :py:func:`get_scenario_weights` and :py:func:`stack_predictors_and_targets`
+  (`#143 <https://github.com/MESMER-group/mesmer/pull/143>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 
 Deprecations
 ^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ New Features
 Breaking changes
 ^^^^^^^^^^^^^^^^
 
-- The :py:func:`train_l_prepare_X_y_wgteq` was refactored and split into two functions:
+- Refactor and split :py:func:`train_l_prepare_X_y_wgteq` into two functions:
   :py:func:`get_scenario_weights` and :py:func:`stack_predictors_and_targets`
   (`#143 <https://github.com/MESMER-group/mesmer/pull/143>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -63,7 +63,8 @@ Train mesmer
    ~calibrate_mesmer.train_gt_ic_OLSVOLC
    ~calibrate_mesmer.train_lv_AR1_sci
    ~calibrate_mesmer.train_lv_find_localized_ecov
-   ~calibrate_mesmer.train_l_prepare_X_y_wgteq
+   ~calibrate_mesmer.get_scenario_weights
+   ~calibrate_mesmer.stack_predictors_and_targets
 
 Create emulations
 ^^^^^^^^^^^^^^^^^

--- a/mesmer/calibrate_mesmer/train_lt.py
+++ b/mesmer/calibrate_mesmer/train_lt.py
@@ -13,7 +13,10 @@ import joblib
 import numpy as np
 from sklearn.linear_model import LinearRegression
 
-from mesmer.calibrate_mesmer.train_utils import train_l_prepare_X_y_wgteq
+from mesmer.calibrate_mesmer.train_utils import (
+    get_scenario_weights,
+    stack_predictors_and_targets,
+)
 
 
 def train_lt(preds, targs, esm, cfg, save_params=True):
@@ -137,8 +140,12 @@ def train_lt(preds, targs, esm, cfg, save_params=True):
 
     # prepare predictors and targets such that they can be ingested into the training
     # function
-    X, y, wgt_scen_eq = train_l_prepare_X_y_wgteq(preds, targs)
+    X, y = stack_predictors_and_targets(preds, targs)
+    # temporary workaround, will be removed again with #141
+    y = np.stack(list(y.values()), axis=2)
+    X = np.stack(list(X.values()), axis=1)
 
+    wgt_scen_eq = get_scenario_weights(targs[targ_name])
     # prepare weights for individual runs
     if wgt_scen_tr_eq is False:
         wgt_scen_eq[:] = 1

--- a/mesmer/calibrate_mesmer/train_utils.py
+++ b/mesmer/calibrate_mesmer/train_utils.py
@@ -7,7 +7,6 @@ Functions to aid the training of MESMER.
 """
 
 import numpy as np
-import xarray as xr
 
 
 def get_scenario_weights(target):

--- a/mesmer/calibrate_mesmer/train_utils.py
+++ b/mesmer/calibrate_mesmer/train_utils.py
@@ -6,14 +6,78 @@
 Functions to aid the training of MESMER.
 """
 
-
 import numpy as np
+import xarray as xr
 
 
-def train_l_prepare_X_y_wgteq(preds, targs):
+def get_scenario_weights(target):
     """
-    Create single array of predictors, single array of targets, and single array of
-    weights.
+    derive scenario weights such that each has equal weight, i.e., 1 / number of samples
+    (= nr_runs * nr_ts)
+
+    Parameters
+    ----------
+    targs : dict
+        nested dictionary of targets with key
+
+        - [scen] (3d array (run, time, gp) of target for specific scenario)
+
+    Returns
+    -------
+    wgt_scen_eq : np.ndarray
+        1d array (sample) of sample weights based on equal treatment of each scenario
+        (if scen has more samples, each sample gets less weight)
+    """
+
+    weights = list()
+
+    # loop through scenarios
+    for array in target.values():
+
+        nr_runs, nr_ts, __ = array.shape
+        nr_samples_scen = nr_runs * nr_ts
+
+        weights.append(np.full(nr_samples_scen, 1 / nr_runs))
+
+    return np.concatenate(weights)
+
+
+def _stack_target(target):
+    """stack target for all scenarios"""
+
+    out = list()
+
+    # loop through scenarios
+    for array in target.values():
+        out.append(array.squeeze())
+
+    return np.concatenate(out)
+
+
+def _stack_predictor(predictor, target):
+    """stack predictor for all scenarios"""
+
+    out = list()
+    for scen, values in predictor.items():
+
+        # if 1 time series per run for predictor (e.g., gv)
+        if values.ndim == 2:
+            out.append(values.flatten())
+
+        # if single time series as predictor (e.g. gt): repeat ts as many times
+        # as runs available
+        elif values.ndim == 1:
+            nr_runs = target[scen].shape[0]
+            out.append(np.tile(values, nr_runs))
+        else:
+            raise ValueError("Predictors of this shape cannot be processed.")
+
+    return np.concatenate(out)
+
+
+def stack_predictors_and_targets(preds, targs):
+    """
+    Create single array of predictors, and single array of targets
 
     Parameters
     ----------
@@ -29,72 +93,17 @@ def train_l_prepare_X_y_wgteq(preds, targs):
 
     Returns
     -------
-    X : np.ndarray
+    X : dict of np.ndarray
         empty array if none, else 2d array (sample, pred) of predictors
-    y : np.ndarray
+    y : dict of np.ndarray
         3d array (sample, gp, targ) of targets
-    wgt_scen_eq : np.ndarray
-        1d array (sample) of sample weights based on equal treatment of each scenario
-        (if scen has more samples, each sample gets less weight)
     """
 
-    targ_names = list(targs.keys())
-    targ_name = targ_names[0]  # because same approach for each targ
-    pred_names = list(preds.keys())
+    # can only be one target at the moment
+    targ_name = list(targs.keys())[0]
 
-    # identify characteristics of the predictors and the targets
-    # predictors are not influenced by whether there is a single or multiple targets
-    targ = targs[targ_name]
-    scens = list(targ.keys())
+    X = {key: _stack_predictor(pred, targs[targ_name]) for key, pred in preds.items()}
 
-    # assumption: nr_runs per scen and nr_ts for these runs can vary
-    # derive weights such that each scenario receives same weight (divide by nr samples)
-    nr_samples = 0
-    wgt_scen_eq = []
-    for scen in scens:
-        nr_runs, nr_ts, nr_gps = targ[scen].shape
-        nr_samples_scen = nr_runs * nr_ts
-        wgt_scen_eq = np.append(wgt_scen_eq, np.repeat(1 / nr_runs, nr_samples_scen))
-        nr_samples += nr_samples_scen
+    y = {key: _stack_target(targ) for key, targ in targs.items()}
 
-    nr_preds = len(pred_names)
-    nr_targs = len(targ_names)
-
-    # derive X (ie array of predictors)
-    if nr_preds == 0:
-        X = np.empty(0)
-    else:
-        X = np.zeros([nr_samples, nr_preds])
-        for p in np.arange(nr_preds):  # index for predictors
-            pred_name = pred_names[p]  # name of predictor p
-            s = 0  # index for samples
-            pred_raw = preds[pred_name]  # values of predictor p
-            for scen in scens:
-                # if 1 time series per run for predictor (e.g., gv)
-                if len(pred_raw[scen].shape) == 2:
-                    # nr_runs*nr_ts for this specific scenario
-                    k = pred_raw[scen].shape[0] * pred_raw[scen].shape[1]
-                    X[s : s + k, p] = pred_raw[scen].flatten()
-                    s += k
-                # if single time series as predictor (e.g. gt): repeat ts as many times
-                # as runs available
-                elif len(pred_raw[scen].shape) == 1:
-                    nr_runs, nr_ts, nr_gps = targ[scen].shape
-                    nr_samples_scen = nr_runs * nr_ts
-                    X[s : s + nr_samples_scen, p] = np.tile(pred_raw[scen], nr_runs)
-                    s += nr_samples_scen
-                else:
-                    raise ValueError("Predictors of this shape cannot be processed.")
-
-    # derive y (i.e. array of targets)
-    y = np.zeros([nr_samples, nr_gps, nr_targs])
-    for t, targ_name in enumerate(targ_names):
-        targ = targs[targ_name]
-        s = 0
-        for scen in scens:
-            # nr_runs * nr_ts for this scenario
-            k = targ[scen].shape[0] * targ[scen].shape[1]
-            y[s : s + k, :, t] = targ[scen].reshape(k, -1)
-            s += k
-
-    return X, y, wgt_scen_eq
+    return X, y

--- a/mesmer/calibrate_mesmer/train_utils.py
+++ b/mesmer/calibrate_mesmer/train_utils.py
@@ -63,7 +63,7 @@ def _stack_predictor(predictor, target):
         if values.ndim == 2:
             out.append(values.flatten())
 
-        # if single time series as predictor (e.g. gt): repeat ts as many times
+        # if single time series as predictor (e.g., gt): repeat ts as many times
         # as runs available
         elif values.ndim == 1:
             nr_runs = target[scen].shape[0]

--- a/mesmer/calibrate_mesmer/train_utils.py
+++ b/mesmer/calibrate_mesmer/train_utils.py
@@ -17,7 +17,7 @@ def get_scenario_weights(target):
     Parameters
     ----------
     targs : dict
-        nested dictionary of targets with key
+        dictionary of targets with key
 
         - [scen] (3d array (run, time, gp) of target for specific scenario)
 


### PR DESCRIPTION
Yet another preparation PR for #141 - rewriting & refactoring `train_l_prepare_X_y_wgteq`. I first wanted to to it quick and dirty but https://github.com/MESMER-group/mesmer/pull/141#discussion_r854703265 by @znicholls prompted me to have a closer look at the function. It's not going to be fun to merge this into #141 but I can worry about this later.

In this PR I

- split the original function into two:
  - `get_scenario_weights`
  - `stack_predictors_and_targets`
- write a helper function to stack predictors and targets
- the stacked arrays are now kept in a dict (instead of an array with an additional dimension)
