### PR TITLE
convert grids to/ from unstructured

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ New Features
 - Refactor the LOWESS smoothing for xarray objects: :py:func:`mesmer.stats.smoothing.lowess`.
   (`#193 <https://github.com/MESMER-group/mesmer/pull/193>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
-- Added functions to convert xarray objects to an unstructured grid and back (`#217
+- Added functions to stack regular lat-lon grids to 1D grids and unstack them again (`#217
   <https://github.com/MESMER-group/mesmer/pull/217>`_). By `Mathias Hauser
   <https://github.com/mathause>`_.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ New Features
 - Refactor the LOWESS smoothing for xarray objects: :py:func:`mesmer.stats.smoothing.lowess`.
   (`#193 <https://github.com/MESMER-group/mesmer/pull/193>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Added functions to convert xarray objects to an unstructured grid and back (`#217
+  <https://github.com/MESMER-group/mesmer/pull/217>`_). By `Mathias Hauser
+  <https://github.com/mathause>`_.
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,10 +42,10 @@ Data manipulation
 .. autosummary::
    :toctree: generated/
 
-   ~xarray_utils.stack_lat_lon
-   ~xarray_utils.unstack_lat_lon_and_align
-   ~xarray_utils.unstack_lat_lon
-   ~xarray_utils.align_to_coords
+   ~xarray_utils.grid.stack_lat_lon
+   ~xarray_utils.grid.unstack_lat_lon_and_align
+   ~xarray_utils.grid.unstack_lat_lon
+   ~xarray_utils.grid.align_to_coords
 
 Train mesmer
 ------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -36,6 +36,15 @@ Computation
    ~core.computation.calc_geodist_exact
    ~core.computation.gaspari_cohn
 
+Data manipulation
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   ~xarray_utils.to_unstructured
+   ~xarray_utils.from_unstructured
+
 Train mesmer
 ------------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,8 +42,10 @@ Data manipulation
 .. autosummary::
    :toctree: generated/
 
-   ~xarray_utils.to_unstructured
-   ~xarray_utils.from_unstructured
+   ~xarray_utils.stack_lat_lon
+   ~xarray_utils.unstack_lat_lon_and_align
+   ~xarray_utils.unstack_lat_lon
+   ~xarray_utils.align_to_coords
 
 Train mesmer
 ------------

--- a/mesmer/__init__.py
+++ b/mesmer/__init__.py
@@ -8,7 +8,7 @@ analyze the results.
 """
 # flake8: noqa
 
-from . import calibrate_mesmer, create_emulations, io, utils
+from . import calibrate_mesmer, create_emulations, io, utils, xarray_utils
 
 try:
     from importlib.metadata import version as _get_version

--- a/mesmer/xarray_utils/__init__.py
+++ b/mesmer/xarray_utils/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-from mesmer.xarray_utils.grid import from_unstructured, to_unstructured
+from mesmer.xarray_utils.grid import stack_lat_lon, unstack_lat_lon_and_align

--- a/mesmer/xarray_utils/__init__.py
+++ b/mesmer/xarray_utils/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-from mesmer.xarray_utils.grid import stack_lat_lon, unstack_lat_lon_and_align
+from mesmer.xarray_utils import grid

--- a/mesmer/xarray_utils/__init__.py
+++ b/mesmer/xarray_utils/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+
+
+from mesmer.xarray_utils.grid import from_unstructured, to_unstructured

--- a/mesmer/xarray_utils/__init__.py
+++ b/mesmer/xarray_utils/__init__.py
@@ -1,4 +1,3 @@
 # flake8: noqa
 
-
 from mesmer.xarray_utils.grid import from_unstructured, to_unstructured

--- a/mesmer/xarray_utils/grid.py
+++ b/mesmer/xarray_utils/grid.py
@@ -4,7 +4,7 @@ from packaging.version import Version
 
 
 def to_unstructured(
-    obj, x_dim="lon", y_dim="lat", cell_dim="cell", multiindex=False, dropna=True
+    obj, *, x_dim="lon", y_dim="lat", cell_dim="cell", multiindex=False, dropna=True
 ):
     """stack a regular grid to an unstructured grid
 
@@ -47,7 +47,7 @@ def to_unstructured(
     return obj
 
 
-def from_unstructured(obj, coords_orig, x_dim="lon", y_dim="lat", cell_dim="cell"):
+def from_unstructured(obj, coords_orig, *, x_dim="lon", y_dim="lat", cell_dim="cell"):
     """unstack an unstructured grid to a regular grid
 
     Parameters
@@ -84,6 +84,6 @@ def from_unstructured(obj, coords_orig, x_dim="lon", y_dim="lat", cell_dim="cell
     obj = xr.align(obj, coords_orig, join="right")[0]
 
     # make sure non-dimension coords are correct
-    obj = obj.assign_coords(coords_orig)
+    obj = obj.assign_coords(coords_orig.coords)
 
     return obj

--- a/mesmer/xarray_utils/grid.py
+++ b/mesmer/xarray_utils/grid.py
@@ -30,14 +30,13 @@ def to_unstructured(
     """
 
     dims = {cell_dim: (y_dim, x_dim)}
-    # dims = {cell_dim: (x_dim, y_dim)}
 
     obj = obj.stack(dims)
 
     if not multiindex:
         # there is a bug in xarray v2022.06 (Index refactor)
-        if Version(xr.__version__) == Version("2022.3"):
-            raise TypeError("There is a bug in xarray v2022.03. Please update xarray.")
+        if Version(xr.__version__) == Version("2022.6"):
+            raise TypeError("There is a bug in xarray v2022.06. Please update xarray.")
 
         obj = obj.reset_index(cell_dim)
 

--- a/mesmer/xarray_utils/grid.py
+++ b/mesmer/xarray_utils/grid.py
@@ -1,0 +1,142 @@
+import pandas as pd
+import xarray as xr
+from packaging.version import Version
+
+
+def to_unstructured(
+    obj, x_dim="lon", y_dim="lat", cell_dim="cell", multiindex=False, dropna=True
+):
+    """stack a regular grid to an unstructured grid
+
+    Parameters
+    ----------
+    obj : xr.Dataset | xr.DataArray
+        Array to convert to an unstructured grid.
+    x_dim : str, default: "lon"
+        Name of the x-dimension.
+    y_dim : str, default: "lat"
+        Name of the y-dimension.
+    cell_dim : str, default: "cell"
+        Name of the new dimension.
+    multiindex : bool, default: False
+        If the new `cell_dim` should be returned as a MultiIndex.
+    dropna : bool, default: True
+        Drops each 'cell' if any NA values are present.
+
+    Returns
+    -------
+    obj : xr.Dataset | xr.DataArray
+        Array converted to an unstructured grid.
+    """
+
+    dims = {cell_dim: (y_dim, x_dim)}
+    # dims = {cell_dim: (x_dim, y_dim)}
+
+    obj = obj.stack(dims)
+
+    if not multiindex:
+        # there is a bug in xarray v2022.06 (Index refactor)
+        if Version(xr.__version__) == Version("2022.3"):
+            raise TypeError(
+                "There is a bug in xarray v2022.03." "Please update of xarray."
+            )
+
+        obj = obj.reset_index(cell_dim)
+
+    if dropna:
+        obj = obj.dropna(cell_dim)
+
+    return obj
+
+
+def from_unstructured(obj, coords_orig, x_dim="lon", y_dim="lat", cell_dim="cell"):
+    """unstack an unstructured grid to a regular grid
+
+    Parameters
+    ----------
+    obj : xr.Dataset | xr.DataArray
+        Array to convert to an unstructured grid.
+    coords_orig : xr.Dataset | xr.DataArray
+        xarray object containing the original coordinates before it was converted to the
+        unstructured grid.
+    x_dim : str, default: "lon"
+        Name of the x-dimension.
+    y_dim : str, default: "lat"
+        Name of the y-dimension.
+    cell_dim : str, default: "cell"
+        Name of the new dimension.
+    multiindex : bool, default: False
+        If the new `cell_dim` should be returned as a MultiIndex.
+    dropna : bool, default: True
+        Drops each 'cell' if any NA values are present.
+
+    Returns
+    -------
+    obj : xr.Dataset | xr.DataArray
+        Array converted to an unstructured grid.
+    """
+
+    # a MultiIndex is needed to unstack
+    if not isinstance(obj.indexes.get(cell_dim), pd.MultiIndex):
+        obj = obj.set_index({cell_dim: (y_dim, x_dim)})
+
+    obj = obj.unstack(cell_dim)
+
+    # ensure we don't loose entire rows/ columns
+    obj = xr.align(obj, coords_orig, join="right")[0]
+
+    # make sure non-dimension coords are correct
+    obj = obj.assign_coords(coords_orig)
+
+    return obj
+
+
+# import mesmer
+
+# tas = None
+# REFERENCE_PERIOD = None
+# x_dim = None
+# y_dim = None
+
+
+# tas = mesmer.tools.calc_anomaly(tas, reference_period=REFERENCE_PERIOD)
+
+# wgt = mesmer.tools.lat_weights(tas)
+# tas_globmean = mesmer.tools.calc_globmean(tas, wgt)
+
+
+# tas = mesmer.tools.mask_land(tas)
+# tas = mesmer.tools.mask_antarctica(tas)
+
+# coords_orig = tas[[x_dim, y_dim]]
+
+# tas = mesmer.tools.to_unstructured(tas)
+
+
+# mesmer.data_utils.to_unstructured
+# mesmer.preproc.to_unstructured
+# mesmer.process.to_unstructured
+# mesmer.tools.to_unstructured
+# mesmer.utils.to_unstructured
+# mesmer.xarray_utils.to_unstructured
+
+# import mesmer.xarray_utils as mxu
+
+# mxu.to_unstructured
+
+
+# tas = mxu.calc_anomaly(tas, reference_period=REFERENCE_PERIOD)
+
+# wgt = mxu.lat_weights(tas)
+# tas_globmean = mxu.calc_globmean(tas, wgt)
+
+
+# tas = mxu.mask_land(tas)
+# tas = mxu.mask_antarctica(tas)
+
+# coords_orig = tas[[x_dim, y_dim]]
+
+# tas = mxu.to_unstructured(tas)
+
+
+# tas = mxu.from_unstructured(tas)

--- a/mesmer/xarray_utils/grid.py
+++ b/mesmer/xarray_utils/grid.py
@@ -37,9 +37,7 @@ def to_unstructured(
     if not multiindex:
         # there is a bug in xarray v2022.06 (Index refactor)
         if Version(xr.__version__) == Version("2022.3"):
-            raise TypeError(
-                "There is a bug in xarray v2022.03." "Please update of xarray."
-            )
+            raise TypeError("There is a bug in xarray v2022.03. Please update xarray.")
 
         obj = obj.reset_index(cell_dim)
 
@@ -89,54 +87,3 @@ def from_unstructured(obj, coords_orig, x_dim="lon", y_dim="lat", cell_dim="cell
     obj = obj.assign_coords(coords_orig)
 
     return obj
-
-
-# import mesmer
-
-# tas = None
-# REFERENCE_PERIOD = None
-# x_dim = None
-# y_dim = None
-
-
-# tas = mesmer.tools.calc_anomaly(tas, reference_period=REFERENCE_PERIOD)
-
-# wgt = mesmer.tools.lat_weights(tas)
-# tas_globmean = mesmer.tools.calc_globmean(tas, wgt)
-
-
-# tas = mesmer.tools.mask_land(tas)
-# tas = mesmer.tools.mask_antarctica(tas)
-
-# coords_orig = tas[[x_dim, y_dim]]
-
-# tas = mesmer.tools.to_unstructured(tas)
-
-
-# mesmer.data_utils.to_unstructured
-# mesmer.preproc.to_unstructured
-# mesmer.process.to_unstructured
-# mesmer.tools.to_unstructured
-# mesmer.utils.to_unstructured
-# mesmer.xarray_utils.to_unstructured
-
-# import mesmer.xarray_utils as mxu
-
-# mxu.to_unstructured
-
-
-# tas = mxu.calc_anomaly(tas, reference_period=REFERENCE_PERIOD)
-
-# wgt = mxu.lat_weights(tas)
-# tas_globmean = mxu.calc_globmean(tas, wgt)
-
-
-# tas = mxu.mask_land(tas)
-# tas = mxu.mask_antarctica(tas)
-
-# coords_orig = tas[[x_dim, y_dim]]
-
-# tas = mxu.to_unstructured(tas)
-
-
-# tas = mxu.from_unstructured(tas)

--- a/mesmer/xarray_utils/grid.py
+++ b/mesmer/xarray_utils/grid.py
@@ -6,7 +6,7 @@ from packaging.version import Version
 def to_unstructured(
     obj, *, x_dim="lon", y_dim="lat", cell_dim="cell", multiindex=False, dropna=True
 ):
-    """stack a regular grid to an unstructured grid
+    """Stack a lat-lon grid to a 1D grid
 
     Parameters
     ----------
@@ -21,7 +21,7 @@ def to_unstructured(
     multiindex : bool, default: False
         If the new `cell_dim` should be returned as a MultiIndex.
     dropna : bool, default: True
-        Drops each 'cell' if any NA values are present.
+        Drops each 'cell' if any NA values are present at any point in the timeseries.
 
     Returns
     -------

--- a/mesmer/xarray_utils/grid.py
+++ b/mesmer/xarray_utils/grid.py
@@ -3,33 +3,39 @@ import xarray as xr
 from packaging.version import Version
 
 
-def to_unstructured(
-    obj, *, x_dim="lon", y_dim="lat", cell_dim="cell", multiindex=False, dropna=True
+def stack_lat_lon(
+    obj,
+    *,
+    x_dim="lon",
+    y_dim="lat",
+    stack_dim="gridcell",
+    multiindex=False,
+    dropna=True
 ):
-    """Stack a lat-lon grid to a 1D grid
+    """Stack a regular lat-lon grid to a 1D (unstructured) grid
 
     Parameters
     ----------
     obj : xr.Dataset | xr.DataArray
-        Array to convert to an unstructured grid.
+        Array to convert to an 1D grid.
     x_dim : str, default: "lon"
         Name of the x-dimension.
     y_dim : str, default: "lat"
         Name of the y-dimension.
-    cell_dim : str, default: "cell"
+    stack_dim : str, default: "gridcell"
         Name of the new dimension.
     multiindex : bool, default: False
-        If the new `cell_dim` should be returned as a MultiIndex.
+        If the new `stack_dim` should be returned as a MultiIndex.
     dropna : bool, default: True
-        Drops each 'cell' if any NA values are present at any point in the timeseries.
+        Drops each 'gridcell' if any NA values are present at any point in the timeseries.
 
     Returns
     -------
     obj : xr.Dataset | xr.DataArray
-        Array converted to an unstructured grid.
+        Array converted to an 1D grid.
     """
 
-    dims = {cell_dim: (y_dim, x_dim)}
+    dims = {stack_dim: (y_dim, x_dim)}
 
     obj = obj.stack(dims)
 
@@ -38,51 +44,92 @@ def to_unstructured(
         if Version(xr.__version__) == Version("2022.6"):
             raise TypeError("There is a bug in xarray v2022.06. Please update xarray.")
 
-        obj = obj.reset_index(cell_dim)
+        obj = obj.reset_index(stack_dim)
 
     if dropna:
-        obj = obj.dropna(cell_dim)
+        obj = obj.dropna(stack_dim)
 
     return obj
 
 
-def from_unstructured(obj, coords_orig, *, x_dim="lon", y_dim="lat", cell_dim="cell"):
-    """unstack an unstructured grid to a regular grid
+def unstack_lat_lon_and_align(
+    obj, coords_orig, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"
+):
+    """unstack an 1D grid to a regular lat-lon grid and align with orignal coords
 
     Parameters
     ----------
     obj : xr.Dataset | xr.DataArray
-        Array to convert to an unstructured grid.
+        Array with 1D grid to unstack and align.
     coords_orig : xr.Dataset | xr.DataArray
         xarray object containing the original coordinates before it was converted to the
-        unstructured grid.
+        1D grid.
     x_dim : str, default: "lon"
         Name of the x-dimension.
     y_dim : str, default: "lat"
         Name of the y-dimension.
-    cell_dim : str, default: "cell"
+    stack_dim : str, default: "gridcell"
         Name of the new dimension.
-    multiindex : bool, default: False
-        If the new `cell_dim` should be returned as a MultiIndex.
-    dropna : bool, default: True
-        Drops each 'cell' if any NA values are present.
 
     Returns
     -------
     obj : xr.Dataset | xr.DataArray
-        Array converted to an unstructured grid.
+        Array converted to a regular lat-lon grid.
+    """
+
+    obj = unstack_lat_lon(obj, x_dim=x_dim, y_dim=y_dim, stack_dim=stack_dim)
+
+    obj = align_to_coords(obj, coords_orig)
+
+    return obj
+
+
+def unstack_lat_lon(obj, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
+    """unstack an 1D grid to a regular lat-lon grid but do not align
+
+    Parameters
+    ----------
+    obj : xr.Dataset | xr.DataArray
+        Array with 1D grid to unstack and align.
+    x_dim : str, default: "lon"
+        Name of the x-dimension.
+    y_dim : str, default: "lat"
+        Name of the y-dimension.
+    stack_dim : str, default: "gridcell"
+        Name of the new dimension.
+
+    Returns
+    -------
+    obj : xr.Dataset | xr.DataArray
+        Array converted to a regular lat-lon grid (unaligned).
     """
 
     # a MultiIndex is needed to unstack
-    if not isinstance(obj.indexes.get(cell_dim), pd.MultiIndex):
-        obj = obj.set_index({cell_dim: (y_dim, x_dim)})
+    if not isinstance(obj.indexes.get(stack_dim), pd.MultiIndex):
+        obj = obj.set_index({stack_dim: (y_dim, x_dim)})
 
-    obj = obj.unstack(cell_dim)
+    return obj.unstack(stack_dim)
+
+
+def align_to_coords(obj, coords_orig):
+    """align an unstacked lat-lon grid with it's orignal coords
+
+    Parameters
+    ----------
+    obj : xr.Dataset | xr.DataArray
+        Unstacked array with lat-lon to align.
+    coords_orig : xr.Dataset | xr.DataArray
+        xarray object containing the original coordinates before it was converted to the
+        1D grid.
+
+    Returns
+    -------
+    obj : xr.Dataset | xr.DataArray
+        Array aligned with original grid.
+    """
 
     # ensure we don't loose entire rows/ columns
     obj = xr.align(obj, coords_orig, join="right")[0]
 
     # make sure non-dimension coords are correct
-    obj = obj.assign_coords(coords_orig.coords)
-
-    return obj
+    return obj.assign_coords(coords_orig.coords)

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -1,0 +1,187 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+import mesmer.xarray_utils as mxu
+
+
+def data_1D_dims(as_dataset, x_dim="lon", y_dim="lat", cell_dim="cell"):
+
+    data = np.arange(2 * 3 * 4, dtype=float)
+    time = [0, 1]
+    lat = [0, 1, 2]
+    lon = [0, 1, 2, 3]
+    name = "name"
+    attrs = {"key": "value"}
+    da_structured = xr.DataArray(
+        data.reshape(2, 3, 4),
+        dims=("time", y_dim, x_dim),
+        coords={"time": time, y_dim: lat, x_dim: lon},
+        name=name,
+        attrs=attrs,
+    )
+
+    da_unstructured = xr.DataArray(
+        data.reshape(2, 12),
+        dims=("time", cell_dim),
+        coords={
+            "time": time,
+            y_dim: (cell_dim, sorted(4 * lat)),
+            x_dim: (cell_dim, 3 * lon),
+        },
+        name=name,
+        attrs=attrs,
+    )
+
+    if as_dataset:
+        return da_structured.to_dataset(), da_unstructured.to_dataset()
+
+    return da_structured, da_unstructured
+
+
+def data_2D_dims(as_dataset):
+
+    data = np.arange(2 * 3 * 4, dtype=float)
+    time = [0, 1]
+    yc = np.array([[90, 90, 90, 90], [89, 89, 89, 89], [88, 88, 88, 88]])
+    xc = np.array([[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]])
+    yc, xc = np.mgrid[90:87:-1, 0:4]
+
+    name = "name"
+    attrs = {"key": "value"}
+    da_structured = xr.DataArray(
+        data.reshape(2, 3, 4),
+        dims=("time", "y", "x"),
+        coords={"time": time, "yc": (("y", "x"), yc), "xc": (("y", "x"), xc)},
+        name=name,
+        attrs=attrs,
+    )
+
+    y, x = np.mgrid[0:3, 0:4]
+
+    da_unstructured = xr.DataArray(
+        data.reshape(2, 12),
+        dims=("time", "cell"),
+        coords={
+            "time": time,
+            "yc": ("cell", yc.flatten()),
+            "xc": ("cell", xc.flatten()),
+            "y": ("cell", y.flatten()),
+            "x": ("cell", x.flatten()),
+        },
+        name=name,
+        attrs=attrs,
+    )
+
+    if as_dataset:
+        return da_structured.to_dataset(), da_unstructured.to_dataset()
+
+    return da_structured, da_unstructured
+
+
+@pytest.mark.parametrize("as_dataset", [True, False])
+def test_to_unstructured_defaults(as_dataset):
+    da, expected = data_1D_dims(as_dataset)
+
+    result = mxu.to_unstructured(da)
+
+    xr.testing.assert_identical(result, expected)
+
+
+@pytest.mark.parametrize("x_dim", ["lon", "x"])
+@pytest.mark.parametrize("y_dim", ["lat", "y"])
+@pytest.mark.parametrize("cell_dim", ["cell", "gridpoint"])
+@pytest.mark.parametrize("as_dataset", [True, False])
+def test_to_unstructured(x_dim, y_dim, cell_dim, as_dataset):
+    da, expected = data_1D_dims(as_dataset, x_dim=x_dim, y_dim=y_dim, cell_dim=cell_dim)
+
+    result = mxu.to_unstructured(da, x_dim=x_dim, y_dim=y_dim, cell_dim=cell_dim)
+
+    xr.testing.assert_identical(result, expected)
+
+
+@pytest.mark.parametrize("as_dataset", [True, False])
+def test_to_unstructured_2D_dims(as_dataset):
+    da, expected = data_2D_dims(as_dataset)
+
+    result = mxu.to_unstructured(da, x_dim="x", y_dim="y")
+    # to_unstructured adds coordinates for "Dimensions without coordinates"
+    # result = result.drop_vars(("x", "y"))
+
+    xr.testing.assert_identical(result, expected)
+
+
+@pytest.mark.parametrize("dropna", [True, False])
+@pytest.mark.parametrize("time_pos", [0, None])
+def test_to_unstructured_dropna(dropna, time_pos):
+
+    da, expected = data_1D_dims(as_dataset=False)
+
+    da[slice(time_pos), 0, 0] = np.NaN
+
+    # the gridpoint is droped if ANY time step is NaN
+    expected[:, 0] = np.NaN
+
+    if dropna:
+        expected = expected.dropna("cell")
+
+    result = mxu.to_unstructured(da, dropna=dropna)
+
+    xr.testing.assert_identical(result, expected)
+
+
+@pytest.mark.parametrize("as_dataset", [True, False])
+def test_from_unstructured_defaults(as_dataset):
+    expected, da = data_1D_dims(as_dataset)
+
+    # todo: get only lon & lat without time for DataArray and Dataset
+    coords_orig = expected.coords.to_dataset()[["lon", "lat"]]
+
+    result = mxu.from_unstructured(da, coords_orig)
+
+    xr.testing.assert_identical(result, expected)
+
+
+@pytest.mark.parametrize("x_dim", ["lon", "x"])
+@pytest.mark.parametrize("y_dim", ["lat", "y"])
+@pytest.mark.parametrize("cell_dim", ["cell", "gridpoint"])
+@pytest.mark.parametrize("as_dataset", [True, False])
+def test_from_unstructured(x_dim, y_dim, cell_dim, as_dataset):
+    expected, da = data_1D_dims(as_dataset, x_dim=x_dim, y_dim=y_dim, cell_dim=cell_dim)
+    # todo: get only lon & lat without time for DataArray and Dataset
+    coords_orig = expected.coords.to_dataset()[[x_dim, y_dim]]
+    result = mxu.from_unstructured(
+        da, coords_orig, x_dim=x_dim, y_dim=y_dim, cell_dim=cell_dim
+    )
+
+    xr.testing.assert_identical(result, expected)
+
+
+@pytest.mark.parametrize("as_dataset", [True, False])
+def test_unstructured_roundtrip_1D_dim(as_dataset):
+
+    da_structured, da_unstructured = data_1D_dims(as_dataset)
+
+    coords_orig = da_structured.coords.to_dataset()[["lon", "lat"]]
+
+    result = mxu.from_unstructured(mxu.to_unstructured(da_structured), coords_orig)
+    xr.testing.assert_identical(result, da_structured)
+
+    result = mxu.to_unstructured(mxu.from_unstructured(da_unstructured, coords_orig))
+    xr.testing.assert_identical(result, da_unstructured)
+
+
+@pytest.mark.parametrize("as_dataset", [True, False])
+def test_unstructured_roundtrip_2D_dim(as_dataset):
+
+    da_structured, da_unstructured = data_2D_dims(as_dataset)
+
+    dims = {"x_dim": "x", "y_dim": "y"}
+
+    coords_orig = da_structured.coords.to_dataset()[["x", "y"]]
+    print(coords_orig)
+
+    result = mxu.to_unstructured(
+        mxu.from_unstructured(da_unstructured, coords_orig, **dims), **dims
+    )
+    xr.testing.assert_identical(result, da_unstructured)

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -83,7 +83,7 @@ def data_2D_coords(as_dataset):
 def test_to_unstructured_defaults(as_dataset):
     da, expected = data_1D_coords(as_dataset)
 
-    result = mxu.stack_lat_lon(da)
+    result = mxu.grid.stack_lat_lon(da)
 
     xr.testing.assert_identical(result, expected)
 
@@ -92,7 +92,7 @@ def test_to_unstructured_defaults(as_dataset):
 def test_to_unstructured_multiindex(as_dataset):
     da, expected = data_1D_coords(as_dataset)
 
-    result = mxu.stack_lat_lon(da, multiindex=True)
+    result = mxu.grid.stack_lat_lon(da, multiindex=True)
 
     expected = expected.set_index({"gridcell": ("lat", "lon")})
 
@@ -108,7 +108,7 @@ def test_to_unstructured(x_dim, y_dim, cell_dim, as_dataset):
         as_dataset, x_dim=x_dim, y_dim=y_dim, stack_dim=cell_dim
     )
 
-    result = mxu.stack_lat_lon(da, x_dim=x_dim, y_dim=y_dim, stack_dim=cell_dim)
+    result = mxu.grid.stack_lat_lon(da, x_dim=x_dim, y_dim=y_dim, stack_dim=cell_dim)
 
     xr.testing.assert_identical(result, expected)
 
@@ -117,7 +117,7 @@ def test_to_unstructured(x_dim, y_dim, cell_dim, as_dataset):
 def test_to_unstructured_2D_coords(as_dataset):
     da, expected = data_2D_coords(as_dataset)
 
-    result = mxu.stack_lat_lon(da, x_dim="x", y_dim="y")
+    result = mxu.grid.stack_lat_lon(da, x_dim="x", y_dim="y")
 
     xr.testing.assert_identical(result, expected)
 
@@ -142,7 +142,7 @@ def test_to_unstructured_dropna(dropna, coords, time_pos):
     if dropna:
         expected = expected.dropna("gridcell")
 
-    result = mxu.stack_lat_lon(da, dropna=dropna, **kwargs)
+    result = mxu.grid.stack_lat_lon(da, dropna=dropna, **kwargs)
 
     xr.testing.assert_identical(result, expected)
 
@@ -162,8 +162,8 @@ def test_unstructured_roundtrip_dropna_row(coords):
     da_structured[:, :, 0] = np.NaN
     expected = da_structured
 
-    da_unstructured = mxu.stack_lat_lon(da_structured, **kwargs)
-    result = mxu.unstack_lat_lon_and_align(da_unstructured, coords_orig, **kwargs)
+    da_unstructured = mxu.grid.stack_lat_lon(da_structured, **kwargs)
+    result = mxu.grid.unstack_lat_lon_and_align(da_unstructured, coords_orig, **kwargs)
 
     # roundtripping adds x & y coords - not sure if there is something to be done about
     if coords == "2D":
@@ -178,7 +178,7 @@ def test_from_unstructured_defaults(as_dataset):
 
     coords_orig = expected.coords.to_dataset()[["lon", "lat"]]
 
-    result = mxu.unstack_lat_lon_and_align(da, coords_orig)
+    result = mxu.grid.unstack_lat_lon_and_align(da, coords_orig)
 
     xr.testing.assert_identical(result, expected)
 
@@ -193,7 +193,7 @@ def test_from_unstructured(x_dim, y_dim, stack_dim, as_dataset):
     )
 
     coords_orig = expected.coords.to_dataset()[[x_dim, y_dim]]
-    result = mxu.unstack_lat_lon_and_align(
+    result = mxu.grid.unstack_lat_lon_and_align(
         da, coords_orig, x_dim=x_dim, y_dim=y_dim, stack_dim=stack_dim
     )
 
@@ -207,13 +207,13 @@ def test_unstructured_roundtrip_1D_coords(as_dataset):
 
     coords_orig = da_structured.coords.to_dataset()[["lon", "lat"]]
 
-    result = mxu.unstack_lat_lon_and_align(
-        mxu.stack_lat_lon(da_structured), coords_orig
+    result = mxu.grid.unstack_lat_lon_and_align(
+        mxu.grid.stack_lat_lon(da_structured), coords_orig
     )
     xr.testing.assert_identical(result, da_structured)
 
-    result = mxu.stack_lat_lon(
-        mxu.unstack_lat_lon_and_align(da_unstructured, coords_orig)
+    result = mxu.grid.stack_lat_lon(
+        mxu.grid.unstack_lat_lon_and_align(da_unstructured, coords_orig)
     )
     xr.testing.assert_identical(result, da_unstructured)
 
@@ -228,7 +228,7 @@ def test_unstructured_roundtrip_2D_coords(as_dataset):
     coords_orig = da_structured.coords.to_dataset()[["x", "y"]]
     print(coords_orig)
 
-    result = mxu.stack_lat_lon(
-        mxu.unstack_lat_lon_and_align(da_unstructured, coords_orig, **dims), **dims
+    result = mxu.grid.stack_lat_lon(
+        mxu.grid.unstack_lat_lon_and_align(da_unstructured, coords_orig, **dims), **dims
     )
     xr.testing.assert_identical(result, da_unstructured)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #117, closes #105
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

---

This is the first of several of PRs which will add helper functions to deal with `Dataset` and `DataArray` objects. This first one deals with converting arrays from regular grids to unstructured grids (i.e. flattening the `lon` and `lat` dimension). What will follow are PRs on masking (land & antarctica), calculating the global mean, and potentially, stacking ensembles, and calculating anomalies.

I do have a number of questions - most of them concerning naming.

---

1. General question: The functions are currently in `mesmer.xarray_utils`. I imagined this as follows:

   ```python
   import mesmer.xarray_utils as mxu

   ds = mxu.to_unstructured(ds)
   ```

   Does this sound good? I had a number of other ideas but start to prefer this name - as the functionality is xarray-specific. However, I am open to suggestions.

   Other ideas I had:
   
   ```python
   mesmer.data_utils
   mesmer.preproc
   mesmer.process
   mesmer.tools
   mesmer.utils
   mesmer.xarray_utils
   ```

2. I now went with `cell_dim="cell"` - objections? See discussion in #105.

2. Should the function be (quasi-)top-level (1) or not (2)?

   ```python
   import mesmer.xarray_utils as mxu

   ds = mxu.to_unstructured(ds) # (1)
   ds = mxu.grid.to_unstructured(ds) # (2)
   ```

3. What about the name `unstructured`? I think it comes from models that have a truly unstructured grid (e.g. ICON), and their spatial data has to be 1D. Thus, the name may not be entirely correct in this [context](https://en.wikipedia.org/wiki/Types_of_mesh#Classification_of_grids) as in most cases we will be flattening a regular grid. So what is a better name? (I mean I am happy to keep the current name if people understand what it means.)

4. There is a difficulty with round-tripping because we remove `cells` that are `NaN`. We need the original coordinates to restore the original coordinates. I decided that the user will be responsible to supplying them. Other solutions did not convince me (#117). This may look like:

   ```python
   import mesmer.xarray_utils as mxu

   ds = mxu.grid.to_unstructured(ds) 
   coords_orig = ds.coords.to_dataset()[["lon", "lat"]]

   ds = mxu.grid.from_unstructured(ds, coords_orig) # (2)
   ```










This is a draft - I plan to tag some people later.







