### PR TITLE
update setup requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel",
-    "setuptools_scm[toml]>=7.0",
+    "setuptools_scm>=7.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,9 +58,7 @@ dev =
     black < 23
     flake8
     isort
-    setuptools
     twine
-    wheel
 
 [flake8]
 ignore=


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

wheel is no longer a setup requirement, the toml is no longer needed and setuptools is not a runtime requirement
