### PR TITLE
train_gt: use separate_hist_future

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -130,6 +130,13 @@ Documentation
 Internal Changes
 ^^^^^^^^^^^^^^^^
 
+- Refactor the mesmer internals to use the new statistical core, employ helper functions
+  etc.:
+
+  - Use :py:func:`mesmer.utils.separate_hist_future` in :py:func:`mesmer.calibrate_mesmer.train_gt` (`#281 <https://github.com/MESMER-group/mesmer/pull/281>`_).
+
+  By `Mathias Hauser <https://github.com/mathause>`_.
+
 - Restore compatibility with regionmask v0.9.0 (`#136 <https://github.com/MESMER-group/mesmer/pull/136>`_).
   By `Mathias Hauser <https://github.com/mathause>`_.
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -187,7 +187,7 @@ Utils
    :toctree: generated/
 
    ~utils.convert.convert_dict_to_arr
-   ~utils.convert.separate_hist_future
+   ~utils.separate_hist_future
    ~utils.select.extract_land
    ~utils.select.extract_time_period
    ~utils.regionmaskcompat import mask_3D_frac_approx

--- a/mesmer/utils/convert.py
+++ b/mesmer/utils/convert.py
@@ -91,15 +91,16 @@ def separate_hist_future(var_c, time_c, cfg):
     var_s, time_s = {}, {}
 
     # gather hist
-    hist = [var_c[scen_c][:, :idx_start_fut] for scen_c in scens_c]
+    hist = [np.atleast_2d(var_c[scen_c])[:, :idx_start_fut] for scen_c in scens_c]
+    hist = np.vstack(hist)
 
     # exclude duplicate historical runs that are available in several scenarios
-    var_s["hist"] = np.unique(np.vstack(hist), axis=0)
+    var_s["hist"] = np.unique(hist, axis=0)
     time_s["hist"] = time[:idx_start_fut]
 
     # gather proj
     for scen_f, scen_c in zip(scens_f, scens_c):
-        var_s[scen_f] = var_c[scen_c][:, idx_start_fut:]
+        var_s[scen_f] = np.atleast_2d(var_c[scen_c])[:, idx_start_fut:]
         time_s[scen_f] = time_c[scen_c][idx_start_fut:]
 
     return var_s, time_s


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

Refactor `train_gt` to use `separate_hist_future`. This simplifies and de-duplicates the code. It still looks a bit convoluted, though.
