### PR TITLE
fix doc version on RTD and small cleanup

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,13 +1,15 @@
 version: 2
 build:
   os: ubuntu-20.04
+  jobs:
+    pre_install:
+        # see https://github.com/readthedocs/readthedocs.org/issues/8201
+      - git update-index --assume-unchanged docs/environment.yml docs/source/conf.py
+      # install regionmask, needs to be editable
+      - pip install -e .
   tools:
     python: mambaforge-4.10
 sphinx:
   configuration: docs/source/conf.py
-python:
-  install:
-  - method: pip
-    path: .
 conda:
   environment: docs/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ sphinx:
   configuration: docs/source/conf.py
 python:
   install:
-  - method: setuptools
+  - method: pip
     path: .
 conda:
   environment: docs/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged docs/environment.yml docs/source/conf.py
       # install regionmask, needs to be editable
-      - pip install -e .
+      - python -m pip install -e .
   tools:
     python: mambaforge-4.10
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ build:
     pre_install:
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged docs/environment.yml docs/source/conf.py
-      # install regionmask, needs to be editable
+      # install mesmer, needs to be editable
       - python -m pip install -e .
   tools:
     python: mambaforge-4.10

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,8 +7,29 @@
 # -- Import packages ---------------------------------------------------------
 
 import datetime
+from importlib.metadata import version
+import sys
+import subprocess
+import os
 
 import mesmer
+
+# -- Display version info ----------------------------------------------------
+#
+
+print("python exec:", sys.executable)
+print("sys.path:", sys.path)
+print("os.getcwd():", os.getcwd())
+
+if "CONDA_DEFAULT_ENV" in os.environ or "conda" in sys.executable:
+    print("conda environment:")
+    subprocess.run([os.environ.get("CONDA_EXE", "conda"), "list"])
+else:
+    print("pip environment:")
+    subprocess.run([sys.executable, "-m", "pip", "list"])
+
+print(f"mesmer: {mesmer.__version__=}, {mesmer.__file__=}")
+
 
 # -- Project information -----------------------------------------------------
 
@@ -22,10 +43,10 @@ copyright = (
 authors = "Authors, see AUTHORS"
 author = authors
 
-# The short X.Y version
-version = mesmer.__version__.split("+")[0]
 # The full version, including alpha/beta/rc tags
-release = mesmer.__version__
+release = version("mesmer-emulator")
+# The short X.Y version
+version = ".".join(release.split(".")[:2])
 
 
 # -- General configuration ---------------------------------------------------
@@ -34,17 +55,11 @@ release = mesmer.__version__
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.extlinks",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "IPython.sphinxext.ipython_directive",
     "IPython.sphinxext.ipython_console_highlighting",
 ]
-
-extlinks = {
-    "issue": ("https://github.com/mesmer-group/mesmer/issues/%s", "GH"),
-    "pull": ("https://github.com/mesmer-group/mesmer/pull/%s", "PR"),
-}
 
 autosummary_generate = True
 
@@ -76,7 +91,6 @@ exclude_patterns = []
 # a list of builtin themes.
 #
 
-html_theme = "sphinx_rtd_theme"
 html_theme = "sphinx_book_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ import os
 import mesmer
 
 # -- Display version info ----------------------------------------------------
-#
+# for debugging on RTD
 
 print("python exec:", sys.executable)
 print("sys.path:", sys.path)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

(Should eventually) fix the wrong version number on RTD with the new pyproject.toml etc. installation.

Also cleans up some unused config in docs/conf.py.


---

We might need to go to a manual install - IIRC RTD does something along the lines `python -m pip install . --upgrade-strategy eager` which upgrades packages we pinned (well we did not pin any at the moment but still).


