### PR TITLE
save_mesmer_data helper function

### DIFF
--- a/mesmer/calibrate_mesmer/train_gt.py
+++ b/mesmer/calibrate_mesmer/train_gt.py
@@ -7,15 +7,13 @@ Functions to train global trend module of MESMER.
 """
 
 
-import os
-
-import joblib
 import numpy as np
 import xarray as xr
 
 from mesmer.core.linear_regression import LinearRegression
 from mesmer.core.smoothing import lowess
 from mesmer.io import load_strat_aod
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
 def train_gt(var, targ, esm, time, cfg, save_params=True):
@@ -143,22 +141,20 @@ def train_gt(var, targ, esm, time, cfg, save_params=True):
 
     # save the global trend paramters if requested
     if save_params:
-        dir_mesmer_params = cfg.dir_mesmer_params
-        dir_mesmer_params_gt = dir_mesmer_params + "global/global_trend/"
-        # check if folder to save params in exists, if not: make it
-        if not os.path.exists(dir_mesmer_params_gt):
-            os.makedirs(dir_mesmer_params_gt)
-            print("created dir:", dir_mesmer_params_gt)
-        filename_parts = [
-            "params_gt",
-            method_gt,
-            *preds_gt,
-            targ,
-            esm,
-            *scenarios_tr,
-        ]
-        filename_params_gt = dir_mesmer_params_gt + "_".join(filename_parts) + ".pkl"
-        joblib.dump(params_gt, filename_params_gt)
+        save_mesmer_data(
+            params_gt,
+            cfg.dir_mesmer_params,
+            "global",
+            "global_trend",
+            filename_parts=(
+                "params_gt",
+                method_gt,
+                *preds_gt,
+                targ,
+                esm,
+                *scenarios_tr,
+            ),
+        )
 
     return params_gt
 

--- a/mesmer/calibrate_mesmer/train_gv.py
+++ b/mesmer/calibrate_mesmer/train_gv.py
@@ -7,15 +7,13 @@ Functions to train global variability module of MESMER.
 """
 
 
-import os
-
-import joblib
 import numpy as np
 import statsmodels.api as sm
 import xarray as xr
 from packaging.version import Version
 
 from mesmer.core.auto_regression import _fit_auto_regression_xr, _select_ar_order_xr
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
 def train_gv(gv, targ, esm, cfg, save_params=True, **kwargs):
@@ -93,22 +91,20 @@ def train_gv(gv, targ, esm, cfg, save_params=True, **kwargs):
 
     # save the global variability paramters if requested
     if save_params:
-        dir_mesmer_params = cfg.dir_mesmer_params
-        dir_mesmer_params_gv = dir_mesmer_params + "global/global_variability/"
-        # check if folder to save params in exists, if not: make it
-        if not os.path.exists(dir_mesmer_params_gv):
-            os.makedirs(dir_mesmer_params_gv)
-            print("created dir:", dir_mesmer_params_gv)
-        filename_parts = [
-            "params_gv",
-            method_gv,
-            *preds_gv,
-            targ,
-            esm,
-            *scenarios_tr,
-        ]
-        filename_params_gv = dir_mesmer_params_gv + "_".join(filename_parts) + ".pkl"
-        joblib.dump(params_gv, filename_params_gv)
+        save_mesmer_data(
+            params_gv,
+            cfg.dir_mesmer_params,
+            "global",
+            "global_variability",
+            filename_parts=[
+                "params_gv",
+                method_gv,
+                *preds_gv,
+                targ,
+                esm,
+                *scenarios_tr,
+            ],
+        )
 
     return params_gv
 

--- a/mesmer/calibrate_mesmer/train_lt.py
+++ b/mesmer/calibrate_mesmer/train_lt.py
@@ -7,9 +7,6 @@ Functions to train local trends module of MESMER.
 """
 
 
-import os
-
-import joblib
 import xarray as xr
 
 from mesmer.calibrate_mesmer.train_utils import (
@@ -17,6 +14,7 @@ from mesmer.calibrate_mesmer.train_utils import (
     stack_predictors_and_targets,
 )
 from mesmer.core.linear_regression import _fit_linear_regression_xr
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
 def train_lt(preds, targs, esm, cfg, save_params=True):
@@ -183,41 +181,38 @@ def train_lt(preds, targs, esm, cfg, save_params=True):
 
     # save the local trend paramters if requested
     if save_params:
-        dir_mesmer_params = cfg.dir_mesmer_params
-        dir_mesmer_params_lt = dir_mesmer_params + "local/local_trends/"
-        # check if folder to save params in exists, if not: make it
-        if not os.path.exists(dir_mesmer_params_lt):
-            os.makedirs(dir_mesmer_params_lt)
-            print("created dir:", dir_mesmer_params_lt)
-        filename_parts = [
-            "params_lt",
-            method_lt,
-            *preds_lt,
-            *targ_names,
-            esm,
-            *scenarios_tr,
-        ]
-        filename_params_lt = dir_mesmer_params_lt + "_".join(filename_parts) + ".pkl"
-        joblib.dump(params_lt, filename_params_lt)
+        save_mesmer_data(
+            params_lt,
+            cfg.dir_mesmer_params,
+            "local",
+            "local_trends",
+            filename_parts=[
+                "params_lt",
+                method_lt,
+                *preds_lt,
+                *targ_names,
+                esm,
+                *scenarios_tr,
+            ],
+        )
 
         # check if local variability parameters need to be saved too
         # overwrites lv module if already exists, i.e., assumption: lt before lv
         if len(params_lv) > 0:
-            dir_mesmer_params_lv = dir_mesmer_params + "local/local_variability/"
-            # check if folder to save params in exists, if not: make it
-            if not os.path.exists(dir_mesmer_params_lv):
-                os.makedirs(dir_mesmer_params_lv)
-                print("created dir:", dir_mesmer_params_lv)
-        filename_parts = [
-            "params_lv",
-            method_lv,
-            *preds_lv,
-            *targ_names,
-            esm,
-            *scenarios_tr,
-        ]
-        filename_params_lv = dir_mesmer_params_lv + "_".join(filename_parts) + ".pkl"
-        joblib.dump(params_lv, filename_params_lv)
+            save_mesmer_data(
+                params_lv,
+                cfg.dir_mesmer_params,
+                "local",
+                "local_variability",
+                filename_parts=[
+                    "params_lv",
+                    method_lv,
+                    *preds_lv,
+                    *targ_names,
+                    esm,
+                    *scenarios_tr,
+                ],
+            )
 
     if len(params_lv) > 0:
         return params_lt, params_lv

--- a/mesmer/calibrate_mesmer/train_lv.py
+++ b/mesmer/calibrate_mesmer/train_lv.py
@@ -7,9 +7,6 @@ Functions to train local variability module of MESMER.
 """
 
 
-import os
-
-import joblib
 import xarray as xr
 
 from mesmer.core.auto_regression import _fit_auto_regression_xr
@@ -17,6 +14,7 @@ from mesmer.core.localized_covariance import (
     adjust_covariance_ar1,
     find_localized_empirical_covariance,
 )
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 from .train_utils import get_scenario_weights, stack_predictors_and_targets
 
@@ -138,22 +136,20 @@ def train_lv(preds, targs, esm, cfg, save_params=True, aux={}, params_lv={}):
 
     # overwrites lv module if already exists, i.e., assumption: always lt before lv
     if save_params:
-        dir_mesmer_params = cfg.dir_mesmer_params
-        dir_mesmer_params_lv = dir_mesmer_params + "local/local_variability/"
-        # check if folder to save params in exists, if not: make it
-        if not os.path.exists(dir_mesmer_params_lv):
-            os.makedirs(dir_mesmer_params_lv)
-            print("created dir:", dir_mesmer_params_lv)
-        filename_parts = [
-            "params_lv",
-            method_lv,
-            *preds_lv,
-            *targ_names,
-            esm,
-            *scenarios_tr,
-        ]
-        filename_params_lv = dir_mesmer_params_lv + "_".join(filename_parts) + ".pkl"
-        joblib.dump(params_lv, filename_params_lv)
+        save_mesmer_data(
+            params_lv,
+            cfg.dir_mesmer_params,
+            "local",
+            "local_variability",
+            filename_parts=[
+                "params_lv",
+                method_lv,
+                *preds_lv,
+                *targ_names,
+                esm,
+                *scenarios_tr,
+            ],
+        )
 
     return params_lv
 

--- a/mesmer/create_emulations/create_emus_gt.py
+++ b/mesmer/create_emulations/create_emus_gt.py
@@ -6,10 +6,9 @@
 Functions to create global trend emulations with MESMER.
 """
 
-import os
-
-import joblib
 import numpy as np
+
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
 # TODO: rename because there's actually no emulation involved in this process
@@ -93,21 +92,19 @@ def create_emus_gt(params_gt, preds_gt, cfg, concat_h_f=False, save_emus=True):
 
     # save the global trend emulation if requested
     if save_emus:
-        dir_mesmer_emus = cfg.dir_mesmer_emus
-        dir_mesmer_emus_gt = dir_mesmer_emus + "global/global_trend/"
-        # check if folder to save params in exists, if not: make it
-        if not os.path.exists(dir_mesmer_emus_gt):
-            os.makedirs(dir_mesmer_emus_gt)
-            print("created dir:", dir_mesmer_emus_gt)
-        filename_parts = [
-            "emus_gt",
-            params_gt["method"],
-            *params_gt["preds"],
-            params_gt["targ"],
-            params_gt["esm"],
-            *scens_out,
-        ]
-        filename_emus_gt = dir_mesmer_emus_gt + "_".join(filename_parts) + ".pkl"
-        joblib.dump(emus_gt, filename_emus_gt)
+        save_mesmer_data(
+            emus_gt,
+            cfg.dir_mesmer_emus,
+            "global",
+            "global_trend",
+            filename_parts=[
+                "emus_gt",
+                params_gt["method"],
+                *params_gt["preds"],
+                params_gt["targ"],
+                params_gt["esm"],
+                *scens_out,
+            ],
+        )
 
     return emus_gt

--- a/mesmer/create_emulations/create_emus_gv.py
+++ b/mesmer/create_emulations/create_emus_gv.py
@@ -7,12 +7,10 @@ Functions to create global variability emulations with MESMER.
 """
 
 
-import os
-
-import joblib
 import numpy as np
 
 from mesmer.core.auto_regression import _draw_auto_regression_correlated_np
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
 def create_emus_gv(params_gv, preds_gv, cfg, save_emus=True):
@@ -56,9 +54,6 @@ def create_emus_gv(params_gv, preds_gv, cfg, save_emus=True):
     """
 
     # specify necessary variables from config file
-    if save_emus:
-        dir_mesmer_emus = cfg.dir_mesmer_emus
-
     nr_emus_v = cfg.nr_emus_v
     seed_all_scens = cfg.seed[params_gv["esm"]]
 
@@ -91,21 +86,20 @@ def create_emus_gv(params_gv, preds_gv, cfg, save_emus=True):
 
     # save the global variability emus if requested
     if save_emus:
-        dir_mesmer_emus_gv = dir_mesmer_emus + "global/global_variability/"
-        # check if folder to save emus in exists, if not: make it
-        if not os.path.exists(dir_mesmer_emus_gv):
-            os.makedirs(dir_mesmer_emus_gv)
-            print("created dir:", dir_mesmer_emus_gv)
-        filename_parts = [
-            "emus_gv",
-            params_gv["method"],
-            *params_gv["preds"],
-            params_gv["targ"],
-            params_gv["esm"],
-            *scens_out,
-        ]
-        filename_emus_gv = dir_mesmer_emus_gv + "_".join(filename_parts) + ".pkl"
-        joblib.dump(emus_gv, filename_emus_gv)
+        save_mesmer_data(
+            emus_gv,
+            cfg.dir_mesmer_emus,
+            "global",
+            "global_variability",
+            filename_parts=[
+                "emus_gv",
+                params_gv["method"],
+                *params_gv["preds"],
+                params_gv["targ"],
+                params_gv["esm"],
+                *scens_out,
+            ],
+        )
 
     return emus_gv
 

--- a/mesmer/create_emulations/create_emus_lt.py
+++ b/mesmer/create_emulations/create_emus_lt.py
@@ -7,10 +7,9 @@ Functions to create local trends emulations with MESMER.
 """
 
 
-import os
-
-import joblib
 import numpy as np
+
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
 def create_emus_lt(params_lt, preds_lt, cfg, concat_h_f=False, save_emus=True):
@@ -67,9 +66,6 @@ def create_emus_lt(params_lt, preds_lt, cfg, concat_h_f=False, save_emus=True):
           by shape predictors
 
     """
-    # specify necessary variables from config file
-    if save_emus:
-        dir_mesmer_emus = cfg.dir_mesmer_emus
 
     # derive necessary scenario names
     pred_names = list(preds_lt.keys())
@@ -125,21 +121,20 @@ def create_emus_lt(params_lt, preds_lt, cfg, concat_h_f=False, save_emus=True):
 
     # save the local trends emulation if requested
     if save_emus:
-        dir_mesmer_emus_lt = dir_mesmer_emus + "local/local_trends/"
-        # check if folder to save params in exists, if not: make it
-        if not os.path.exists(dir_mesmer_emus_lt):
-            os.makedirs(dir_mesmer_emus_lt)
-            print("created dir:", dir_mesmer_emus_lt)
-        filename_parts = [
-            "emus_lt",
-            params_lt["method"],
-            *params_lt["preds"],
-            *params_lt["targs"],
-            params_lt["esm"],
-            *scens_out,
-        ]
-        filename_emus_lt = dir_mesmer_emus_lt + "_".join(filename_parts) + ".pkl"
-        joblib.dump(emus_lt, filename_emus_lt)
+        save_mesmer_data(
+            emus_lt,
+            cfg.dir_mesmer_emus,
+            "local",
+            "local_trends",
+            filename_parts=[
+                "emus_lt",
+                params_lt["method"],
+                *params_lt["preds"],
+                *params_lt["targs"],
+                params_lt["esm"],
+                *scens_out,
+            ],
+        )
 
     return emus_lt
 

--- a/mesmer/create_emulations/create_emus_lv.py
+++ b/mesmer/create_emulations/create_emus_lv.py
@@ -7,12 +7,10 @@ Functions to create local variability emulations with MESMER.
 """
 
 
-import os
-
-import joblib
 import numpy as np
 
 from mesmer.core.auto_regression import _draw_auto_regression_correlated_np
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
 def create_emus_lv(params_lv, preds_lv, cfg, save_emus=True, submethod=""):
@@ -66,10 +64,6 @@ def create_emus_lv(params_lv, preds_lv, cfg, save_emus=True, submethod=""):
           others for other methods
     """
 
-    # specify necessary variables from config file
-    if save_emus:
-        dir_mesmer_emus = cfg.dir_mesmer_emus
-
     pred_names = list(preds_lv.keys())
     scens_out = list(preds_lv[pred_names[0]].keys())
 
@@ -92,21 +86,20 @@ def create_emus_lv(params_lv, preds_lv, cfg, save_emus=True, submethod=""):
 
     # save the local trends emulation if requested
     if save_emus:
-        dir_mesmer_emus_lv = dir_mesmer_emus + "local/local_variability/"
-        # check if folder to save params in exists, if not: make it
-        if not os.path.exists(dir_mesmer_emus_lv):
-            os.makedirs(dir_mesmer_emus_lv)
-            print("created dir:", dir_mesmer_emus_lv)
-        filename_parts = [
-            "emus_lv",
-            submethod,
-            *params_lv["preds"],
-            *params_lv["targs"],
-            params_lv["esm"],
-            *scens_out,
-        ]
-        filename_emus_lv = dir_mesmer_emus_lv + "_".join(filename_parts) + ".pkl"
-        joblib.dump(emus_lv, filename_emus_lv)
+        save_mesmer_data(
+            emus_lv,
+            cfg.dir_mesmer_emus,
+            "local",
+            "local_variability",
+            filename_parts=[
+                "emus_lv",
+                submethod,
+                *params_lv["preds"],
+                *params_lv["targs"],
+                params_lv["esm"],
+                *scens_out,
+            ],
+        )
 
     return emus_lv
 

--- a/mesmer/create_emulations/merge_emus.py
+++ b/mesmer/create_emulations/merge_emus.py
@@ -7,10 +7,9 @@ Functions to merge emulations of different MESMER modules.
 """
 
 
-import os
 import warnings
 
-import joblib
+from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
 def create_emus_g(emus_gt, emus_gv, params_gt, params_gv, cfg, save_emus=True):
@@ -87,27 +86,23 @@ def create_emus_g(emus_gt, emus_gv, params_gt, params_gv, cfg, save_emus=True):
 
     # save the global emus if requested
     if save_emus:
-        dir_mesmer_emus = cfg.dir_mesmer_emus
-        dir_mesmer_emus_g = dir_mesmer_emus + "global/"
-        # check if folder to save emus in exists, if not: make it
-        if not os.path.exists(dir_mesmer_emus_g):
-            os.makedirs(dir_mesmer_emus_g)
-            print("created dir:", dir_mesmer_emus_g)
-
-        filename_parts = [
-            "emus_g",
-            "gt",
-            params_gt["method"],
-            *params_gt["preds"],
-            "gv",
-            params_gv["method"],
-            *params_gv["preds"],
-            targ,
-            esm,
-            *scenarios_gt,
-        ]
-        filename_emus_g = dir_mesmer_emus_g + "_".join(filename_parts) + ".pkl"
-        joblib.dump(emus_g, filename_emus_g)
+        save_mesmer_data(
+            emus_g,
+            cfg.dir_mesmer_emus,
+            "global",
+            filename_parts=[
+                "emus_g",
+                "gt",
+                params_gt["method"],
+                *params_gt["preds"],
+                "gv",
+                params_gv["method"],
+                *params_gv["preds"],
+                targ,
+                esm,
+                *scenarios_gt,
+            ],
+        )
 
     return emus_g
 
@@ -158,10 +153,6 @@ def create_emus_l(emus_lt, emus_lv, params_lt, params_lv, cfg, save_emus=True):
 
     """
 
-    # specify necessary variables from config file
-    if save_emus:
-        dir_mesmer_emus = cfg.dir_mesmer_emus
-
     scenarios_lt = list(emus_lt.keys())
     scenarios_lv = list(emus_lv.keys())
 
@@ -201,24 +192,22 @@ def create_emus_l(emus_lt, emus_lv, params_lt, params_lv, cfg, save_emus=True):
 
     # save the global emus if requested
     if save_emus:
-        dir_mesmer_emus_l = dir_mesmer_emus + "local/"
-        # check if folder to save emus in exists, if not: make it
-        if not os.path.exists(dir_mesmer_emus_l):
-            os.makedirs(dir_mesmer_emus_l)
-            print("created dir:", dir_mesmer_emus_l)
-        filename_parts = [
-            "emus_l",
-            "lt",
-            params_lt["method"],
-            *params_lt["preds"],
-            "lv",
-            params_lv["method"],
-            *params_lv["preds"],
-            *targs,
-            esm,
-            *scenarios_lt,
-        ]
-        filename_emus_l = dir_mesmer_emus_l + "_".join(filename_parts) + ".pkl"
-        joblib.dump(emus_l, filename_emus_l)
+        save_mesmer_data(
+            emus_l,
+            cfg.dir_mesmer_emus,
+            "local",
+            filename_parts=[
+                "emus_l",
+                "lt",
+                params_lt["method"],
+                *params_lt["preds"],
+                "lv",
+                params_lv["method"],
+                *params_lv["preds"],
+                *targs,
+                esm,
+                *scenarios_lt,
+            ],
+        )
 
     return emus_l

--- a/mesmer/io/save_mesmer_bundle.py
+++ b/mesmer/io/save_mesmer_bundle.py
@@ -3,6 +3,8 @@
 # Licensed under the GNU General Public License v3.0 or later see LICENSE or
 # https://www.gnu.org/licenses/
 
+import os
+
 import joblib
 import xarray as xr
 
@@ -72,3 +74,32 @@ def save_mesmer_bundle(
         "land_fractions": land_fractions,
     }
     joblib.dump(mesmer_bundle, bundle_file)
+
+
+def save_mesmer_data(params, *folders, filename_parts):
+    """save mesmer data to pickle format
+
+    Parameters
+    ----------
+    params : Any
+        Python object containg the parameters to save (e.g. a dictionary containing
+        numpy arrays etc.)
+    *folders : str
+        Name of the folders where to store the data.
+    filename_parts : iterable of str
+        Parts making up the filename. The parts will be joined by "_"
+
+    """
+
+    folder = os.path.join(*folders)
+
+    # check if folder to save params in exists, if not: make it
+    if not os.path.exists(folder):
+        os.makedirs(folder)
+        print(f"created dir: {folder}")
+
+    filename = "_".join(filename_parts) + ".pkl"
+    filename = f"{filename}.pkl"
+
+    fullname = os.path.join(folder, filename)
+    joblib.dump(params, fullname)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Adds a helper function to save mesmer parameters and emulations (in the pickle format). This is not super important but (1) helps to clean up the code a bit, (2) allows to no longer add `"/"` add the end of path definitions.
