### PR TITLE
mask_frac: rename, fix coords and pole behaviour

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,7 +42,7 @@ Breaking changes
 - Moved ``gaspari_cohn`` & ``calc_geodist_exact`` from ``io.load_constant_files`` to ``core.computation``
   (`#158 <https://github.com/MESMER-group/mesmer/issues/158>`_).
   By `Yann Quilcaille <https://github.com/yquilcaille>`_.
- - The function `mask_percentage` has been renamed to :py:func:`utils.regionmaskcompat.mask_3D_frac_approx`
+ - The function ``mask_percentage`` has been renamed to :py:func:`utils.regionmaskcompat.mask_3D_frac_approx`
   (`#202 <https://github.com/MESMER-group/mesmer/pull/202>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Breaking changes
 - Moved ``gaspari_cohn`` & ``calc_geodist_exact`` from ``io.load_constant_files`` to ``core.computation``
   (`#158 <https://github.com/MESMER-group/mesmer/issues/158>`_).
   By `Yann Quilcaille <https://github.com/yquilcaille>`_.
+ - The function `mask_percentage` has been renamed to :py:func:`utils.regionmaskcompat.mask_3D_frac_approx`
+  (`#202 <https://github.com/MESMER-group/mesmer/pull/202>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 
 Deprecations
 ^^^^^^^^^^^^
@@ -50,6 +53,10 @@ Deprecations
 Bug fixes
 ^^^^^^^^^
 
+- Fix two issues with :py:func:`utils.regionmaskcompat.mask_3D_frac_approx`. Note that these
+  issues are only relevant if passing xarray objects or masks close to the poles
+  (`#202 <https://github.com/MESMER-group/mesmer/pull/202>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 
 Documentation
 ^^^^^^^^^^^^^

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -15,7 +15,7 @@ import numpy as np
 import regionmask
 from packaging.version import Version
 
-from ..utils.regionmaskcompat import mask_percentage
+from ..utils.regionmaskcompat import mask_3D_frac_approx
 from ..utils.xrcompat import infer_interval_breaks
 
 
@@ -198,7 +198,7 @@ def load_regs_ls_wgt_lon_lat(reg_type, lon, lat):
     reg_dict["abbrevs"] = reg.abbrevs
     reg_dict["names"] = reg.names
     # have fraction of grid cells
-    reg_dict["grids"] = mask_percentage(reg, lon["c"], lat["c"]).values
+    reg_dict["grids"] = mask_3D_frac_approx(reg, lon["c"], lat["c"]).values
     # not sure if needed: "binary" grid with each grid point assigned to single country
     reg_dict["grid_b"] = reg.mask(lon["c"], lat["c"]).values
     # to be used for plotting outlines (mainly useful for srex regs)
@@ -213,7 +213,9 @@ def load_regs_ls_wgt_lon_lat(reg_type, lon, lat):
 
     # gives fraction of land -> in extract_land() script decide above which land
     # fraction threshold to consider a grid point as a land grid point
-    ls["grid_raw"] = np.squeeze(mask_percentage(land_110, lon["c"], lat["c"]).values)
+    ls["grid_raw"] = np.squeeze(
+        mask_3D_frac_approx(land_110, lon["c"], lat["c"]).values
+    )
 
     # remove Antarctica
     idx_ANT = np.where(lat["c"] < -60)[0]

--- a/mesmer/utils/regionmaskcompat.py
+++ b/mesmer/utils/regionmaskcompat.py
@@ -2,6 +2,7 @@
 # see licenses/REGIONMASK_LICENSE
 
 import numpy as np
+import regionmask
 import xarray as xr
 
 
@@ -17,10 +18,22 @@ def mask_percentage(regions, lon, lat, **kwargs):
 
     """
 
+    backend = regionmask.core.mask._determine_method(lon, lat)
+    if "rasterize" not in backend:
+        raise ValueError("'lon' and 'lat' must be 1D and equally spaced.")
+
+    if np.min(lat) < -90 or np.max(lat) > 90:
+        raise ValueError("lat must be between -90 and +90")
+
+    lon_name = getattr(lon, "name", "lon")
+    lat_name = getattr(lat, "name", "lat")
+
     lon_sampled = sample_coord(lon)
     lat_sampled = sample_coord(lat)
 
     mask = regions.mask(lon_sampled, lat_sampled, **kwargs)
+
+    sel = (mask.lat >= -90) & (mask.lat <= 90)
 
     isnan = np.isnan(mask.values)
 
@@ -30,14 +43,27 @@ def mask_percentage(regions, lon, lat, **kwargs):
     mask_sampled = list()
     for num in numbers:
         # coarsen the mask again
-        mask_coarse = (mask == num).coarsen(lat=10, lon=10).mean()
+        mask_coarse = mask == num
+        # set points beyond 90° to NaN so we get the correct fraction
+        mask_coarse = mask_coarse.where(sel)
+        mask_coarse = mask_coarse.coarsen(lat=10, lon=10).mean()
         mask_sampled.append(mask_coarse)
 
     mask_sampled = xr.concat(
         mask_sampled, dim="region", compat="override", coords="minimal"
     )
 
-    mask_sampled = mask_sampled.assign_coords(region=("region", numbers))
+    abbrevs = regions[numbers].abbrevs
+    names = regions[numbers].names
+
+    coords = {
+        "region": numbers,
+        lon_name: lon,
+        lat_name: lat,
+        "abbrevs": ("region", abbrevs),
+        "names": ("region", names),
+    }
+    mask_sampled = mask_sampled.assign_coords(coords)
 
     return mask_sampled
 
@@ -52,9 +78,12 @@ def sample_coord(coord):
     -> prototype of what will eventually be integrated in his regionmask package
 
     """
+
+    coord = np.asarray(coord)
+
     d_coord = coord[1] - coord[0]
 
-    n_cells = len(coord)
+    n_cells = coord.size
 
     left = coord[0] - d_coord / 2 + d_coord / 20
     right = coord[-1] + d_coord / 2 - d_coord / 20

--- a/mesmer/utils/regionmaskcompat.py
+++ b/mesmer/utils/regionmaskcompat.py
@@ -1,12 +1,22 @@
 # code vendored from regionmask under the conditions of their license
 # see licenses/REGIONMASK_LICENSE
 
+import warnings
+
 import numpy as np
 import regionmask
 import xarray as xr
 
 
 def mask_percentage(regions, lon, lat, **kwargs):
+
+    warnings.warn(
+        "`mask_percentage` has been renamed to `mask_3D_frac_approx`", FutureWarning
+    )
+    return mask_3D_frac_approx(regions, lon, lat, **kwargs)
+
+
+def mask_3D_frac_approx(regions, lon, lat, **kwargs):
     """Sample with 10 times higher resolution.
 
     Notes

--- a/tests/unit/test_regionmaskcompat.py
+++ b/tests/unit/test_regionmaskcompat.py
@@ -3,7 +3,7 @@ import pytest
 import regionmask
 import shapely.geometry
 
-from mesmer.utils.regionmaskcompat import mask_percentage, sample_coord
+from mesmer.utils.regionmaskcompat import mask_3D_frac_approx, sample_coord
 
 
 def test_sample_coord():
@@ -29,7 +29,7 @@ def test_mask_percentage_wrong_coords(dim, invalid_coords):
     with pytest.raises(
         ValueError, match="'lon' and 'lat' must be 1D and equally spaced."
     ):
-        mask_percentage(None, **latlon)
+        mask_3D_frac_approx(None, **latlon)
 
 
 @pytest.mark.parametrize("lat", ((-91, 90), (-90, 92), (-91, 92)))
@@ -39,7 +39,7 @@ def test_mask_percentage_lon_beyond_90(lat):
     lon = np.arange(0, 360, 10)
 
     with pytest.raises(ValueError, match=r"lat must be between \-90 and \+90"):
-        mask_percentage(None, lon, lat)
+        mask_3D_frac_approx(None, lon, lat)
 
 
 def test_mask_percentage_coords():
@@ -51,7 +51,7 @@ def test_mask_percentage_coords():
     r = shapely.geometry.box(0, -90, 360, 90)
     r = regionmask.Regions([r])
 
-    result = mask_percentage(r, lon, lat)
+    result = mask_3D_frac_approx(r, lon, lat)
 
     np.testing.assert_equal(result.lon.values, lon)
     np.testing.assert_equal(result.lat.values, lat)
@@ -70,7 +70,7 @@ def test_mask_percentage_poles():
     r = shapely.geometry.box(0, -90, 360, 90)
     r = regionmask.Regions([r])
 
-    result = mask_percentage(r, lon, lat)
+    result = mask_3D_frac_approx(r, lon, lat)
     assert (result == 1).all()
 
 
@@ -85,7 +85,7 @@ def test_mask_percentage_southpole():
 
     for offset in np.arange(0, 1, 0.02):
         lat = np.arange(-90, -80, 1) + offset
-        result = mask_percentage(r, lon, lat)
+        result = mask_3D_frac_approx(r, lon, lat)
         assert (result.isel(lat=0) == 1).all()
 
 
@@ -100,7 +100,7 @@ def test_mask_percentage_northpole():
 
     for offset in np.arange(0, 1, 0.05):
         lat = np.arange(90, 80, -1) - offset
-        result = mask_percentage(r, lon, lat)
+        result = mask_3D_frac_approx(r, lon, lat)
         assert (result.isel(lat=0) == 1).all()
 
 
@@ -113,7 +113,7 @@ def test_mask_percentage():
     r = shapely.geometry.box(0, 0, 30, 30)
     r = regionmask.Regions([r])
 
-    result = mask_percentage(r, lon, lat)
+    result = mask_3D_frac_approx(r, lon, lat)
 
     expected = [[1, 0.5], [0.5, 0.25]]
     expected = np.array(expected)

--- a/tests/unit/test_regionmaskcompat.py
+++ b/tests/unit/test_regionmaskcompat.py
@@ -1,0 +1,121 @@
+import numpy as np
+import pytest
+import regionmask
+import shapely.geometry
+
+from mesmer.utils.regionmaskcompat import mask_percentage, sample_coord
+
+
+def test_sample_coord():
+
+    actual = sample_coord([0, 10])
+    expected = np.arange(-4.5, 14.6, 1)
+    np.testing.assert_allclose(actual, expected)
+
+    actual = sample_coord([0, 1, 2])
+    expected = np.arange(-0.45, 2.46, 0.1)
+    np.testing.assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("dim", ["lon", "lat"])
+@pytest.mark.parametrize("invalid_coords", ([0, 1, 3], [[0, 1, 2]]))
+def test_mask_percentage_wrong_coords(dim, invalid_coords):
+
+    valid_coords = [0, 1, 2]
+    latlon = {"lon": valid_coords, "lat": valid_coords}
+    # replace one of the coords with invalid values
+    latlon[dim] = invalid_coords
+
+    with pytest.raises(
+        ValueError, match="'lon' and 'lat' must be 1D and equally spaced."
+    ):
+        mask_percentage(None, **latlon)
+
+
+@pytest.mark.parametrize("lat", ((-91, 90), (-90, 92), (-91, 92)))
+def test_mask_percentage_lon_beyond_90(lat):
+
+    lat = np.arange(*lat)
+    lon = np.arange(0, 360, 10)
+
+    with pytest.raises(ValueError, match=r"lat must be between \-90 and \+90"):
+        mask_percentage(None, lon, lat)
+
+
+def test_mask_percentage_coords():
+    # ensure coords are the same (as they might by averaged)
+
+    lat = np.arange(90, -90, -1)
+    lon = np.arange(0, 360, 1)
+
+    r = shapely.geometry.box(0, -90, 360, 90)
+    r = regionmask.Regions([r])
+
+    result = mask_percentage(r, lon, lat)
+
+    np.testing.assert_equal(result.lon.values, lon)
+    np.testing.assert_equal(result.lat.values, lat)
+
+    assert result.abbrevs.item() == "r0"
+    assert result.names.item() == "Region0"
+    assert result.region.item() == 0
+
+
+def test_mask_percentage_poles():
+    # all points should be 1 for a global mask
+
+    lat = np.arange(90, -90, -1)
+    lon = np.arange(0, 360, 1)
+
+    r = shapely.geometry.box(0, -90, 360, 90)
+    r = regionmask.Regions([r])
+
+    result = mask_percentage(r, lon, lat)
+    assert (result == 1).all()
+
+
+def test_mask_percentage_southpole():
+    # all at the southpole should be 1 - irrespective of where exactly the southernmost
+    # latitude is
+
+    lon = np.arange(0, 30, 1)
+
+    r = shapely.geometry.box(0, -90, 360, -85)
+    r = regionmask.Regions([r])
+
+    for offset in np.arange(0, 1, 0.02):
+        lat = np.arange(-90, -80, 1) + offset
+        result = mask_percentage(r, lon, lat)
+        assert (result.isel(lat=0) == 1).all()
+
+
+def test_mask_percentage_northpole():
+    # all at the southpole should be 1 - irrespective of where exactly the southernmost
+    # latitude is
+
+    lon = np.arange(0, 30, 1)
+
+    r = shapely.geometry.box(0, 85, 360, 90)
+    r = regionmask.Regions([r])
+
+    for offset in np.arange(0, 1, 0.05):
+        lat = np.arange(90, 80, -1) - offset
+        result = mask_percentage(r, lon, lat)
+        assert (result.isel(lat=0) == 1).all()
+
+
+def test_mask_percentage():
+
+    lon = np.array([15, 30])
+    lat = np.array([15, 30])
+
+    # the center of the region is at 15°
+    r = shapely.geometry.box(0, 0, 30, 30)
+    r = regionmask.Regions([r])
+
+    result = mask_percentage(r, lon, lat)
+
+    expected = [[1, 0.5], [0.5, 0.25]]
+    expected = np.array(expected)
+
+    np.testing.assert_allclose(result.values.squeeze(), expected)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

I found two issues when trying to use `mask_percentage` with xarray objects.

1. The coords were not exactly correct (due to numerical issues)
2. The fractional overlap at the poles was incorrect.

This PR fixes those two problems. Note that the problems were not relevant for mesmer so far! Also adds some basic tests.

I will double check with the author of regionmask if this makes sense.