### PR TITLE
rename _calibrate_and_draw_realisations to _calibrate_tas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -88,6 +88,9 @@ Breaking changes
 - Removed ``ref["type"] == "first"``, i.e., caculating the anomaly w.r.t. the first
   ensemble member (`#247 <https://github.com/MESMER-group/mesmer/pull/247>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Renamed ``mesmer.calibrate_mesmer._calibrate_and_draw_realisations`` to ``mesmer.calibrate_mesmer._calibrate_tas``
+  (`#66 <https://github.com/MESMER-group/mesmer/issues/66>`_).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 
 Deprecations
 ^^^^^^^^^^^^

--- a/mesmer/calibrate_mesmer/__init__.py
+++ b/mesmer/calibrate_mesmer/__init__.py
@@ -6,7 +6,7 @@
 Collection of functions to calibrate all modules of MESMER.
 """
 # flake8: noqa
-from .calibrate_mesmer import _calibrate_tas, _calibrate_and_draw_realisations
+from .calibrate_mesmer import _calibrate_and_draw_realisations, _calibrate_tas
 from .train_gt import *
 from .train_gv import *
 from .train_lt import *

--- a/mesmer/calibrate_mesmer/__init__.py
+++ b/mesmer/calibrate_mesmer/__init__.py
@@ -6,7 +6,7 @@
 Collection of functions to calibrate all modules of MESMER.
 """
 # flake8: noqa
-from .calibrate_mesmer import _calibrate_and_draw_realisations
+from .calibrate_mesmer import _calibrate_tas, _calibrate_and_draw_realisations
 from .train_gt import *
 from .train_gv import *
 from .train_lt import *

--- a/mesmer/calibrate_mesmer/calibrate_mesmer.py
+++ b/mesmer/calibrate_mesmer/calibrate_mesmer.py
@@ -98,8 +98,17 @@ class _Config:
         self.dir_mesmer_params = params_output_dir
 
 
-# TODO: remove draw realisations functionality
-def _calibrate_and_draw_realisations(
+def _calibrate_and_draw_realisations(*args, **kwargs):
+
+    warnings.warn(
+        "``_calibrate_and_draw_realisations`` has been renamed to ``_calibrate_tas``",
+        FutureWarning,
+        )
+
+    return _calibrate_tas(*args, **kwargs)
+
+
+def _calibrate_tas(
     *args,
     esms,
     scenarios_to_train,

--- a/mesmer/calibrate_mesmer/calibrate_mesmer.py
+++ b/mesmer/calibrate_mesmer/calibrate_mesmer.py
@@ -103,7 +103,7 @@ def _calibrate_and_draw_realisations(*args, **kwargs):
     warnings.warn(
         "``_calibrate_and_draw_realisations`` has been renamed to ``_calibrate_tas``",
         FutureWarning,
-        )
+    )
 
     return _calibrate_tas(*args, **kwargs)
 

--- a/tests/integration/test_calibrate_mesmer.py
+++ b/tests/integration/test_calibrate_mesmer.py
@@ -4,7 +4,7 @@ import shutil
 import joblib
 import pytest
 
-from mesmer.calibrate_mesmer import _calibrate_and_draw_realisations
+from mesmer.calibrate_mesmer import _calibrate_tas
 from mesmer.testing import assert_dict_allclose
 
 
@@ -47,7 +47,7 @@ def test_calibrate_mesmer(
         "auxiliary",
     )
 
-    _calibrate_and_draw_realisations(
+    _calibrate_tas(
         esms=test_esms,
         scenarios_to_train=test_scenarios_to_train,
         threshold_land=test_threshold_land,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Ok I think we are finally there to rename `_calibrate_and_draw_realisations` to `_calibrate_tas`.

 - [x] Closes #66
 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`
