### PR TITLE
remove ensemble anomaly type 'first'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -85,7 +85,9 @@ Breaking changes
   and the ``reg_dict`` argument to :py:func:`mesmer.utils.select.extract_land`. These arguments
   no longer have any affect (`#235 <https://github.com/MESMER-group/mesmer/pull/235>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
-
+- Removed ``ref["type"] == "first"``, i.e., caculating the anomaly w.r.t. the first
+  ensemble member (`#247 <https://github.com/MESMER-group/mesmer/pull/247>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 
 Deprecations
 ^^^^^^^^^^^^

--- a/tests/integration/test_load_cmipng.py
+++ b/tests/integration/test_load_cmipng.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import numpy.testing as npt
 import pytest
 
 import mesmer
@@ -11,7 +10,6 @@ from mesmer.testing import assert_dict_allclose
 
 def _get_default_kwargs(
     test_data_root_dir,
-    varn=None,
     esm="IPSL-CM6A-LR",
     scen="ssp126",
     type="all",
@@ -50,6 +48,14 @@ def test_load_cmipng_var_missing_data():
     assert time is None
 
 
+def test_load_cmipng_var_type_first_error(test_data_root_dir):
+
+    with pytest.raises(ValueError, match="reference type 'first'"):
+        _load_cmipng_var(
+            varn="tas", **_get_default_kwargs(test_data_root_dir, type="first")
+        )
+
+
 @pytest.mark.parametrize("varn", ["tas", "hfds"])
 def test_load_cmipng(test_data_root_dir, varn):
 
@@ -68,16 +74,73 @@ def test_load_cmipng(test_data_root_dir, varn):
     assert dta[1].shape == (251, 20, 20)
     assert dta_global[1].shape == (251,)
 
-    npt.assert_allclose(lon["c"], lon_expected)
-    npt.assert_allclose(lat["c"], lat_expected)
-    npt.assert_allclose(time, time_expected)
+    np.testing.assert_allclose(lon["c"], lon_expected)
+    np.testing.assert_allclose(lat["c"], lat_expected)
+    np.testing.assert_allclose(time, time_expected)
+
+
+@pytest.mark.parametrize("varn", ["tas", "hfds"])
+@pytest.mark.parametrize("start, end", [("1850", "1900"), ("1850", "1860")])
+def test_load_cmipng_ref_two_ens_all(test_data_root_dir, varn, start, end):
+
+    dta, dta_global, lon, lat, time = _load_cmipng_var(
+        varn=varn,
+        **_get_default_kwargs(test_data_root_dir, scen="ssp585", start=start, end=end),
+    )
+    time = np.asarray(time)
+    sel = (time >= int(start)) & (time <= int(end))
+
+    # stack ensemble members, new axis at end
+    dta_arr = np.stack(list(dta.values()), axis=-1)
+    dta_global_arr = np.stack(list(dta_global.values()), axis=-1)
+
+    # test mean over all grid points is 0 (over reference period AND ensembles)
+    np.testing.assert_allclose(0, np.nanmean(dta_arr[sel, :, :]), atol=1e-6)
+
+    # test individual gridpoints are 0 (over reference period)
+    result = np.mean(dta_arr[sel, :, :], axis=(0, -1))
+
+    print(result.shape)
+    expected = np.zeros_like(result)
+    expected[np.isnan(result)] = np.NaN
+    np.testing.assert_allclose(expected, result, atol=1e-6)
+
+    # test global mean is 0 (over reference period)
+    np.testing.assert_allclose(0, np.mean(dta_global_arr[sel]), atol=1e-6)
+
+
+@pytest.mark.parametrize("varn", ["tas", "hfds"])
+@pytest.mark.parametrize("start, end", [("1850", "1900"), ("1850", "1860")])
+def test_load_cmipng_ref_two_ens_indiv(test_data_root_dir, varn, start, end):
+
+    dta, dta_global, lon, lat, time = _load_cmipng_var(
+        varn=varn,
+        **_get_default_kwargs(
+            test_data_root_dir, scen="ssp585", type="individ", start=start, end=end
+        ),
+    )
+    time = np.asarray(time)
+    sel = (time >= int(start)) & (time <= int(end))
+
+    # test mean over all grid points is 0 (over reference period)
+    for arr in dta.values():
+        np.testing.assert_allclose(0, np.nanmean(arr[sel, :, :]), atol=1e-6)
+
+    # test individual gridpoints are 0 (over reference period)
+    for arr in dta.values():
+        result = np.mean(arr[sel, :, :], axis=0)
+        expected = np.zeros_like(result)
+        expected[np.isnan(result)] = np.NaN
+        np.testing.assert_allclose(expected, result, atol=1e-6)
+
+    # test global mean is 0 (over reference period)
+    for arr_global in dta_global.values():
+        np.testing.assert_allclose(0, np.mean(arr_global[sel]), atol=1e-6)
 
 
 @pytest.mark.parametrize("varn", ["tas", "hfds"])
 @pytest.mark.parametrize("start, end", [("1850", "1900"), ("1850", "1860")])
 def test_load_cmipng_ref(test_data_root_dir, varn, start, end):
-
-    # TODO: test ref["type"] once there is more than one test dataset
 
     dta, dta_global, lon, lat, time = _load_cmipng_var(
         varn=varn, **_get_default_kwargs(test_data_root_dir, start=start, end=end)
@@ -86,16 +149,16 @@ def test_load_cmipng_ref(test_data_root_dir, varn, start, end):
     sel = (time >= int(start)) & (time <= int(end))
 
     # test mean over all grid points is 0 (over reference period)
-    npt.assert_allclose(0, np.nanmean(dta[1][sel, :, :]), atol=1e-6)
+    np.testing.assert_allclose(0, np.nanmean(dta[1][sel, :, :]), atol=1e-6)
 
     # test individual gridpoints are 0 (over reference period)
     result = np.mean(dta[1][sel, :, :], axis=0)
     expected = np.zeros_like(result)
     expected[np.isnan(result)] = np.NaN
-    npt.assert_allclose(expected, result, atol=1e-6)
+    np.testing.assert_allclose(expected, result, atol=1e-6)
 
     # test global mean is 0 (over reference period)
-    npt.assert_allclose(0, np.mean(dta_global[1][sel]), atol=1e-6)
+    np.testing.assert_allclose(0, np.mean(dta_global[1][sel]), atol=1e-6)
 
 
 @pytest.mark.parametrize("varn", ["tas", "hfds"])
@@ -118,4 +181,4 @@ def test_load_cmimpng_vs_load_var(test_data_root_dir, varn):
     assert_dict_allclose(dta_global_d, dta_global_i, "direct", "indirect")
     assert_dict_allclose(lon_d, lon_i, "direct", "indirect")
     assert_dict_allclose(lat_d, lat_i, "direct", "indirect")
-    npt.assert_allclose(time_d, time_i)
+    np.testing.assert_allclose(time_d, time_i)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

This removes `ref["type"] == "first"` i.e., caculating the anomaly w.r.t. the first ensemble member. Also adds more tests to the data loading and cleans the code/ comments a bit.
