### PR TITLE
refactor concat_hist_future

### DIFF
--- a/mesmer/create_emulations/create_emus_lt.py
+++ b/mesmer/create_emulations/create_emus_lt.py
@@ -7,10 +7,12 @@ Functions to create local trends emulations with MESMER.
 """
 
 
-import numpy as np
-
 import mesmer.stats
-from mesmer.create_emulations.utils import _gather_params, _gather_preds
+from mesmer.create_emulations.utils import (
+    _concatenate_hist_future,
+    _gather_params,
+    _gather_preds,
+)
 from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
@@ -77,18 +79,8 @@ def create_emus_lt(params_lt, preds_lt, cfg, concat_h_f=False, save_emus=True):
     pred_names = list(preds_lt.keys())
     scenarios_emus = list(preds_lt[pred_names[0]].keys())
 
-    if concat_h_f:
-        if scenarios_emus[0] == "hist":
-            scens_out_f = scenarios_emus[1:]
-            scens_out = ["h-" + s for s in scens_out_f]
-        else:
-            raise ValueError("This combination is not supported.")
-    else:
-        if "h-" in scenarios_emus[0]:
-            scens_out_f = list(map(lambda x: x.replace("h-", ""), scenarios_emus))
-            scens_out = ["hist"] + scens_out_f
-        else:
-            scens_out = scens_out_f = scenarios_emus
+    if "h-" in scenarios_emus[0]:
+        scenarios_emus = ["hist"] + [scen.replace("h-", "") for scen in scenarios_emus]
 
     # check if correct predictors
     if pred_names != params_lt["preds"]:
@@ -112,18 +104,13 @@ def create_emus_lt(params_lt, preds_lt, cfg, concat_h_f=False, save_emus=True):
 
     # create emulations
     emus_lt = {}
+
+    for scen in scenarios_emus:
+        emus_lt[scen] = create_emus_method_lt(params_lt, preds_lt, scen)
+
     if concat_h_f:
-        lt_hist = create_emus_method_lt(params_lt, preds_lt, "hist")
-        for scen_out, scen_out_f in zip(scens_out, scens_out_f):
-            lt_scen_f = create_emus_method_lt(params_lt, preds_lt, scen_out_f)
-            emus_lt[scen_out] = {}
-            for targ in params_lt["targs"]:
-                emus_lt[scen_out][targ] = np.concatenate(
-                    [lt_hist[targ], lt_scen_f[targ]]
-                )
-    else:
-        for scen_out in scens_out:
-            emus_lt[scen_out] = create_emus_method_lt(params_lt, preds_lt, scen_out)
+        emus_lt = _concatenate_hist_future(emus_lt)
+        scenarios_emus = list(emus_lt.keys())
 
     # save the local trends emulation if requested
     if save_emus:
@@ -138,7 +125,7 @@ def create_emus_lt(params_lt, preds_lt, cfg, concat_h_f=False, save_emus=True):
                 *params_lt["preds"],
                 *params_lt["targs"],
                 params_lt["esm"],
-                *scens_out,
+                *scenarios_emus,
             ],
         )
 

--- a/mesmer/create_emulations/utils.py
+++ b/mesmer/create_emulations/utils.py
@@ -3,7 +3,7 @@ import xarray as xr
 
 
 def _concatenate_hist_future(data):
-    """concatenate hist and future data
+    """concatenate historical and future data
 
     Parameters
     ----------
@@ -20,7 +20,7 @@ def _concatenate_hist_future(data):
 
     scens_in = list(data.keys())
 
-    if "hist" not in scens_in[0]:
+    if "hist" not in scens_in:
         raise ValueError("data does not contain 'hist' scenario")
 
     scens_in.remove("hist")
@@ -35,7 +35,6 @@ def _concatenate_hist_future(data):
 
         for scen_out, scen_in in zip(scens_out, scens_in):
             concatenated[scen_out] = {}
-
             for targ in data[scen_in].keys():
                 concatenated[scen_out][targ] = np.concatenate(
                     [hist[targ], data[scen_in][targ]]
@@ -45,7 +44,6 @@ def _concatenate_hist_future(data):
     else:
 
         for scen_out, scen_in in zip(scens_out, scens_in):
-
             concatenated[scen_out] = np.concatenate([hist, data[scen_in]])
 
     return concatenated


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes  #27
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

I am not sure this actually fixes #27, as it does not remove the `concat_h_f` argument. However, it does refactor the code and I think the logic is now easier to follow. @leabeusch what do you think?



