### PR TITLE
lowess: n_steps and use_coords

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,8 +48,9 @@ New Features
 
 - Other refactorings:
    - Extract the LOWESS smoothing for xarray objects: :py:func:`mesmer.stats.smoothing.lowess`.
-     (`#193 <https://github.com/MESMER-group/mesmer/pull/193>`_ and `#283
-     <https://github.com/MESMER-group/mesmer/pull/283>`_).
+     (`#193 <https://github.com/MESMER-group/mesmer/pull/193>`_,
+     `#283 <https://github.com/MESMER-group/mesmer/pull/283>`_, and
+     `#285 <https://github.com/MESMER-group/mesmer/pull/285>`_).
      By `Mathias Hauser <https://github.com/mathause>`_.
 
 - Added helper functions to process xarray-based model data:

--- a/mesmer/stats/smoothing.py
+++ b/mesmer/stats/smoothing.py
@@ -4,7 +4,7 @@ import xarray as xr
 from mesmer.core.utils import _check_dataarray_form
 
 
-def lowess(data, dim, *, frac, use_coords_as_x=False, it=0):
+def lowess(data, dim, *, n_steps=None, frac=None, use_coords=True, it=0):
     """LOWESS (Locally Weighted Scatterplot Smoothing) for xarray objects
 
     Parameters
@@ -13,13 +13,27 @@ def lowess(data, dim, *, frac, use_coords_as_x=False, it=0):
         Data to smooth (y-values).
     dim : str
         Dimension along which to smooth (x-dimension)
+    n_steps : int
+        The number of data points used to estimate each y-value, must be between 0 and
+        the length of dim. If given used to calculate ``frac``. Exactly one of
+        ``n_steps`` and ``frac`` must be given.
     frac : float
-        Between 0 and 1. The fraction of the data used when estimating each y-value.
-    use_coords_as_x : boolean, default: False
+        The fraction of the data used when estimating each y-value. Between 0 and 1.
+        Exactly one of ``n_steps`` and ``frac`` must be given.
+    use_coords : boolean, default: True
         If True uses ``data[dim]`` as x-values else uses ``np.arange(data[dim].size)``
         (useful if ``dim`` are time coordinates).
     it : int, default: 0
         The number of residual-based re-weightings to perform.
+
+    Returns
+    -------
+    out : xr.DataArray | xr.Dataset
+        LOWESS smoothed array
+
+    See Also
+    --------
+    statsmodels.nonparametric.smoothers_lowess.lowess
     """
 
     from statsmodels.nonparametric.smoothers_lowess import lowess
@@ -27,11 +41,37 @@ def lowess(data, dim, *, frac, use_coords_as_x=False, it=0):
     if not isinstance(dim, str):
         raise ValueError("Can only pass a single dimension.")
 
+    if (n_steps is None and frac is None) or (n_steps is not None and frac is not None):
+        raise ValueError("Exactly one of ``n_steps`` and ``frac`` must be given.")
+
     coords = data[dim]
     _check_dataarray_form(coords, name=dim, ndim=1)
 
-    if use_coords_as_x:
-        x = coords
+    n_coords = coords.size
+    if n_steps is not None:
+
+        if n_steps > n_coords:
+            raise ValueError(
+                f"``n_steps`` ({n_steps}) cannot be be larger than the length of '{dim}' ({n_coords})"
+            )
+
+        frac = n_steps / n_coords
+
+    # TODO: could instead convert datetime coords to numeric (see e.g. in flox)
+    if use_coords:
+        try:
+            # test if coords can be cast to float (required by statsmodels..lowess)
+            # use safe casting so we don't convert np datetime to float
+            # while this technically works the x values are then too large such that
+            # a missing year is no longer detected...
+            x = coords.astype(float, casting="safe")
+        except TypeError as e:
+            raise TypeError(
+                f"Cannot convert coords ({dim}) of type `{coords.dtype}` to float. "
+                "Set ``use_coords=False`` to use enumerated coords "
+                "(``np.arange(data[dim].size)``) instead."
+            ) from e
+
     else:
         x = xr.ones_like(coords)
         x.data = np.arange(coords.size)

--- a/tests/unit/test_smoothing.py
+++ b/tests/unit/test_smoothing.py
@@ -76,7 +76,6 @@ def test_lowess_use_coords():
     time[-1] = time[-1] + 10
     data = data.assign_coords(time=time)
 
-
     result = mesmer.stats.smoothing.lowess(data, "time", frac=0.1)
 
     # time is not equally spaced: we do NOT want the same result as for use_coords=False

--- a/tests/unit/test_smoothing.py
+++ b/tests/unit/test_smoothing.py
@@ -1,5 +1,7 @@
+import pandas as pd
 import pytest
 import xarray as xr
+from packaging.version import Version
 from statsmodels.nonparametric.smoothers_lowess import lowess
 
 import mesmer.stats.smoothing
@@ -26,18 +28,21 @@ def test_lowess_errors():
         mesmer.stats.smoothing.lowess(data.to_dataset(), "lat", n_steps=40)
 
     # numpy datetime
-    time = xr.date_range("2000-01-01", periods=30)
+    time = pd.date_range("2000-01-01", periods=30)
     data = data.assign_coords(time=time)
 
     with pytest.raises(TypeError, match="Cannot convert coords"):
         mesmer.stats.smoothing.lowess(data.to_dataset(), "time", frac=0.5)
 
-    # cftime datetime
-    time = xr.date_range("2000-01-01", periods=30, calendar="noleap")
-    data = data.assign_coords(time=time)
+    # TODO: remove check once we drop python 3.7
+    if Version(xr.__version__) >= Version("21.0"):
 
-    with pytest.raises(TypeError, match="Cannot convert coords"):
-        mesmer.stats.smoothing.lowess(data.to_dataset(), "time", frac=0.5)
+        # cftime datetime
+        time = xr.date_range("2000-01-01", periods=30, calendar="noleap")
+        data = data.assign_coords(time=time)
+
+        with pytest.raises(TypeError, match="Cannot convert coords"):
+            mesmer.stats.smoothing.lowess(data.to_dataset(), "time", frac=0.5)
 
 
 @pytest.mark.parametrize("it", [0, 3])

--- a/tests/unit/test_smoothing.py
+++ b/tests/unit/test_smoothing.py
@@ -33,7 +33,7 @@ def test_lowess_errors():
         mesmer.stats.smoothing.lowess(data.to_dataset(), "time", frac=0.5)
 
     # cftime datetime
-    time = xr.date_range("2000-01-01", periods=30, calendar="noloeap")
+    time = xr.date_range("2000-01-01", periods=30, calendar="noleap")
     data = data.assign_coords(time=time)
 
     with pytest.raises(TypeError, match="Cannot convert coords"):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

This adds some changes to `mesmer.stats.smoothing.lowess`:
- add `n_steps` keyword, which can be used instead of `frac` (as this is used in mesmer)
- rename `use_coords_as_x` to `use_coords`
- set `use_coords=True` to use coords as x-values per default. For datetime coords this will have to be set to `False` - this is a bit unfortunate (because we will mostly use it for that). However, it's the right thing to do - we want to be explicit about not using the coords (important when they are not equally spaced).