### PR TITLE
localized_covariance: add xarray wrapper

### DIFF
--- a/mesmer/core/localized_covariance.py
+++ b/mesmer/core/localized_covariance.py
@@ -132,11 +132,8 @@ def find_localized_empirical_covariance(data, weights, localizer, dim, k_folds):
     # localization_radius, covariance, localized_covariance = out
 
     out = _find_localized_empirical_covariance_np(
-        data.data,
-        weights.data,
-        localizer,
-        k_folds
-        )
+        data.data, weights.data, localizer, k_folds
+    )
     localization_radius, covariance, localized_covariance = out
 
     covariance = xr.DataArray(covariance, dims=out_dims)

--- a/mesmer/core/localized_covariance.py
+++ b/mesmer/core/localized_covariance.py
@@ -80,13 +80,13 @@ def find_localized_empirical_covariance(data, weights, localizer, dim, k_folds):
 
     Parameters
     ----------
-    data : 2D array
-        Data array with shape n_samples x n_gridpoints.
-    weights : 1D array
+    data : xr.DataArray
+        2D DataArray with with n_samples x n_gridpoints.
+    weights : xr.DataArray
         Weights for the individual samples.
-    localizer : dict of array-like
+    localizer : dict of DataArray```
         Dictonary containing the localization radii as keys and the localization matrix
-        as values. The localization must be 2D and of shape nr_gridpoints x nr_gridpoints.
+        as values. The localization must be 2D and of shape n_gridpoints x n_gridpoints.
         Currently only the Gaspari-Cohn localizer is implemented in MESMER.
     dim : str
         Dimension along which to calculate the covariance.

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -6,7 +6,7 @@ import xarray as xr
 
 # xarray cannot represent two dims with the same name -> need to give them another name
 # TODO: expose this via function argument or config?
-EQUAL_DIM_SUFFIXES = ("i", "j")
+EQUAL_DIM_SUFFIXES = ("_i", "_j")
 
 
 class OptimizeWarning(UserWarning):
@@ -19,7 +19,7 @@ class LinAlgWarning(UserWarning):
 
 def create_equal_dim_names(dim):
 
-    return [f"{dim}_{suffix}" for suffix in EQUAL_DIM_SUFFIXES]
+    return [f"{dim}{suffix}" for suffix in EQUAL_DIM_SUFFIXES]
 
 
 def _minimize_local_discrete(func, sequence, **kwargs):

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -4,10 +4,6 @@ from typing import Set, Union
 import numpy as np
 import xarray as xr
 
-# xarray cannot represent two dims with the same name -> need to give them another name
-# TODO: expose this via function argument or config?
-EQUAL_DIM_SUFFIXES = ("_i", "_j")
-
 
 class OptimizeWarning(UserWarning):
     pass
@@ -17,9 +13,12 @@ class LinAlgWarning(UserWarning):
     pass
 
 
-def create_equal_dim_names(dim):
+def create_equal_dim_names(dim, suffixes):
 
-    return [f"{dim}{suffix}" for suffix in EQUAL_DIM_SUFFIXES]
+    if not len(suffixes) == 2:
+        raise ValueError("must provide exactly two suffixes")
+
+    return tuple(f"{dim}{suffix}" for suffix in suffixes)
 
 
 def _minimize_local_discrete(func, sequence, **kwargs):

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -4,6 +4,10 @@ from typing import Set, Union
 import numpy as np
 import xarray as xr
 
+# xarray cannot represent two dims with the same name -> need to give them another name
+# TODO: expose this via function argument or config?
+EQUAL_DIM_SUFFIXES = ("i", "j")
+
 
 class OptimizeWarning(UserWarning):
     pass
@@ -11,6 +15,11 @@ class OptimizeWarning(UserWarning):
 
 class LinAlgWarning(UserWarning):
     pass
+
+
+def create_equal_dim_names(dim):
+
+    return [f"{dim}_{suffix}" for suffix in EQUAL_DIM_SUFFIXES]
 
 
 def _minimize_local_discrete(func, sequence, **kwargs):

--- a/tests/integration/test_localized_covariance.py
+++ b/tests/integration/test_localized_covariance.py
@@ -81,6 +81,22 @@ def test_find_localized_empirical_covariance():
     _check_dataarray_form(result.covariance, "covariance", **required_form)
     _check_dataarray_form(result.covariance, "localized_covariance", **required_form)
 
+    # ensure can pass equal_dim_suffixes
+    result = find_localized_empirical_covariance(
+        data,
+        weights,
+        localizer,
+        dim="samples",
+        k_folds=3,
+        equal_dim_suffixes=(":j", ":i"),
+    )
+
+    required_form["required_dims"] = ("cell:j", "cell:i")
+
+    assert result.localization_radius == 1
+    _check_dataarray_form(result.covariance, "covariance", **required_form)
+    _check_dataarray_form(result.covariance, "localized_covariance", **required_form)
+
 
 def test_find_localized_empirical_covariance_np():
 

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -21,6 +21,15 @@ def test_minimize_local_discrete(values, expected):
     assert result == expected
 
 
+def test_create_equal_dim_names():
+
+    with pytest.raises(ValueError, match="must provide exactly two suffixes"):
+        mesmer.core.utils.create_equal_dim_names("dim", "a")
+
+    result = mesmer.core.utils.create_equal_dim_names("dim", (".1", ".2"))
+    assert result == ("dim.1", "dim.2")
+
+
 def test_minimize_local_discrete_warning():
     def func(i, data_dict):
         return data_dict[i]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #153
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

xarray wrapper for `find_localized_empirical_covariance` and `adjust_covariance_ar1`. Ugly as hell but there is no good way to have the same dim more than once for a DataArray.

cc @znicholls 
