### PR TITLE
rename create_emus_gt function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,7 +90,11 @@ Breaking changes
 Deprecations
 ^^^^^^^^^^^^
 
-- The function `mesmer.utils.select.extract_time_period` is now deprecated and will be
+- The function ``mesmer.create_emulations.create_emus_gt`` has been renamed to
+  :py:func:`create_emulations.gather_gt_data` (`#246 <https://github.com/MESMER-group/mesmer/pull/246>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
+
+- The function ``mesmer.utils.select.extract_time_period`` is now deprecated and will be
   removed in a future version. Please raise an issue if you use this function (`#243
   <https://github.com/MESMER-group/mesmer/pull/243>`_). By `Mathias Hauser
   <https://github.com/mathause>`_.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -98,7 +98,7 @@ Create emulations
 .. autosummary::
    :toctree: generated/
 
-   ~create_emulations.create_emus_gt
+   ~create_emulations.gather_gt_data
    ~create_emulations.create_emus_gv
    ~create_emulations.create_emus_lt
    ~create_emulations.create_emus_lv

--- a/examples/train_create_emus_automated.py
+++ b/examples/train_create_emus_automated.py
@@ -11,11 +11,11 @@ import configs.config_across_scen_T_cmip6ng_test as cfg
 from mesmer.calibrate_mesmer import train_gt, train_gv, train_lt, train_lv
 from mesmer.create_emulations import (
     create_emus_g,
-    create_emus_gt,
     create_emus_gv,
     create_emus_l,
     create_emus_lt,
     create_emus_lv,
+    gather_gt_data,
 )
 from mesmer.io import load_cmipng, load_phi_gc, load_regs_ls_wgt_lon_lat
 from mesmer.utils import convert_dict_to_arr, extract_land, separate_hist_future
@@ -81,10 +81,10 @@ for esm in esms:
     params_gt_T = train_gt(GSAT[esm], targ, esm, time[esm], cfg, save_params=True)
 
     preds_gt = {"time": time[esm]}
-    gt_T_s = create_emus_gt(
+    gt_T_s = gather_gt_data(
         params_gt_T, preds_gt, cfg, concat_h_f=False, save_emus=False
     )
-    emus_gt_T = create_emus_gt(
+    emus_gt_T = gather_gt_data(
         params_gt_T, preds_gt, cfg, concat_h_f=True, save_emus=True
     )
 

--- a/mesmer/calibrate_mesmer/calibrate_mesmer.py
+++ b/mesmer/calibrate_mesmer/calibrate_mesmer.py
@@ -4,7 +4,7 @@ Functions to calibrate all modules of MESMER
 import logging
 import warnings
 
-from ..create_emulations import create_emus_gt, create_emus_lt, create_emus_lv
+from ..create_emulations import create_emus_lt, create_emus_lv, gather_gt_data
 from ..io import load_cmipng, load_phi_gc, load_regs_ls_wgt_lon_lat, save_mesmer_bundle
 from ..utils import convert_dict_to_arr, extract_land, separate_hist_future
 from .train_gt import train_gt
@@ -220,11 +220,10 @@ def _calibrate_and_draw_realisations(
         LOGGER.info("Creating global-trend emulations")
         preds_gt = {"time": time[esm]}
 
-        # TODO: remove use of emus_gt from this script.
-        emus_gt_T = create_emus_gt(
+        emus_gt_T = gather_gt_data(
             params_gt_T, preds_gt, cfg, concat_h_f=True, save_emus=False
         )
-        gt_T_s = create_emus_gt(
+        gt_T_s = gather_gt_data(
             params_gt_T, preds_gt, cfg, concat_h_f=False, save_emus=False
         )
 
@@ -236,7 +235,7 @@ def _calibrate_and_draw_realisations(
         for scen in gt_T_s.keys():
             gt_T2_s[scen] = gt_T_s[scen] ** 2
 
-        gt_hfds_s = create_emus_gt(
+        gt_hfds_s = gather_gt_data(
             params_gt_hfds, preds_gt, cfg, concat_h_f=False, save_emus=False
         )
 

--- a/mesmer/create_emulations/create_emus_gt.py
+++ b/mesmer/create_emulations/create_emus_gt.py
@@ -14,7 +14,9 @@ from mesmer.io.save_mesmer_bundle import save_mesmer_data
 def create_emus_gt(params_gt, preds_gt, cfg, concat_h_f=False, save_emus=True):
     """see docstring of `gather_gt_data`"""
 
-    warnings.warn("'create_emus_gt' has been renamed to `gather_gt_data`")
+    warnings.warn(
+        "'create_emus_gt' has been renamed to `gather_gt_data`", FutureWarning
+    )
 
     return gather_gt_data(
         params_gt, preds_gt, cfg, concat_h_f=concat_h_f, save_emus=save_emus

--- a/mesmer/create_emulations/create_emus_gt.py
+++ b/mesmer/create_emulations/create_emus_gt.py
@@ -5,15 +5,23 @@
 """
 Functions to create global trend emulations with MESMER.
 """
-
+import warnings
 
 from mesmer.create_emulations.utils import _concatenate_hist_future
 from mesmer.io.save_mesmer_bundle import save_mesmer_data
 
 
-# TODO: rename because there's actually no emulation involved in this process
-# (global trends always come from an external source)
 def create_emus_gt(params_gt, preds_gt, cfg, concat_h_f=False, save_emus=True):
+    """see docstring of `gather_gt_data`"""
+
+    warnings.warn("'create_emus_gt' has been renamed to `gather_gt_data`")
+
+    return gather_gt_data(
+        params_gt, preds_gt, cfg, concat_h_f=concat_h_f, save_emus=save_emus
+    )
+
+
+def gather_gt_data(params_gt, preds_gt, cfg, concat_h_f=False, save_emus=True):
     """
     Create global trend (emissions + volcanoes) emulations for specified ensemble type
     and method.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

This renames `create_emus_gt` to `gather_gt_data`. I am not sure how good this idea is because (1) it breaks the name symmetry of these functions. The functions should eventually go away i.e. not sure there is much gain to enforce this name change now). But I feel like this is the better name as no emulations are actually created. Somewhat part of #27.