### PR TITLE
xarray_utils: mask ocean and Antarctica

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,10 @@ New Features
 - Refactor the LOWESS smoothing for xarray objects: :py:func:`mesmer.stats.smoothing.lowess`.
   (`#193 <https://github.com/MESMER-group/mesmer/pull/193>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Added functions to mask the ocean and Antarctica for xarray objects (`#219
+  <https://github.com/MESMER-group/mesmer/pull/219>`_). By `Mathias Hauser
+  <https://github.com/mathause>`_.
+
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,8 +42,8 @@ Data manipulation
 .. autosummary::
    :toctree: generated/
 
-   ~xarray_utils.mask_land_fraction
-   ~xarray_utils.mask_land
+   ~xarray_utils.mask_ocean_fraction
+   ~xarray_utils.mask_ocean
    ~xarray_utils.mask_antarctica
 
 Train mesmer

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -36,6 +36,16 @@ Computation
    ~core.computation.calc_geodist_exact
    ~core.computation.gaspari_cohn
 
+Data manipulation
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   ~xarray_utils.mask_land_fraction
+   ~xarray_utils.mask_land
+   ~xarray_utils.mask_antarctica
+
 Train mesmer
 ------------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,14 +46,11 @@ Data manipulation
    ~xarray_utils.grid.unstack_lat_lon_and_align
    ~xarray_utils.grid.unstack_lat_lon
    ~xarray_utils.grid.align_to_coords
-<<<<<<< HEAD
    ~xarray_utils.mask.mask_ocean_fraction
    ~xarray_utils.mask.mask_ocean
    ~xarray_utils.mask.mask_antarctica
-=======
    ~xarray_utils.global_mean.lat_weights
    ~xarray_utils.global_mean.weighted_mean
->>>>>>> main
 
 Train mesmer
 ------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,9 +46,9 @@ Data manipulation
    ~xarray_utils.grid.unstack_lat_lon_and_align
    ~xarray_utils.grid.unstack_lat_lon
    ~xarray_utils.grid.align_to_coords
-   ~xarray_utils.mask_ocean_fraction
-   ~xarray_utils.mask_ocean
-   ~xarray_utils.mask_antarctica
+   ~xarray_utils.mask.mask_ocean_fraction
+   ~xarray_utils.mask.mask_ocean
+   ~xarray_utils.mask.mask_antarctica
 
 Train mesmer
 ------------

--- a/mesmer/xarray_utils/__init__.py
+++ b/mesmer/xarray_utils/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+
+from mesmer.xarray_utils.mask import mask_antarctica, mask_land, mask_land_fraction

--- a/mesmer/xarray_utils/__init__.py
+++ b/mesmer/xarray_utils/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-from mesmer.xarray_utils.mask import mask_antarctica, mask_ocean, mask_ocean_fraction
+from mesmer.xarray_utils import mask

--- a/mesmer/xarray_utils/__init__.py
+++ b/mesmer/xarray_utils/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-from mesmer.xarray_utils.mask import mask_antarctica, mask_land, mask_land_fraction
+from mesmer.xarray_utils.mask import mask_antarctica, mask_ocean, mask_ocean_fraction

--- a/mesmer/xarray_utils/mask.py
+++ b/mesmer/xarray_utils/mask.py
@@ -21,7 +21,7 @@ def _where_if_dim(obj, cond, dims):
     return obj.where(cond)
 
 
-def mask_land_fraction(obj, threshold, *, x_coords="lon", y_coords="lat"):
+def mask_ocean_fraction(obj, threshold, *, x_coords="lon", y_coords="lat"):
     """mask out ocean using fractional overlap
 
     Parameters
@@ -74,7 +74,7 @@ def mask_land_fraction(obj, threshold, *, x_coords="lon", y_coords="lat"):
     return _where_if_dim(obj, mask_bool, [y_coords, x_coords])
 
 
-def mask_land(obj, *, x_coords="lon", y_coords="lat"):
+def mask_ocean(obj, *, x_coords="lon", y_coords="lat"):
     """mask out ocean
 
     Parameters

--- a/mesmer/xarray_utils/mask.py
+++ b/mesmer/xarray_utils/mask.py
@@ -21,12 +21,12 @@ def _where_if_dim(obj, cond, dims):
     return obj.where(cond)
 
 
-def mask_ocean_fraction(obj, threshold, *, x_coords="lon", y_coords="lat"):
+def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
     """mask out ocean using fractional overlap
 
     Parameters
     ----------
-    obj : xr.Dataset | xr.DataArray
+    data : xr.Dataset | xr.DataArray
         Array to mask.
     threshold : float
         Threshold above which land fraction to consider a grid point as a land grid
@@ -38,7 +38,7 @@ def mask_ocean_fraction(obj, threshold, *, x_coords="lon", y_coords="lat"):
 
     Returns
     -------
-    obj : xr.Dataset | xr.DataArray
+    data : xr.Dataset | xr.DataArray
         Array with ocean grid points masked out.
 
     Notes
@@ -57,11 +57,11 @@ def mask_ocean_fraction(obj, threshold, *, x_coords="lon", y_coords="lat"):
 
     try:
         mask_fraction = mesmer.utils.regionmaskcompat.mask_3D_frac_approx(
-            land_110, obj[x_coords], obj[y_coords]
+            land_110, data[x_coords], data[y_coords]
         )
     except mesmer.utils.regionmaskcompat.InvalidCoordsError as e:
         raise ValueError(
-            "Cannot calculate fractional mask for irregularly-spaced coords - please "
+            "Cannot calculate fractional mask for irregularly-spaced coords - use "
             "``mask_land`` instead."
         ) from e
 
@@ -71,15 +71,15 @@ def mask_ocean_fraction(obj, threshold, *, x_coords="lon", y_coords="lat"):
     mask_bool = mask_fraction > threshold
 
     # only mask data_vars that have the coords
-    return _where_if_dim(obj, mask_bool, [y_coords, x_coords])
+    return _where_if_dim(data, mask_bool, [y_coords, x_coords])
 
 
-def mask_ocean(obj, *, x_coords="lon", y_coords="lat"):
+def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
     """mask out ocean
 
     Parameters
     ----------
-    obj : xr.Dataset | xr.DataArray
+    data : xr.Dataset | xr.DataArray
         Array to mask.
     x_coords : str, default: "lon"
         Name of the x-coordinates.
@@ -88,7 +88,7 @@ def mask_ocean(obj, *, x_coords="lon", y_coords="lat"):
 
     Returns
     -------
-    obj : xr.Dataset | xr.DataArray
+    data : xr.Dataset | xr.DataArray
         Array with ocean grid points masked out.
 
     Notes
@@ -99,27 +99,27 @@ def mask_ocean(obj, *, x_coords="lon", y_coords="lat"):
     # TODO: allow other masks?
     land_110 = regionmask.defined_regions.natural_earth_v5_0_0.land_110
 
-    mask_bool = land_110.mask_3D(obj[x_coords], obj[y_coords])
+    mask_bool = land_110.mask_3D(data[x_coords], data[y_coords])
 
     mask_bool = mask_bool.squeeze(drop=True)
 
     # only mask data_vars that have the coords
-    return _where_if_dim(obj, mask_bool, [y_coords, x_coords])
+    return _where_if_dim(data, mask_bool, [y_coords, x_coords])
 
 
-def mask_antarctica(obj, *, y_coords="lat"):
+def mask_antarctica(data, *, y_coords="lat"):
     """mask out ocean
 
     Parameters
     ----------
-    obj : xr.Dataset | xr.DataArray
+    data : xr.Dataset | xr.DataArray
         Array to mask.
     y_coords : str, default: "lat"
         Name of the y-coordinates.
 
     Returns
     -------
-    obj : xr.Dataset | xr.DataArray
+    data : xr.Dataset | xr.DataArray
         Array with Antarctic grid points masked out.
 
     Notes
@@ -127,7 +127,7 @@ def mask_antarctica(obj, *, y_coords="lat"):
     - Masks grid points below 60°S.
     """
 
-    mask_bool = obj[y_coords] >= -60
+    mask_bool = data[y_coords] >= -60
 
-    # only mask if obj has y_coords
-    return _where_if_dim(obj, mask_bool, [y_coords])
+    # only mask if data has y_coords
+    return _where_if_dim(data, mask_bool, [y_coords])

--- a/mesmer/xarray_utils/mask.py
+++ b/mesmer/xarray_utils/mask.py
@@ -94,6 +94,8 @@ def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
     Notes
     -----
     - Uses the 1:110m land mask from Natural Earth (http://www.naturalearthdata.com).
+    - Whether a grid cell is in the ocean or on land is based on its center. For
+      regularly spaced coordinates use :py:func:`mesmer.xarray_utils.mask_land_fraction`.
     """
 
     # TODO: allow other masks?

--- a/mesmer/xarray_utils/mask.py
+++ b/mesmer/xarray_utils/mask.py
@@ -1,0 +1,133 @@
+import numpy as np
+import regionmask
+import xarray as xr
+
+import mesmer.utils
+
+
+def _where_if_dim(obj, cond, dims):
+
+    # xarray applies where to all data_vars - even if they do not have the corresponding
+    # dimensions - we don't want that https://github.com/pydata/xarray/issues/7027
+
+    def _where(da):
+        if all(dim in da.dims for dim in dims):
+            return da.where(cond)
+        return da
+
+    if isinstance(obj, xr.Dataset):
+        return obj.map(_where, keep_attrs=True)
+
+    return obj.where(cond)
+
+
+def mask_land_fraction(obj, threshold, *, x_coords="lon", y_coords="lat"):
+    """mask out ocean using fractional overlap
+
+    Parameters
+    ----------
+    obj : xr.Dataset | xr.DataArray
+        Array to mask.
+    threshold : float
+        Threshold above which land fraction to consider a grid point as a land grid
+        point. Must be must be between 0 and 1 inclusive.
+    x_coords : str, default: "lon"
+        Name of the x-coordinates.
+    y_coords : str, default: "lat"
+        Name of the y-coordinates.
+
+    Returns
+    -------
+    obj : xr.Dataset | xr.DataArray
+        Array with ocean grid points masked out.
+
+    Notes
+    -----
+    - Uses the 1:110m land mask from Natural Earth (http://www.naturalearthdata.com).
+    - The fractional overlap of individual grid points and the land mask can only be
+      computed for regularly-spaced 1D x- and y-coordinates. For irregularly spaced
+      coordinates use :py:func:`mesmer.xarray_utils.mask_land`.
+    """
+
+    if np.ndim(threshold) != 0 or (threshold < 0) or (threshold > 1):
+        raise ValueError("`threshold` must be a scalar between 0 and 1 (inclusive).")
+
+    # TODO: allow other masks?
+    land_110 = regionmask.defined_regions.natural_earth_v5_0_0.land_110
+
+    try:
+        mask_fraction = mesmer.utils.regionmaskcompat.mask_3D_frac_approx(
+            land_110, obj[x_coords], obj[y_coords]
+        )
+    except mesmer.utils.regionmaskcompat.InvalidCoordsError as e:
+        raise ValueError(
+            "Cannot calculate fractional mask for irregularly-spaced coords - please "
+            "``mask_land`` instead."
+        ) from e
+
+    # drop region-specific coords
+    mask_fraction = mask_fraction.squeeze(drop=True)
+
+    mask_bool = mask_fraction > threshold
+
+    # only mask data_vars that have the coords
+    return _where_if_dim(obj, mask_bool, [y_coords, x_coords])
+
+
+def mask_land(obj, *, x_coords="lon", y_coords="lat"):
+    """mask out ocean
+
+    Parameters
+    ----------
+    obj : xr.Dataset | xr.DataArray
+        Array to mask.
+    x_coords : str, default: "lon"
+        Name of the x-coordinates.
+    y_coords : str, default: "lat"
+        Name of the y-coordinates.
+
+    Returns
+    -------
+    obj : xr.Dataset | xr.DataArray
+        Array with ocean grid points masked out.
+
+    Notes
+    -----
+    - Uses the 1:110m land mask from Natural Earth (http://www.naturalearthdata.com).
+    """
+
+    # TODO: allow other masks?
+    land_110 = regionmask.defined_regions.natural_earth_v5_0_0.land_110
+
+    mask_bool = land_110.mask_3D(obj[x_coords], obj[y_coords])
+
+    mask_bool = mask_bool.squeeze(drop=True)
+
+    # only mask data_vars that have the coords
+    return _where_if_dim(obj, mask_bool, [y_coords, x_coords])
+
+
+def mask_antarctica(obj, *, y_coords="lat"):
+    """mask out ocean
+
+    Parameters
+    ----------
+    obj : xr.Dataset | xr.DataArray
+        Array to mask.
+    y_coords : str, default: "lat"
+        Name of the y-coordinates.
+
+    Returns
+    -------
+    obj : xr.Dataset | xr.DataArray
+        Array with Antarctic grid points masked out.
+
+    Notes
+    -----
+    - Masks grid points below 60°S.
+    """
+
+    mask_bool = obj[y_coords] >= -60
+
+    # only mask if obj has y_coords
+    return _where_if_dim(obj, mask_bool, [y_coords])

--- a/tests/unit/test_mask.py
+++ b/tests/unit/test_mask.py
@@ -34,7 +34,7 @@ def test_ocean_land_fraction_errors(threshold):
     with pytest.raises(
         ValueError, match="`threshold` must be a scalar between 0 and 1"
     ):
-        mxu.mask_ocean_fraction(data, threshold=threshold)
+        mxu.mask.mask_ocean_fraction(data, threshold=threshold)
 
 
 def test_ocean_land_fraction_irregular():
@@ -48,15 +48,15 @@ def test_ocean_land_fraction_irregular():
         ValueError,
         match="Cannot calculate fractional mask for irregularly-spaced coords",
     ):
-        mxu.mask_ocean_fraction(data, threshold=0.5)
+        mxu.mask.mask_ocean_fraction(data, threshold=0.5)
 
 
 def test_ocean_land_fraction_threshold():
     # check that the threshold has an influence
     data = data_lon_lat(as_dataset=True)
 
-    result_033 = mxu.mask_ocean_fraction(data, threshold=0.33)
-    result_066 = mxu.mask_ocean_fraction(data, threshold=0.66)
+    result_033 = mxu.mask.mask_ocean_fraction(data, threshold=0.33)
+    result_066 = mxu.mask.mask_ocean_fraction(data, threshold=0.66)
 
     assert not (result_033.data == result_066.data).all()
 
@@ -87,7 +87,7 @@ def _test_mask(func, as_dataset, threshold=None, **kwargs):
 @pytest.mark.parametrize("as_dataset", (True, False))
 def test_ocean_land_fraction_default(as_dataset):
 
-    _test_mask(mxu.mask_ocean_fraction, as_dataset, threshold=0.5)
+    _test_mask(mxu.mask.mask_ocean_fraction, as_dataset, threshold=0.5)
 
 
 @pytest.mark.parametrize("as_dataset", (True, False))
@@ -96,7 +96,7 @@ def test_ocean_land_fraction_default(as_dataset):
 def test_ocean_land_fraction(as_dataset, x_coords, y_coords):
 
     _test_mask(
-        mxu.mask_ocean_fraction,
+        mxu.mask.mask_ocean_fraction,
         as_dataset,
         threshold=0.5,
         x_coords=x_coords,
@@ -109,7 +109,7 @@ def test_ocean_land_default(
     as_dataset,
 ):
 
-    _test_mask(mxu.mask_ocean, as_dataset)
+    _test_mask(mxu.mask.mask_ocean, as_dataset)
 
 
 @pytest.mark.parametrize("as_dataset", (True, False))
@@ -117,7 +117,7 @@ def test_ocean_land_default(
 @pytest.mark.parametrize("y_coords", ("y", "lat"))
 def test_mask_land(as_dataset, x_coords, y_coords):
 
-    _test_mask(mxu.mask_ocean, as_dataset, x_coords=x_coords, y_coords=y_coords)
+    _test_mask(mxu.mask.mask_ocean, as_dataset, x_coords=x_coords, y_coords=y_coords)
 
 
 @pytest.mark.parametrize("as_dataset", (True, False))
@@ -125,11 +125,11 @@ def test_mask_antarctiva_default(
     as_dataset,
 ):
 
-    _test_mask(mxu.mask_antarctica, as_dataset)
+    _test_mask(mxu.mask.mask_antarctica, as_dataset)
 
 
 @pytest.mark.parametrize("as_dataset", (True, False))
 @pytest.mark.parametrize("y_coords", ("y", "lat"))
 def test_mask_antarctiva(as_dataset, y_coords):
 
-    _test_mask(mxu.mask_antarctica, as_dataset, y_coords=y_coords)
+    _test_mask(mxu.mask.mask_antarctica, as_dataset, y_coords=y_coords)

--- a/tests/unit/test_mask.py
+++ b/tests/unit/test_mask.py
@@ -32,7 +32,7 @@ def test_mask_land_fraction_errors(threshold):
     with pytest.raises(
         ValueError, match="`threshold` must be a scalar between 0 and 1"
     ):
-        mxu.mask_land_fraction(data, threshold=threshold)
+        mxu.mask_ocean_fraction(data, threshold=threshold)
 
 
 def test_mask_land_fraction_irregular():
@@ -46,15 +46,15 @@ def test_mask_land_fraction_irregular():
         ValueError,
         match="Cannot calculate fractional mask for irregularly-spaced coords",
     ):
-        mxu.mask_land_fraction(data, threshold=0.5)
+        mxu.mask_ocean_fraction(data, threshold=0.5)
 
 
 def test_mask_land_fraction_threshold():
     # check that the threshold has an influence
     data = data_lon_lat()
 
-    result_033 = mxu.mask_land_fraction(data, threshold=0.33)
-    result_066 = mxu.mask_land_fraction(data, threshold=0.66)
+    result_033 = mxu.mask_ocean_fraction(data, threshold=0.33)
+    result_066 = mxu.mask_ocean_fraction(data, threshold=0.66)
 
     assert not (result_033.data == result_066.data).all()
 
@@ -82,7 +82,7 @@ def _test_mask(func, threshold=None, **kwargs):
 
 def test_mask_land_fraction_default():
 
-    _test_mask(mxu.mask_land_fraction, threshold=0.5)
+    _test_mask(mxu.mask_ocean_fraction, threshold=0.5)
 
 
 @pytest.mark.parametrize("x_coords", ("x", "lon"))
@@ -90,20 +90,20 @@ def test_mask_land_fraction_default():
 def test_mask_land_fraction(x_coords, y_coords):
 
     _test_mask(
-        mxu.mask_land_fraction, threshold=0.5, x_coords=x_coords, y_coords=y_coords
+        mxu.mask_ocean_fraction, threshold=0.5, x_coords=x_coords, y_coords=y_coords
     )
 
 
 def test_mask_land_default():
 
-    _test_mask(mxu.mask_land)
+    _test_mask(mxu.mask_ocean)
 
 
 @pytest.mark.parametrize("x_coords", ("x", "lon"))
 @pytest.mark.parametrize("y_coords", ("y", "lat"))
 def test_mask_land(x_coords, y_coords):
 
-    _test_mask(mxu.mask_land, x_coords=x_coords, y_coords=y_coords)
+    _test_mask(mxu.mask_ocean, x_coords=x_coords, y_coords=y_coords)
 
 
 def test_mask_antarctiva_default():

--- a/tests/unit/test_mask.py
+++ b/tests/unit/test_mask.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+import mesmer.xarray_utils as mxu
+
+
+def data_lon_lat(x_coords="lon", y_coords="lat"):
+
+    lon = np.arange(0.5, 360, 2)
+    lat = np.arange(90, -91, -2)
+
+    data = np.random.randn(*lat.shape, *lon.shape)
+
+    da = xr.DataArray(
+        data,
+        dims=(y_coords, x_coords),
+        coords={x_coords: lon, y_coords: lat},
+        attrs={"key": "da_attrs"},
+    )
+
+    ds = xr.Dataset(data_vars={"data": da, "scalar": 1}, attrs={"key": "ds_attrs"})
+
+    return ds
+
+
+@pytest.mark.parametrize("threshold", ([0, 1], -0.1, 1.1))
+def test_mask_land_fraction_errors(threshold):
+
+    data = data_lon_lat()
+
+    with pytest.raises(
+        ValueError, match="`threshold` must be a scalar between 0 and 1"
+    ):
+        mxu.mask_land_fraction(data, threshold=threshold)
+
+
+def test_mask_land_fraction_irregular():
+
+    lon = [0, 1, 3]
+    lat = [0, 1, 3]
+
+    data = xr.Dataset(coords={"lon": lon, "lat": lat})
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot calculate fractional mask for irregularly-spaced coords",
+    ):
+        mxu.mask_land_fraction(data, threshold=0.5)
+
+
+def test_mask_land_fraction_threshold():
+    # check that the threshold has an influence
+    data = data_lon_lat()
+
+    result_033 = mxu.mask_land_fraction(data, threshold=0.33)
+    result_066 = mxu.mask_land_fraction(data, threshold=0.66)
+
+    assert not (result_033.data == result_066.data).all()
+
+
+def _test_mask(func, threshold=None, **kwargs):
+    # not checking the actual mask
+
+    data = data_lon_lat(**kwargs)
+
+    kwargs = kwargs if threshold is None else {"threshold": threshold, **kwargs}
+    result = func(data, **kwargs)
+
+    # ensure scalar is not broadcast
+    assert result.scalar.ndim == 0
+
+    # ensure no nan in data
+    assert result.data.notnull().all()
+
+    # ensure mask is applied
+    assert result.data.isnull().any()
+
+    assert result.attrs == {"key": "ds_attrs"}
+    assert result.data.attrs == {"key": "da_attrs"}
+
+
+def test_mask_land_fraction_default():
+
+    _test_mask(mxu.mask_land_fraction, threshold=0.5)
+
+
+@pytest.mark.parametrize("x_coords", ("x", "lon"))
+@pytest.mark.parametrize("y_coords", ("y", "lat"))
+def test_mask_land_fraction(x_coords, y_coords):
+
+    _test_mask(
+        mxu.mask_land_fraction, threshold=0.5, x_coords=x_coords, y_coords=y_coords
+    )
+
+
+def test_mask_land_default():
+
+    _test_mask(mxu.mask_land)
+
+
+@pytest.mark.parametrize("x_coords", ("x", "lon"))
+@pytest.mark.parametrize("y_coords", ("y", "lat"))
+def test_mask_land(x_coords, y_coords):
+
+    _test_mask(mxu.mask_land, x_coords=x_coords, y_coords=y_coords)
+
+
+def test_mask_antarctiva_default():
+
+    _test_mask(mxu.mask_antarctica)
+
+
+@pytest.mark.parametrize("y_coords", ("y", "lat"))
+def test_mask_antarctiva(y_coords):
+
+    _test_mask(mxu.mask_antarctica, y_coords=y_coords)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

The second one in the series of data manipulation PRs (after #217). This adds functions to mask out the ocean and Antarctica. I think this is quite a bit easier than #217.

The naming of `x_dim` vs. `x_coords` is intentional (compare in #217). For most cases this will not play a role and the two will be the same. However, for regional simulations with a rotated grid it will make a difference. I should probably do a terminology section as for [xarray](https://docs.xarray.dev/en/stable/user-guide/terminology.html).




