### PR TITLE
use LinearRegression in train_gt_ic_OLSVOLC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,9 @@ Internal Changes
 - Renamed the ``interpolation`` keyword of ``np.quantile`` to ``method`` changed in
   numpy v1.22.0 (`#137 <https://github.com/MESMER-group/mesmer/pull/137>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Make use of :py:class:`mesmer.core.linear_regression.LinearRegression` in
+  :py:func:`mesmer.calibrate_mesmer.train_gt_ic_OLSVOLC` (`#145 <https://github.com/MESMER-group/mesmer/pull/145>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 
 v0.8.3 - 2021-12-23
 -------------------

--- a/mesmer/calibrate_mesmer/train_gt.py
+++ b/mesmer/calibrate_mesmer/train_gt.py
@@ -239,7 +239,7 @@ def train_gt_ic_OLSVOLC(var, gt_lowess, time, cfg):
     # account for volcanic eruptions in historical time period
     # load in observed stratospheric aerosol optical depth
     aod_obs = load_strat_aod(time, dir_obs)
-    # drop "year" coords - aod_obs_all does not have coords (currently)
+    # drop "year" coords - aod_obs does not have coords (currently)
     aod_obs = aod_obs.drop_vars("year")
 
     # repeat aod time series as many times as runs available

--- a/mesmer/io/load_obs.py
+++ b/mesmer/io/load_obs.py
@@ -182,20 +182,19 @@ def load_strat_aod(time, dir_obs):
     """
 
     path_file = dir_obs + "aerosols/isaod_gl.dat"
-    ts = pd.read_csv(
-        path_file, delim_whitespace=True, skiprows=11, names=("year", "month", "AOD")
+    df = pd.read_csv(
+        path_file,
+        delim_whitespace=True,
+        skiprows=11,
+        names=("year", "month", "AOD"),
+        parse_dates=[["year", "month"]],
     )
 
-    beg = str(ts["year"].iloc[0]) + "-" + str(ts["month"].iloc[0])
-    end = str(ts["year"].iloc[-1]) + "-" + str(ts["month"].iloc[-1])
-    range = pd.to_datetime([beg, end]) + pd.offsets.MonthEnd()
-    date_range = pd.date_range(*range, freq="m")
-
     aod_obs = xr.DataArray(
-        ts["AOD"].values, dims=("time",), coords=dict(time=("time", date_range))
+        df["AOD"], dims=("time",), coords=dict(time=("time", df["year_month"]))
     )
 
     aod_obs = aod_obs.groupby("time.year").mean("time")
-    aod_obs = aod_obs.sel(year=slice(str(time[0]), str(time[-1]))).values
+    aod_obs = aod_obs.sel(year=slice(time[0], time[-1]))
 
     return aod_obs


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

After #144 we can now use `mesmer.core.linear_regression.LinearRegression` in `train_gt_ic_OLSVOLC`.

 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`
