### PR TITLE
deprecate reg_type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -81,6 +81,11 @@ Breaking changes
   from the `lat` and `lon` dictionaries i.e., ``lon["e"]`` and ``lat["e"]``
   (`#233 <https://github.com/MESMER-group/mesmer/pull/233>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Deprecated the ``reg_type`` argument to :py:func:`mesmer.io.load_constant_files.load_regs_ls_wgt_lon_lat`
+  and the ``reg_dict`` argument to :py:func:`mesmer.utils.select.extract_land`. These arguments
+  no longer have any affect (`#235 <https://github.com/MESMER-group/mesmer/pull/235>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
+
 
 Deprecations
 ^^^^^^^^^^^^

--- a/configs/config_across_scen_T_cmip6ng_test.py
+++ b/configs/config_across_scen_T_cmip6ng_test.py
@@ -43,8 +43,6 @@ esms = ["IPSL-CM6A-LR"]
 # emulated variables
 targs = ["tas"]
 
-reg_type = "srex"
-
 # reference period
 ref = {}
 

--- a/examples/train_create_emus_automated.py
+++ b/examples/train_create_emus_automated.py
@@ -65,12 +65,10 @@ for esm in esms:
     GSAT[esm] = convert_dict_to_arr(GSAT_dict[esm])
 
 # load in the constant files
-reg_dict, ls, wgt_g, lon, lat = load_regs_ls_wgt_lon_lat(cfg.reg_type, lon, lat)
+ls, wgt_g, lon, lat = load_regs_ls_wgt_lon_lat(lon=lon, lat=lat)
 
 # extract land
-tas, reg_dict, ls = extract_land(
-    tas_g, reg_dict, wgt_g, ls, threshold_land=cfg.threshold_land
-)
+tas, ls = extract_land(tas_g, wgt=wgt_g, ls=ls, threshold_land=cfg.threshold_land)
 
 print()
 

--- a/mesmer/calibrate_mesmer/calibrate_mesmer.py
+++ b/mesmer/calibrate_mesmer/calibrate_mesmer.py
@@ -190,13 +190,14 @@ def _calibrate_and_draw_realisations(
         GSAT[esm] = convert_dict_to_arr(GSAT_dict[esm])
         GHFDS[esm] = convert_dict_to_arr(GHFDS_dict[esm])
 
+    if reg_type is not None:
+        warnings.warn("Passing ``reg_type`` no longer has any effect.", FutureWarning)
+
     # load in the constant files
-    reg_dict, ls, wgt_g, lon, lat = load_regs_ls_wgt_lon_lat(reg_type, lon, lat)
+    ls, wgt_g, lon, lat = load_regs_ls_wgt_lon_lat(lon=lon, lat=lat)
 
     # extract land
-    tas, reg_dict, ls = extract_land(
-        tas_g, reg_dict, wgt_g, ls, threshold_land=threshold_land
-    )
+    tas, ls = extract_land(tas_g, wgt=wgt_g, ls=ls, threshold_land=threshold_land)
 
     for esm in esms:
         LOGGER.info("Calibrating %s", esm)

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -141,7 +141,7 @@ def load_regs_ls_wgt_lon_lat(reg_type=None, lon=None, lat=None):
     ----------
     reg_type : str, optional, default: None
         Deprecated. No longer has an effect, if None is passed this
-        function will only returns four parameters.
+        function will only return four parameters.
 
     lon : dict
         longitude dictionary with key
@@ -187,7 +187,7 @@ def load_regs_ls_wgt_lon_lat(reg_type=None, lon=None, lat=None):
     if reg_type is not None:
         warnings.warn(
             "``reg_type`` no longer has any effect. When passing `None` this "
-            "function will only returns four parameters.",
+            "function will only return four parameters.",
             FutureWarning,
         )
 

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -9,6 +9,7 @@ weights, longitude and latitude information.
 
 import copy
 import os
+import warnings
 
 import joblib
 import numpy as np
@@ -133,13 +134,14 @@ def load_phi_gc(lon, lat, ls, cfg, L_start=1500, L_end=10000, L_interval=250):
     return phi_gc
 
 
-def load_regs_ls_wgt_lon_lat(reg_type, lon, lat):
+def load_regs_ls_wgt_lon_lat(reg_type=None, lon=None, lat=None):
     """Load constant files.
 
     Parameters
     ----------
-    reg_type : str
-        region type ("ar6.land", "countries", "srex")
+    reg_type : str, optional, default: None
+        Deprecated. No longer has an effect, if None is passed this
+        function will only returns four parameters.
 
     lon : dict
         longitude dictionary with key
@@ -154,15 +156,9 @@ def load_regs_ls_wgt_lon_lat(reg_type, lon, lat):
     Returns
     -------
     reg_dict : dict
-        region dictionary with keys
+        Optional output (empty dict). Only returned when the input ``reg_type`` is not
+        ``None``.
 
-        - ["type"] (region type)
-        - ["abbrevs"] (abbreviations for regions)
-        - ["names"] (full names of regions)
-        - ["grids"] (3d array (region, lat, lon) of subsampled region fraction)
-        - ["grid_b"] (2d array (lat, lon) of regions with each grid point being assigned
-          to a single region ("binary" grid))
-        - ["full"] (full Region object (for plotting region outlines))
     ls : dict
         land-sea dictionary with keys
 
@@ -188,28 +184,12 @@ def load_regs_ls_wgt_lon_lat(reg_type, lon, lat):
 
     """
 
-    # choose the Regions object depending on the region type
-    if reg_type == "countries":
-        if Version(regionmask.__version__) >= Version("0.9.0"):
-            reg = regionmask.defined_regions.natural_earth_v5_0_0.countries_110
-        else:
-            reg = regionmask.defined_regions.natural_earth.countries_110
-    elif reg_type == "srex":
-        reg = regionmask.defined_regions.srex
-    elif reg_type == "ar6.land":
-        reg = regionmask.defined_regions.ar6.land
-
-    # extract all the desired information from the Regions object
-    reg_dict = {}
-    reg_dict["type"] = reg_type
-    reg_dict["abbrevs"] = reg.abbrevs
-    reg_dict["names"] = reg.names
-    # have fraction of grid cells
-    reg_dict["grids"] = mask_3D_frac_approx(reg, lon["c"], lat["c"]).values
-    # not sure if needed: "binary" grid with each grid point assigned to single country
-    reg_dict["grid_b"] = reg.mask(lon["c"], lat["c"]).values
-    # to be used for plotting outlines (mainly useful for srex regs)
-    reg_dict["full"] = reg
+    if reg_type is not None:
+        warnings.warn(
+            "``reg_type`` no longer has any effect. When passing `None` this "
+            "function will only returns four parameters.",
+            FutureWarning,
+        )
 
     # obtain a (subsampled) land-sea mask
     ls = {}
@@ -225,7 +205,7 @@ def load_regs_ls_wgt_lon_lat(reg_type, lon, lat):
     )
 
     # remove Antarctica
-    idx_ANT = np.where(lat["c"] < -60)[0]
+    idx_ANT = lat["c"] < -60
     ls["grid_no_ANT"] = copy.deepcopy(ls["grid_raw"])
     ls["grid_no_ANT"][idx_ANT] = 0
 
@@ -233,4 +213,7 @@ def load_regs_ls_wgt_lon_lat(reg_type, lon, lat):
     lon["grid"], lat["grid"] = np.meshgrid(lon["c"], lat["c"])
     wgt = np.cos(np.deg2rad(lat["grid"]))
 
-    return reg_dict, ls, wgt, lon, lat
+    if reg_type is None:
+        return ls, wgt, lon, lat
+
+    return {}, ls, wgt, lon, lat

--- a/mesmer/utils/select.py
+++ b/mesmer/utils/select.py
@@ -70,7 +70,7 @@ def extract_land(var, reg_dict=None, wgt=None, ls=None, threshold_land=0.25):
     if reg_dict is not None:
         warnings.warn(
             "Passing `reg_dict` no longer has an effect. When passing `None` this "
-            "function will only returns two parameters.",
+            "function will only return two parameters.",
             FutureWarning,
         )
 

--- a/mesmer/utils/select.py
+++ b/mesmer/utils/select.py
@@ -8,11 +8,12 @@ Functions to extract regions or time period of interest.
 
 
 import copy as copy
+import warnings
 
 import numpy as np
 
 
-def extract_land(var, reg_dict, wgt, ls, threshold_land=0.25):
+def extract_land(var, reg_dict=None, wgt=None, ls=None, threshold_land=0.25):
     """
     Extract all land grid points and area weights in regions and in land-sea mask for
     given threshold.
@@ -24,16 +25,9 @@ def extract_land(var, reg_dict, wgt, ls, threshold_land=0.25):
 
         - [esm][scen] (4d array (run, time, lat, lon) of variable)
 
-    reg_dict : dict
-        region dictionary with keys
-
-        - ["type"] (region type)
-        - ["abbrevs"] (abbreviations for regions)
-        - ["names"] (full names of regions)
-        - ["grids"] (3d array (regions, lat, lon) of subsampled region fraction)
-        - ["grid_b"] (2d array (lat, lon) of regions with each grid point being assigned
-          to a single region ("binary" grid))
-        - ["full"] (full Region object (for plotting region outlines))
+    reg_dict : dict | None
+        Deprecated. No longer has an effect (except changing the number of output
+        params).
 
     wgt : np.ndarray
         2d array (lat, lon) of weights to be used for area weighted means
@@ -54,13 +48,11 @@ def extract_land(var, reg_dict, wgt, ls, threshold_land=0.25):
         nested variable at land grid points dictionary with keys
 
         - [esm] (3d array (run, time, gp_l) of variable at land grid points)
-    reg_dict : dict
-        region dictionary with added keys
 
-        - ["gps_l"] (2d array (region, gp_l) of region fraction at land grid points)
-        - ["wgt_gps_l"] (2d array (region, gp_l) of area weights for each region on land)
-        - ["gp_b_l"] (1d array of region index at land grid points with each grid point
-          being assigned to a single region)
+    reg_dict : dict
+        Optional output (empty dict). Only returned when the input ``reg_dict`` is not
+        ``None``.
+
     ls : dict
         land sea dictionary with added keys
 
@@ -74,6 +66,13 @@ def extract_land(var, reg_dict, wgt, ls, threshold_land=0.25):
           fraction)
 
     """
+
+    if reg_dict is not None:
+        warnings.warn(
+            "Passing `reg_dict` no longer has an effect. When passing `None` this "
+            "function will only returns two parameters.",
+            FutureWarning,
+        )
 
     # determine which grid points count as land grid points
     idx_l = ls["grid_no_ANT"] > threshold_land
@@ -91,19 +90,6 @@ def extract_land(var, reg_dict, wgt, ls, threshold_land=0.25):
     # weights for land points: multiply weight by land fraction
     ls["wgt_gp_l"] = wgt[idx_l] * ls["gp_l"]
 
-    # extract the land points + weights from the region grids
-    reg_dict["gps_l"] = reg_dict["grids"][:, idx_l]  # country is the first axis
-    # weights for regions (1st axis): region fraction * area weights
-    reg_dict["wgt_gps_l"] = wgt[idx_l] * reg_dict["gps_l"]
-
-    if reg_dict["type"] in ["srex", "ar6.land"]:
-        # multiply by land fraction to account for coastal cells
-        # because SREX / ar6.land regions include ocean
-        reg_dict["wgt_gps_l"] = reg_dict["wgt_gps_l"] * ls["gp_l"]
-
-    # not sure if needed; extracts land from the "binary" mask
-    reg_dict["gp_b_l"] = reg_dict["grid_b"][idx_l]
-
     # extract the land points of the variable of interest
     var_l = {}
     for esm in var.keys():
@@ -112,7 +98,10 @@ def extract_land(var, reg_dict, wgt, ls, threshold_land=0.25):
             # run is the first axis, followed by time
             var_l[esm][scen] = var[esm][scen][:, :, idx_l]
 
-    return var_l, reg_dict, ls
+    if reg_dict is None:
+        return var_l, ls
+
+    return var_l, {}, ls
 
 
 def extract_time_period(var, time, start, end):

--- a/tests/integration/test_calibrate_mesmer.py
+++ b/tests/integration/test_calibrate_mesmer.py
@@ -29,7 +29,7 @@ def test_calibrate_mesmer(
     test_esms = ["IPSL-CM6A-LR"]
     test_scenarios_to_train = scenarios
     test_target_variable = "tas"
-    test_reg_type = "srex"
+    test_reg_type = None
     test_threshold_land = 1 / 3
     test_output_file = os.path.join(tmpdir, "test_calibrate_mesmer_output.pkl")
     test_scen_seed_offset_v = 0


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

Similar to to #233 this PR deprecates the `reg_type` param from `load_regs_ls_wgt_lon_lat` and the `reg_dict` param from `extract_land`. Calculating regional means should be part of the postprocessing and not of the calibration and emulation. Also regionmask can handle stacked lat/lon grids (since v0.9, i.e. spring 2022).

At the end of the day I am not entirely sure if this is worth it as it also introduces some complexity and this code path might go away eventually. 