### PR TITLE
paths: remove need for trailing separator

### DIFF
--- a/configs/config_across_scen_T_cmip6ng_test.py
+++ b/configs/config_across_scen_T_cmip6ng_test.py
@@ -4,8 +4,7 @@ Configuration file for tests
 """
 import os.path
 
-# path to mesmer root directory can be found in a slightly sneaky way
-# like this
+# path to mesmer root directory can be found in a slightly sneaky way like this
 MESMER_ROOT = os.path.join(os.path.dirname(__file__), "..")
 
 # using os.path makes the paths platform-portable i.e. this will
@@ -21,21 +20,17 @@ TEST_DATA_ROOT = os.path.join(
 
 # cmip-ng
 gen = 6  # generation
-dir_cmipng = os.path.join(
-    TEST_DATA_ROOT, f"cmip{gen}-ng/"
-)  # TODO: remove need for trailing "/" here
+dir_cmipng = os.path.join(TEST_DATA_ROOT, f"cmip{gen}-ng")
 
 # observations
-dir_obs = os.path.join(
-    TEST_DATA_ROOT, "observations/"
-)  # TODO: remove need for trailing "/" here
+dir_obs = os.path.join(TEST_DATA_ROOT, "observations")
 
 # auxiliary data
-dir_aux = "auxillary/"
+dir_aux = "auxillary"
 
 # mesmer
-dir_mesmer_params = os.path.join(MESMER_ROOT, "calibrated_parameters/")
-dir_mesmer_emus = os.path.join(MESMER_ROOT, "emulations/")
+dir_mesmer_params = os.path.join(MESMER_ROOT, "calibrated_parameters")
+dir_mesmer_emus = os.path.join(MESMER_ROOT, "emulations")
 
 
 # configs that can be set for every run:

--- a/mesmer/calibrate_mesmer/calibrate_mesmer.py
+++ b/mesmer/calibrate_mesmer/calibrate_mesmer.py
@@ -2,7 +2,6 @@
 Functions to calibrate all modules of MESMER
 """
 import logging
-import os
 import warnings
 
 from ..create_emulations import create_emus_gt, create_emus_lt, create_emus_lv
@@ -47,10 +46,10 @@ class _Config:
         self.esms = esms
         self.scenarios = scenarios
         self.gen = cmip_generation
-        # TODO: remove need for trailing seperator eventually
-        self.dir_cmipng = f"{cmip_data_root_dir}{os.sep}"
-        self.dir_obs = f"{observations_root_dir}{os.sep}"
-        self.dir_aux = f"{auxiliary_data_dir}{os.sep}"
+
+        self.dir_cmipng = cmip_data_root_dir
+        self.dir_obs = observations_root_dir
+        self.dir_aux = auxiliary_data_dir
         self.ref = {
             "type": reference_period_type,
             "start": reference_period_start_year,
@@ -89,8 +88,7 @@ class _Config:
             raise ValueError("`dir_mesmer_params` required if `save_params` is True")
 
         self.save_params = save_params
-        # TODO: remove need for trailing seperator eventually
-        self.dir_mesmer_params = f"{params_output_dir}{os.sep}"
+        self.dir_mesmer_params = params_output_dir
 
 
 # TODO: remove draw realisations functionality

--- a/mesmer/io/_load_cmipng.py
+++ b/mesmer/io/_load_cmipng.py
@@ -8,6 +8,7 @@ Functions to load in cmip5 and cmip6 data from the cmip-ng archive at ETHZ.
 
 import copy as copy
 import glob as glob
+import os
 
 import numpy as np
 import xarray as xr
@@ -88,7 +89,7 @@ def find_files_cmipng(gen, esm, var, scenario, dir_cmipng):
 
     # for cmip5-ng
     if gen == 5:
-        dir_name = dir_cmipng + var + "/"
+        dir_name = os.path.join(dir_cmipng, var)
 
         if var == "tas":
             esms_excl = ["GISS-E2-H", "EC-EARTH"]
@@ -103,23 +104,12 @@ def find_files_cmipng(gen, esm, var, scenario, dir_cmipng):
             runs_excl = []
             print("TO DO: create list of excluded runs / ESMs for this variable")
 
-        path_runs_list = sorted(
-            glob.glob(
-                dir_name
-                + var
-                + "_ann_"
-                + esm
-                + "_"
-                + scenario
-                + "_"
-                + "r*i1p1"
-                + "_g025.nc"
-            )
-        )
+        path = os.path.join(dir_name, f"{var}_ann_{esm}_{scenario}_r*i1p1_g025.nc")
+        path_runs_list = sorted(glob.glob(path))
 
     # for cmip6-ng
     if gen == 6:
-        dir_name = dir_cmipng + var + "/ann/g025/"
+        dir_name = os.path.join(dir_cmipng, var, "ann", "g025")
 
         # TODO: remove hard-coding
         if var == "tas":
@@ -164,31 +154,11 @@ def find_files_cmipng(gen, esm, var, scenario, dir_cmipng):
         # print(
         #   "TO DO: rewrite selection of p2 in way that needs less space for CanESM5 (+ see if other ESMs need p2 too)"
         # )
-        path_runs_list_scen = sorted(
-            glob.glob(
-                dir_name
-                + var
-                + "_ann_"
-                + esm
-                + "_"
-                + scenario
-                + "_"
-                + "r*i1p1f*"
-                + "_g025.nc"
-            )
-        )
+        path = os.path.join(dir_name, f"{var}_ann_{esm}_{scenario}_r*i1p1f*_g025.nc")
+        path_runs_list_scen = sorted(glob.glob(path))
 
-        path_runs_list_hist = sorted(
-            glob.glob(
-                dir_name
-                + var
-                + "_ann_"
-                + esm
-                + "_historical_"
-                + "r*i1p1f*"
-                + "_g025.nc"
-            )
-        )
+        path = os.path.join(dir_name, f"{var}_ann_{esm}_historical_r*i1p1f*_g025.nc")
+        path_runs_list_hist = sorted(glob.glob(path))
 
         # check if both scenario and historical run are available for this realization, if yes add to path_runs_list
         path_runs_list = []

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -79,11 +79,20 @@ def load_phi_gc(lon, lat, ls, cfg, L_start=1500, L_end=10000, L_interval=250):
     dir_aux = cfg.dir_aux
     threshold_land = cfg.threshold_land
 
-    L_set = np.arange(L_start, L_end + 1, L_interval)
-
     # geodistance for all gps for certain threshold
     geodist_name = f"geodist_landthres_{threshold_land:1.2f}.pkl"
-    if not os.path.exists(dir_aux + geodist_name):
+
+    # gaspari-cohn correlation function phi
+    phi_gc_name = "phi_gaspari-cohn_landthres_{tl:1.2f}_Lset_{L_start}-{L_interval}-{L_end}.pkl".format(
+        tl=threshold_land, L_start=L_start, L_interval=L_interval, L_end=L_end
+    )
+
+    fullname_geodist = os.path.join(dir_aux, geodist_name)
+    fullname_phi_gc = os.path.join(dir_aux, phi_gc_name)
+
+    L_set = np.arange(L_start, L_end + 1, L_interval)
+
+    if not os.path.exists(fullname_geodist):
         # create geodist matrix + save it
         print("compute geographical distance between all land points")
 
@@ -97,18 +106,13 @@ def load_phi_gc(lon, lat, ls, cfg, L_start=1500, L_end=10000, L_interval=250):
         os.makedirs(dir_aux, exist_ok=True)
 
         # save the geodist file
-        joblib.dump(geodist, dir_aux + geodist_name)
+        joblib.dump(geodist, fullname_geodist)
 
     else:
         # load geodist matrix
-        geodist = joblib.load(dir_aux + geodist_name)
+        geodist = joblib.load(fullname_geodist)
 
-    # gaspari-cohn correlation function phi
-    phi_gc_name = "phi_gaspari-cohn_landthres_{tl:1.2f}_Lset_{L_start}-{L_interval}-{L_end}.pkl".format(
-        tl=threshold_land, L_start=L_start, L_interval=L_interval, L_end=L_end
-    )
-
-    if not os.path.exists(dir_aux + phi_gc_name):
+    if not os.path.exists(fullname_phi_gc):
         print("compute Gaspari-Cohn correlation function phi")
 
         phi_gc = {}
@@ -116,10 +120,10 @@ def load_phi_gc(lon, lat, ls, cfg, L_start=1500, L_end=10000, L_interval=250):
             phi_gc[L] = gaspari_cohn(geodist / L)
             print("done with L:", L)
 
-        joblib.dump(phi_gc, dir_aux + phi_gc_name)
+        joblib.dump(phi_gc, fullname_phi_gc)
 
     else:
-        phi_gc = joblib.load(dir_aux + phi_gc_name)
+        phi_gc = joblib.load(fullname_phi_gc)
 
     return phi_gc
 

--- a/mesmer/io/load_obs.py
+++ b/mesmer/io/load_obs.py
@@ -6,6 +6,8 @@
 Functions to load in observations which are saved locally.
 """
 
+import os
+
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -118,16 +120,13 @@ def load_obs_tblend(prod, lon, lat, cfg, sel_ref):
 
     """
 
+    path = os.path.join(cfg.dir_obs, "blended_temperatures", prod)
     if prod == "best":
-        path = (
-            cfg.dir_obs + "blended_temperatures/" + prod + "/best_ann_1850-2019_g025.nc"
-        )
+        path = os.path.join(path, "best_ann_1850-2019_g025.nc")
         tblend = xr.open_dataset(path).temperature
         tblend["time"] = np.arange(1850, 2020)
     elif prod == "cw":
-        path = (
-            cfg.dir_obs + "blended_temperatures/" + prod + "/cw_ann_1850-2018_g025.nc"
-        )
+        path = os.path.join(path, "cw_ann_1850-2018_g025.nc")
         tblend = xr.open_dataset(path).temperature_anomaly
         tblend["time"] = np.arange(1850, 2019)
 
@@ -136,7 +135,6 @@ def load_obs_tblend(prod, lon, lat, cfg, sel_ref):
         raise ValueError(
             "The grids of the ESM output and the observations do not agree."
         )
-        tblend = []
 
     # extract time
     time = tblend.time.values
@@ -181,7 +179,7 @@ def load_strat_aod(time, dir_obs):
 
     """
 
-    path_file = dir_obs + "aerosols/isaod_gl.dat"
+    path_file = os.path.join(dir_obs, "aerosols", "isaod_gl.dat")
     df = pd.read_csv(
         path_file,
         delim_whitespace=True,

--- a/tests/integration/test_load_cmipng.py
+++ b/tests/integration/test_load_cmipng.py
@@ -24,7 +24,7 @@ def _get_default_kwargs(
     test_cmip_data_root_dir = os.path.join(
         test_data_root_dir,
         "calibrate-coarse-grid",
-        f"cmip{gen}-ng/",
+        f"cmip{gen}-ng",
     )
 
     # mock cfg class

--- a/tests/unit/test_phi_gc.py
+++ b/tests/unit/test_phi_gc.py
@@ -7,7 +7,7 @@ from mesmer.io import load_phi_gc, load_regs_ls_wgt_lon_lat
 
 class mock_cfg:
     def __init__(self, tmp_path, threshold_land):
-        self.dir_aux = str(tmp_path) + "/"
+        self.dir_aux = str(tmp_path)
         self.threshold_land = threshold_land
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Paths can now be given without a trailing separator (`"/"`). This should - in principle - also allow to run mesmer on windows.
