### PR TITLE
linear_regression: add fit_intercept argument

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ New Features
 - Add ``mesmer.core._fit_linear_regression_xr``: xarray wrapper for ``mesmer.core._fit_linear_regression_np``.
   (`#123 <https://github.com/MESMER-group/mesmer/pull/123>`_ and `#142 <https://github.com/MESMER-group/mesmer/pull/142>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Add add ``fit_intercept`` argument to the ``linear_regression`` fitting methods and
+  functions (`#144 <https://github.com/MESMER-group/mesmer/pull/144>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 - Add ``mesmer.core.auto_regression._fit_auto_regression_xr``: xarray wrapper to fit an
   auto regression model (`#139 <https://github.com/MESMER-group/mesmer/pull/139>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR adds `fit_intercept` to `mesmer.core.linear_regression`.


`train_gt_ic_OLSVOLC` uses `fit_intercept=False` therefore this needs to be added to `_fit_linear_regression_xr` before we can refactor this code path.

https://github.com/MESMER-group/mesmer/blob/f63fbeb0d9d1318a575e2aa7ad0febc4e675e98f/mesmer/calibrate_mesmer/train_gt.py#L264

---

Open question - how should `intercept` be saved when `fit_intercept=False`?

1. Omit `intercept` from the result
2. As scalar (this is what sklearn does)
3. The same shape as the predictors (this is the current solution)

See details for an example.

<details>

(1) would look like this:

```python
<xarray.Dataset>
Dimensions:        (cell: 3)
Data variables:
    tas            (cell) int64 0 1 2
    fit_intercept  bool False
```

(2) would look like this:

```python
<xarray.Dataset>
Dimensions:        (cell: 3)
Data variables:
    intercept      int64 0
    tas            (cell) int64 0 1 2
    fit_intercept  bool False
```


(3) would look like this:

```python
<xarray.Dataset>
Dimensions:        (cell: 3)
Data variables:
    intercept      int64 0 0 0
    tas            (cell) int64 0 1 2
    fit_intercept  bool False
```

</details>

I went for 3 because it's easiest. I would probably go for (2) if it did not involve changing a ton of tests.

---

Remark: I use `LinearRegression().fit(..., fit_intercept=False)` while sklearn uses `LinearRegression(fit_intercept=False).fit(...)`. I think this makes more sense (here) because I want to be able to do `res = LinearRegression()`, `res.params = params` (i.e., assign the params).

cc @znicholls 