### PR TITLE
fix .gitattributes for setuptools_scm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-mesmer/_version.py export-subst
+.git_archival.txt export-subst


### PR DESCRIPTION
Another forgotten change from versioneer. For setuptools_scm we want `export-subst` to point at .git_archival.txt in .gitattributes.