### PR TITLE
fit_auto_regression_xr: add lags to output

### DIFF
--- a/mesmer/core/auto_regression.py
+++ b/mesmer/core/auto_regression.py
@@ -105,13 +105,20 @@ def _fit_auto_regression_xr(data, dim, lags):
         input_core_dims=[[dim]],
         output_core_dims=((), ("lags",), ()),
         vectorize=True,
-        output_dtypes=[float, float, float],
+        output_dtypes=[float, float, float, int],
         kwargs={"lags": lags},
     )
 
-    data_vars = {"intercept": intercept, "coeffs": coeffs, "standard_deviation": std}
+    if np.ndim(lags) == 0:
+        lags = np.arange(lags) + 1
 
-    # TODO: add coords for lags?
+    data_vars = {
+        "intercept": intercept,
+        "coeffs": coeffs,
+        "standard_deviation": std,
+        "lags": lags,
+    }
+
     return xr.Dataset(data_vars)
 
 

--- a/mesmer/core/auto_regression.py
+++ b/mesmer/core/auto_regression.py
@@ -105,7 +105,7 @@ def _fit_auto_regression_xr(data, dim, lags):
         input_core_dims=[[dim]],
         output_core_dims=((), ("lags",), ()),
         vectorize=True,
-        output_dtypes=[float, float, float, int],
+        output_dtypes=[float, float, float],
         kwargs={"lags": lags},
     )
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Towards #164
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`

Adds the `lags` as coordinates to the parameters returned in `_fit_auto_regression_xr`.

