### PR TITLE
flake8 6.1: ignore E721

### DIFF
--- a/tests/integration/test_calibrate_mesmer.py
+++ b/tests/integration/test_calibrate_mesmer.py
@@ -70,7 +70,7 @@ def test_calibrate_mesmer(
         exp = joblib.load(expected_output_file)
 
         assert isinstance(res, dict)
-        assert type(res) == type(exp)
+        assert type(res) == type(exp)  # noqa: E721
         assert res.keys() == exp.keys()
 
         # check all keys of res match exp


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Ignore E721 (do not compare types, use isinstance()) for comparing _two_ unknown types. See https://stackoverflow.com/q/52395064/3010700