### PR TITLE
setup options to setup.cfg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,9 @@ Internal Changes
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Add python 3.10 to list of supported versions (`#162 <https://github.com/MESMER-group/mesmer/pull/162>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Move contents of setup.py to setup.cfg (`#169 <https://github.com/MESMER-group/mesmer/pull/169>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
+
 
 v0.8.3 - 2021-12-23
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,67 @@
+[metadata]
+name = mesmer-emulator
+author = mesmer developpers
+author_email = mesmer@env.ethz.ch
+license = GPLv3+
+keywords = climate atmosphere "Earth System Model Emulator"
+description = Modular Earth System Model Emulator with spatially Resolved output
+long_description_content_type=text/x-rst
+long_description = file: README.rst
+url = https://github.com/MESMER-group/mesmer
+project_urls =
+    Documentation = https://mesmer-emulator.readthedocs.io
+    Source = https://github.com/MESMER-group/mesmer
+    BugReports = https://github.com/MESMER-group/mesmer/issues
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Operating System :: OS Independent
+    Intended Audience :: Science/Research
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Atmospheric Science
+
+[options]
+packages = find:
+zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
+include_package_data = True
+python_requires = >=3.7
+install_requires =
+    dask[complete]
+    numpy
+    packaging
+    pandas
+    regionmask
+    scikit-learn
+    statsmodels
+    xarray
+
+[options.extras_require]
+docs = 
+    numpydoc
+    sphinx-book-theme
+    sphinx
+
+tests =
+    pytest-cov
+    pytest-xdist
+    pytest
+
+dev = 
+    %(docs)s
+    %(tests)s
+    black
+    flake8
+    isort
+    setuptools
+    twine
+    wheel
+
 [flake8]
 ignore=
     E203 # whitespace before ':' - doesn't work well with black

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,5 @@
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 import versioneer
 
-
-class Mesmer(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-
-        pytest.main(self.test_args)
-
-
-cmdclass = versioneer.get_cmdclass()
-cmdclass.update({"test": Mesmer})
-
-setup(version=versioneer.get_version(), cmdclass=cmdclass)
+setup(version=versioneer.get_version(), cmdclass=versioneer.get_cmdclass())

--- a/setup.py
+++ b/setup.py
@@ -1,90 +1,7 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 import versioneer
-
-PACKAGE_NAME = "mesmer-emulator"
-DESCRIPTION = "Modular Earth System Model Emulator with spatially Resolved output"
-KEYWORDS = [
-    "climate",
-    "atmosphere",
-    "Earth System Model Emulator",
-]
-
-AUTHOR = "mesmer developpers"
-EMAIL = "mesmer@env.ethz.ch"
-URL = "https://github.com/MESMER-group/mesmer"  # use documentation url?
-PROJECT_URLS = {
-    "Source": "https://github.com/MESMER-group/mesmer",
-    "Bug Reports": "https://github.com/MESMER-group/mesmer/issues",
-    # "Documentation": "TBD",
-}
-
-LICENSE = "GPLv3+"
-CLASSIFIERS = [
-    "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
-    "Topic :: Scientific/Engineering :: Atmospheric Science",
-]
-
-
-REQUIREMENTS_INSTALL = [
-    "dask[complete]",
-    "numpy",
-    "packaging",
-    "pandas",
-    "regionmask",
-    "scikit-learn",
-    "statsmodels",
-    "xarray",
-]
-REQUIREMENTS_TESTS = [
-    "pytest-cov",
-    "pytest-xdist",
-    "pytest",
-]
-REQUIREMENTS_DOCS = [
-    "numpydoc",
-    "sphinx-book-theme",
-    "sphinx",
-]
-REQUIREMENTS_DEV = [
-    "black",
-    "flake8",
-    "isort",
-    "setuptools",
-    "twine",
-    "wheel",
-    *REQUIREMENTS_TESTS,
-    *REQUIREMENTS_DOCS,
-]
-
-REQUIREMENTS_EXTRAS = {
-    "dev": REQUIREMENTS_DEV,
-    "docs": REQUIREMENTS_DOCS,
-    "tests": REQUIREMENTS_TESTS,
-}
-
-
-SOURCE_DIR = "mesmer"
-
-PACKAGES = find_packages(include={"mesmer*"})
-PACKAGE_DATA = {}
-
-
-README = "README.rst"
-
-with open(README) as readme_file:
-    README_TEXT = readme_file.read()
 
 
 class Mesmer(TestCommand):
@@ -102,25 +19,4 @@ class Mesmer(TestCommand):
 cmdclass = versioneer.get_cmdclass()
 cmdclass.update({"test": Mesmer})
 
-setup(
-    name=PACKAGE_NAME,
-    version=versioneer.get_version(),
-    description=DESCRIPTION,
-    long_description=README_TEXT,
-    long_description_content_type="text/x-rst",
-    author=AUTHOR,
-    author_email=EMAIL,
-    url=URL,
-    project_urls=PROJECT_URLS,
-    license=LICENSE,
-    classifiers=CLASSIFIERS,
-    keywords=KEYWORDS,
-    packages=PACKAGES,
-    package_data=PACKAGE_DATA,
-    include_package_data=True,
-    python_requires=">=3.7",
-    install_requires=REQUIREMENTS_INSTALL,
-    extras_require=REQUIREMENTS_EXTRAS,
-    cmdclass=cmdclass,
-    # entry_points=ENTRY_POINTS,
-)
+setup(version=versioneer.get_version(), cmdclass=cmdclass)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

I wasn't sure what to tackle next so I did some infrastructure maintenance :upside_down_face:

@znicholls what does the `TestCommand` do? Is that something that you use? Is used? Could that be removed or something similar be achieved via `conftest.py`?

The next steps would be to use `setuptools_scm` instead of `versioneer` and add a pyproject.toml file.


