### PR TITLE
mask_3D_frac_approx: fix passing named cooords

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,9 +53,9 @@ Deprecations
 Bug fixes
 ^^^^^^^^^
 
-- Fix two issues with :py:func:`utils.regionmaskcompat.mask_3D_frac_approx`. Note that these
-  issues are only relevant if passing xarray objects or masks close to the poles
-  (`#202 <https://github.com/MESMER-group/mesmer/pull/202>`_).
+- Fix three issues with :py:func:`utils.regionmaskcompat.mask_3D_frac_approx`. Note that these
+  issues are only relevant if passing xarray objects and/ or masks close to the poles
+  (`#202 <https://github.com/MESMER-group/mesmer/pull/202>`_ and `#218 <https://github.com/MESMER-group/mesmer/pull/218>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
 
 Documentation

--- a/tests/unit/test_regionmaskcompat.py
+++ b/tests/unit/test_regionmaskcompat.py
@@ -4,7 +4,11 @@ import regionmask
 import shapely.geometry
 import xarray as xr
 
-from mesmer.utils.regionmaskcompat import mask_3D_frac_approx, sample_coord
+from mesmer.utils.regionmaskcompat import (
+    InvalidCoordsError,
+    mask_3D_frac_approx,
+    sample_coord,
+)
 
 
 def test_sample_coord():
@@ -28,7 +32,7 @@ def test_mask_percentage_wrong_coords(dim, invalid_coords):
     latlon[dim] = invalid_coords
 
     with pytest.raises(
-        ValueError, match="'lon' and 'lat' must be 1D and equally spaced."
+        InvalidCoordsError, match="'lon' and 'lat' must be 1D and equally spaced."
     ):
         mask_3D_frac_approx(None, **latlon)
 
@@ -39,7 +43,7 @@ def test_mask_percentage_lon_beyond_90(lat):
     lat = np.arange(*lat)
     lon = np.arange(0, 360, 10)
 
-    with pytest.raises(ValueError, match=r"lat must be between \-90 and \+90"):
+    with pytest.raises(InvalidCoordsError, match=r"lat must be between \-90 and \+90"):
         mask_3D_frac_approx(None, lon, lat)
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

Another fix to `mesmer.utils.regionmaskcompat.mask_3D_frac_approx`: passing lat & lon coords _not named_ `"lat"` or `"lon"` now works correctly. The `InvalidCoordsError` change is unrelated but oh well.

Someone tell me to add this functionality to regionmask already...!

