### PR TITLE
fix ar order selection

### DIFF
--- a/mesmer/calibrate_mesmer/train_gv.py
+++ b/mesmer/calibrate_mesmer/train_gv.py
@@ -189,7 +189,7 @@ def train_gv_AR(params_gv, gv, max_lag, sel_crit):
 
     # median over all scenarios
     AR_order_scen = xr.concat(AR_order_scen, dim="scen")
-    AR_order_sel = int(AR_order.quantile(q=0.5, **{method: "nearest"}).item())
+    AR_order_sel = int(AR_order_scen.quantile(q=0.5, **{method: "nearest"}).item())
 
     # determine the AR params for the selected AR order
     params_scen = list()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

I was playing around with #109 when I noticed some tests randomly failing. Took me too long what's going wrong. Writing a test for this would be a pain...

One thing I noticed - the way it is set up, we select `AROrder = 1` for the following situation:

```
                          order
scenario ensemble_member       
hist     r1i1p1f1             1
         r2i1p1f1             2
ssp126   r1i1p1f1             2
         r2i1p1f1             2
```

`arr.quantile(q=0.5, method="nearest")` over the scenarios selects `[1, 2]` and from this we select 1. (However, rounding up is no better, because then we could end up selecting 2 for (3 x 1 and 1 x 2). I may have to open an issue for this. Maybe it's also only relevant in this artificial scenario...




