### PR TITLE
fix typos (using codespell)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -117,7 +117,7 @@ Breaking changes
   and the ``reg_dict`` argument to :py:func:`mesmer.utils.select.extract_land`. These arguments
   no longer have any affect (`#235 <https://github.com/MESMER-group/mesmer/pull/235>`_).
   By `Mathias Hauser`_.
-- Removed ``ref["type"] == "first"``, i.e., caculating the anomaly w.r.t. the first
+- Removed ``ref["type"] == "first"``, i.e., calculating the anomaly w.r.t. the first
   ensemble member (`#247 <https://github.com/MESMER-group/mesmer/pull/247>`_).
   By `Mathias Hauser`_.
 - Renamed ``mesmer.calibrate_mesmer._calibrate_and_draw_realisations`` to ``mesmer.calibrate_mesmer._calibrate_tas``

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ There are two levels of internal data structures used within MESMER: (i) an arra
 
 MESMER currently uses [numpy](https://numpy.org/) to represent its array data structure.
 While numpy is the de-facto standard of array computing today, MESMER can profit from labels which encode information about how the array values map to locations in space, time, etc..
-For example a 3 dimensional array can be augmented with named dimensons (`time`, `latitude`, `longitude`) and these dimensions can be augmented with coordinates (e.g. the first time step corresponds to 1850).
+For example a 3 dimensional array can be augmented with named dimensions (`time`, `latitude`, `longitude`) and these dimensions can be augmented with coordinates (e.g. the first time step corresponds to 1850).
 Such data structures are provided by the well established [xarray](http://xarray.pydata.org/en/stable/) library, which adds named dimensions, coordinates and attributes on top of raw numpy-like arrays and is particularly tailored to working with netCDF files.
 We therefore plan to replace the array data structure with xarray data structures.
 
@@ -43,7 +43,7 @@ Specific tasks
 
 ### Disentangle the data handling from the statistical functions
 
-Currently, most functions in MESMER combine data handling (e.g. splitting historical data and projections), statistical calibration (e.g. estimating linear regression coefficients), and saving the estimated parameters. These three steps should be split into individual functions, which will offer several benefits: (i) It should become easier to understand what happens in each step of the calibration/ emulation pipeline. (ii) The individual code parts become easier to re-use and update. (iii) Each part can be tested individually.
+Currently, most functions in MESMER combine data handling (e.g. splitting historical data and projections), statistical calibration (e.g. estimating linear regression coefficients), and saving the estimated parameters. These three steps should be split into individual functions, which will offer several benefits: (i) It should become easier to understand what happens in each step of the calibration/ emulation pipeline. (ii) The individual code parts become easier to reuse and update. (iii) Each part can be tested individually.
 
 Specific tasks
 - Extract common data handling tasks and write individual functions for each of them ([#109](https://github.com/MESMER-group/mesmer/pull/109)).

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -82,7 +82,7 @@ Masking regions
    ~core.mask.mask_antarctica
    ~core.regionmaskcompat.mask_3D_frac_approx
 
-Weighted operarions: calculate global mean
+Weighted operations: calculate global mean
 ------------------------------------------
 
    ~core.weighted.global_mean

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -101,7 +101,7 @@ Testing philosophy
 ------------------
 
 When writing tests, we try to put them in one of two categories: integration and regression.
-Integration tests run bits of the code and assert the correct behaviour was achived.
+Integration tests run bits of the code and assert the correct behaviour was achieved.
 Some of the integration tests might run fairly big bits of code, others will be more targeted.
 Try to keep integration test files targeted and fairly small.
 We can always create `fixtures <https://docs.pytest.org/en/stable/explanation/fixtures.html>`__ to aid code reuse.
@@ -129,7 +129,7 @@ Note that ``make format`` can only be run if you have committed all your work i.
 This restriction is made to ensure that you don't format code without being able to undo it, just in case something goes wrong.
 
 
-Buiding the docs
+Building the docs
 ----------------
 
 After setting yourself up (see `Development setup`_), building the docs is as simple as running ``make docs`` (note, run ``make -B docs`` to force the docs to rebuild and ignore make when it says '... index.html is up to date').
@@ -150,7 +150,7 @@ Why is there a ``Makefile`` in a pure Python repository?
 --------------------------------------------------------
 
 Whilst it may not be standard practice, a ``Makefile`` is a simple way to automate general setup (environment setup in particular).
-Hence we have one here which basically acts as a notes file for how to do all those little jobs which we often forget e.g. setting up environments, running tests (and making sure we're in the right environment), building docs, setting up auxillary bits and pieces.
+Hence we have one here which basically acts as a notes file for how to do all those little jobs which we often forget e.g. setting up environments, running tests (and making sure we're in the right environment), building docs, setting up auxiliary bits and pieces.
 
 .. _Sphinx: http://www.sphinx-doc.org
 .. _MESMER issue tracker: https://github.com/MESMER-group/mesmer/issues

--- a/examples/config_tas_cmip6ng_example.py
+++ b/examples/config_tas_cmip6ng_example.py
@@ -30,7 +30,7 @@ dir_cmipng = os.path.join(TEST_DATA_ROOT, f"cmip{gen}-ng")
 dir_obs = os.path.join(TEST_DATA_ROOT, "observations")
 
 # mesmer output
-dir_aux = os.path.join(EXAMPLE_OUTPUT_ROOT, "auxillary")
+dir_aux = os.path.join(EXAMPLE_OUTPUT_ROOT, "auxiliary")
 dir_mesmer_params = os.path.join(EXAMPLE_OUTPUT_ROOT, "calibrated_parameters")
 dir_mesmer_emus = os.path.join(EXAMPLE_OUTPUT_ROOT, "emulations")
 

--- a/examples/train_create_emus_automated.py
+++ b/examples/train_create_emus_automated.py
@@ -19,7 +19,7 @@ def main(cfg):
 
     # specify the target variable
     targ = cfg.targs[0]
-    print(f"Target variables: {targ}")
+    print(f"Target variable: {targ}")
 
     # load in the ESM runs
     esms = cfg.esms

--- a/mesmer/calibrate_mesmer/train_gt.py
+++ b/mesmer/calibrate_mesmer/train_gt.py
@@ -129,7 +129,7 @@ def train_gt(data, targ, esm, time, cfg, save_params=True):
     for scen, data in gt_to_distribute.items():
         params_gt[scen] = data.squeeze()
 
-    # save the global trend paramters if requested
+    # save the global trend parameters if requested
     if save_params:
         save_mesmer_data(
             params_gt,
@@ -251,7 +251,7 @@ def train_gt_ic_OLSVOLC(var, gt_lowess, time, cfg=None):
 
     # fit linear regression of gt to aod (because some ESMs react very strongly to
     # volcanoes)
-    # no intercept to not artifically move the ts
+    # no intercept to not artificially move the ts
     lr.fit(
         predictors={"aod_obs": aod_obs_all},
         target=gv_all_for_aod,
@@ -265,7 +265,7 @@ def train_gt_ic_OLSVOLC(var, gt_lowess, time, cfg=None):
     # apply linear regression model to obtain volcanic spikes
     contrib_volc = lr.predict(predictors={"aod_obs": aod_obs})
 
-    # merge the lowess trend wit the volc contribution
+    # merge the lowess trend with the volc contribution
     gt = gt_lowess + contrib_volc.values.squeeze()
 
     return coef_saod, gt

--- a/mesmer/calibrate_mesmer/train_gv.py
+++ b/mesmer/calibrate_mesmer/train_gv.py
@@ -84,7 +84,7 @@ def train_gv(gv, targ, esm, cfg, save_params=True, **kwargs):
 
     # apply the chosen method
     if params_gv["method"] == "AR" and wgt_scen_tr_eq:
-        # specifiy parameters employed for AR process fitting
+        # specify parameters employed for AR process fitting
 
         kwargs["max_lag"] = kwargs.get("max_lag", 12)
         kwargs["sel_crit"] = kwargs.get("sel_crit", "bic")
@@ -93,7 +93,7 @@ def train_gv(gv, targ, esm, cfg, save_params=True, **kwargs):
     else:
         raise ValueError("No such method and/ or weighting approach.")
 
-    # save the global variability paramters if requested
+    # save the global variability parameters if requested
     if save_params:
         save_mesmer_data(
             params_gv,

--- a/mesmer/calibrate_mesmer/train_lt.py
+++ b/mesmer/calibrate_mesmer/train_lt.py
@@ -60,7 +60,7 @@ def train_lt(preds, targs, esm, cfg, save_params=True):
         - ["full_model_contains_lv"] (whether the full model contains part of the local
           variability module, bool)
     params_lv : dict, optional
-        dictionary of local variability paramters which are derived together with the
+        dictionary of local variability parameters which are derived together with the
         local trend parameters
 
         - ["targs"] (emulated variables, str)
@@ -186,7 +186,7 @@ def train_lt(preds, targs, esm, cfg, save_params=True):
     else:
         raise NotImplementedError()
 
-    # save the local trend paramters if requested
+    # save the local trend parameters if requested
     if save_params:
         save_mesmer_data(
             params_lt,

--- a/mesmer/calibrate_mesmer/train_lv.py
+++ b/mesmer/calibrate_mesmer/train_lv.py
@@ -55,7 +55,7 @@ def train_lv(preds, targs, esm, cfg, save_params=True, aux={}, params_lv={}):
     Returns
     -------
     params_lv : dict
-        dictionary of local variability paramters
+        dictionary of local variability parameters
 
         - ["targs"] (emulated variables, str)
         - ["esm"] (Earth System Model, str)

--- a/mesmer/core/computation.py
+++ b/mesmer/core/computation.py
@@ -180,7 +180,7 @@ def _calc_geodist_exact(lon, lat):
     geodist = np.zeros([n_points, n_points])
 
     # calculate only the upper right half of the triangle
-    for i in range(n_points):
+    for i in range(n_points - 1):
 
         # need to duplicate gridpoint (required by geod.inv)
         lt = np.repeat(lat[i : i + 1], n_points - (i + 1))

--- a/mesmer/core/grid.py
+++ b/mesmer/core/grid.py
@@ -127,7 +127,7 @@ def stack_lat_lon(
 def unstack_lat_lon_and_align(
     data, coords_orig, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"
 ):
-    """unstack an 1D grid to a regular lat-lon grid and align with orignal coords
+    """unstack an 1D grid to a regular lat-lon grid and align with original coords
 
     Parameters
     ----------
@@ -184,7 +184,7 @@ def unstack_lat_lon(data, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
 
 
 def align_to_coords(data, coords_orig):
-    """align an unstacked lat-lon grid with its orignal coords
+    """align an unstacked lat-lon grid with its original coords
 
     Parameters
     ----------

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -61,7 +61,7 @@ def _minimize_local_discrete(func, sequence, **kwargs):
             raise ValueError("`fun` returned `-inf`")
         # skip element if inf is returned - not sure about this?
         elif np.isinf(res):
-            warnings.warn("`fun` retured `inf`", OptimizeWarning)
+            warnings.warn("`fun` returned `inf`", OptimizeWarning)
 
         if res < current_min:
             current_min = res

--- a/mesmer/core/weighted.py
+++ b/mesmer/core/weighted.py
@@ -35,7 +35,7 @@ def lat_weights(lat_coords):
 
 
 def weighted_mean(data, weights, dims=None):
-    """weighted mean - convinience function which ignores data_vars missing dims
+    """weighted mean - convenience function which ignores data_vars missing dims
 
     Parameters
     ----------

--- a/mesmer/create_emulations/create_emus_gv.py
+++ b/mesmer/create_emulations/create_emus_gv.py
@@ -135,7 +135,7 @@ def create_emus_gv_AR(params_gv, nr_emus_v, nr_ts_emus_v, seed):
         number of time steps in each global variability emulation
 
     seed : int
-        esm and scenario specific seed for gv module to ensure reproducability of
+        esm and scenario specific seed for gv module to ensure reproducibility of
         results
 
     Returns

--- a/mesmer/create_emulations/utils.py
+++ b/mesmer/create_emulations/utils.py
@@ -57,7 +57,7 @@ def _gather_lr_preds(preds_dict, predictor_names, scen, dims):
     Parameters
     ----------
     preds_dict : dict
-        Dictonary containg all predictors.
+        Dictionary containing all predictors.
     predictor_names : list of str
         List of all predictors to gather from ``preds_dict``.
     scen : str
@@ -68,7 +68,7 @@ def _gather_lr_preds(preds_dict, predictor_names, scen, dims):
     Returns
     -------
     predictors : dict
-        Dictonary of gathered predictors.
+        Dictionary of gathered predictors.
 
     Notes
     -----
@@ -88,7 +88,7 @@ def _gather_lr_params(params_dict, targ, dims):
     Parameters
     ----------
     params_dict : dict
-        Dictonary containg all parameters.
+        Dictionary containing all parameters.
     targ : str
         Name of target variable for which to read the parameters.
     dims : str, tuple of str

--- a/mesmer/io/_load_cmipng.py
+++ b/mesmer/io/_load_cmipng.py
@@ -58,7 +58,7 @@ def extract_time_lon_lat_wgt3d(data):
 
 
 def find_files_cmipng(gen, esm, var, scenario, dir_cmipng):
-    """Find filname in ETHZ cmip-ng archive.
+    """Find filename in ETHZ cmip-ng archive.
 
     Parameters
     ----------

--- a/mesmer/io/load_mesmer.py
+++ b/mesmer/io/load_mesmer.py
@@ -40,7 +40,7 @@ def load_mesmer_output(
         target variables (e.g., "tas")
     esm_str : str, optional
         Earth System Model (e.g., "CanESM2", "CanESM5")
-    scen_str : str, otional
+    scen_str : str, optional
         scenario (e.g., "rcp85", "ssp585", "h-ssp585")
     mid_path : str, optional
         middle part of pathway depending on what exactly want to load (e.g.,
@@ -106,7 +106,7 @@ def load_mesmer_output(
         dict_out = {}
     elif len(path_list) > 1:
         warnings.warn(
-            "More than 1 file exists for these critera. "
+            "More than 1 file exists for these criteria. "
             "Please be more concrete in your selection."
             " An empty dictionary will be returned.",
         )

--- a/mesmer/io/save_mesmer_bundle.py
+++ b/mesmer/io/save_mesmer_bundle.py
@@ -88,7 +88,7 @@ def save_mesmer_data(params, *folders, filename_parts):
     Parameters
     ----------
     params : Any
-        Python object containg the parameters to save (e.g. a dictionary containing
+        Python object containing the parameters to save (e.g. a dictionary containing
         numpy arrays etc.)
     *folders : str
         Name of the folders where to store the data.

--- a/mesmer/stats/linear_regression.py
+++ b/mesmer/stats/linear_regression.py
@@ -75,7 +75,7 @@ class LinearRegression:
         available_predictors = set(predictors.keys())
 
         if required_predictors != available_predictors:
-            raise ValueError("Missing or superflous predictors.")
+            raise ValueError("Missing or superfluous predictors.")
 
         prediction = params.intercept
         for key in required_predictors:

--- a/mesmer/stats/localized_covariance.py
+++ b/mesmer/stats/localized_covariance.py
@@ -88,7 +88,7 @@ def find_localized_empirical_covariance(
     weights : xr.DataArray
         Weights for the individual samples.
     localizer : dict of DataArray```
-        Dictonary containing the localization radii as keys and the localization matrix
+        Dictionary containing the localization radii as keys and the localization matrix
         as values. The localization must be 2D and of shape n_gridpoints x n_gridpoints.
         Currently only the Gaspari-Cohn localizer is implemented in MESMER.
     dim : str
@@ -154,7 +154,7 @@ def _find_localized_empirical_covariance_np(data, weights, localizer, k_folds):
     weights : 1D array
         Weights for the individual samples.
     localizer : dict of array-like
-        Dictonary containing the localization radii as keys and the localization matrix
+        Dictionary containing the localization radii as keys and the localization matrix
         as values. The localization must be 2D and of shape nr_gridpoints x nr_gridpoints.
         Currently only the Gaspari-Cohn localizer is implemented in MESMER.
     k_folds : int

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mesmer-emulator
-author = mesmer developpers
+author = mesmer developers
 author_email = mesmer@env.ethz.ch
 license = GPLv3+
 keywords = climate atmosphere "Earth System Model Emulator"

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -136,7 +136,7 @@ def test_to_unstructured_dropna(dropna, coords, time_pos):
 
     da[slice(time_pos), 0, 0] = np.NaN
 
-    # the gridpoint is droped if ANY time step is NaN
+    # the gridpoint is dropped if ANY time step is NaN
     expected[:, 0] = np.NaN
 
     if dropna:

--- a/tests/unit/test_linear_regression.py
+++ b/tests/unit/test_linear_regression.py
@@ -88,10 +88,10 @@ def test_LR_predict(as_2D):
     )
     lr.params = params if as_2D else params.squeeze()
 
-    with pytest.raises(ValueError, match="Missing or superflous predictors"):
+    with pytest.raises(ValueError, match="Missing or superfluous predictors"):
         lr.predict({})
 
-    with pytest.raises(ValueError, match="Missing or superflous predictors"):
+    with pytest.raises(ValueError, match="Missing or superfluous predictors"):
         lr.predict({"tas": None, "something else": None})
 
     tas = xr.DataArray([0, 1, 2], dims="time")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -47,7 +47,7 @@ def test_minimize_local_discrete_warning():
 
     data_dict = {key: value for key, value in enumerate((5, np.inf, 3))}
 
-    with pytest.warns(mesmer.core.utils.OptimizeWarning, match="`fun` retured `inf`"):
+    with pytest.warns(mesmer.core.utils.OptimizeWarning, match="`fun` returned `inf`"):
         result = mesmer.core.utils._minimize_local_discrete(
             func, data_dict.keys(), data_dict=data_dict
         )


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->


fix some typos (using [codespell](https://github.com/codespell-project/codespell)). Called using:

```bash
codespell --skip=".git,.mypy_cache,*.tex,*.ipynb,./docs/build,./build" --ignore-words-list varn  -w -i 3
```

(to extend the word list, separate by comma, e.g., `varn,mod`)