### PR TITLE
speed up import

### DIFF
--- a/mesmer/calibrate_mesmer/train_gv.py
+++ b/mesmer/calibrate_mesmer/train_gv.py
@@ -8,7 +8,6 @@ Functions to train global variability module of MESMER.
 
 
 import numpy as np
-import statsmodels.api as sm
 import xarray as xr
 from packaging.version import Version
 
@@ -165,6 +164,8 @@ def train_gv_AR(params_gv, gv, max_lag, sel_crit):
         - each scenario receives equal weight during training
 
     """
+
+    import statsmodels.api as sm
 
     params_gv["max_lag"] = max_lag
     params_gv["sel_crit"] = sel_crit

--- a/mesmer/stats/localized_covariance.py
+++ b/mesmer/stats/localized_covariance.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 import xarray as xr
-from scipy.stats import multivariate_normal
 
 from mesmer.core.utils import (
     LinAlgWarning,
@@ -266,6 +265,8 @@ def _get_neg_loglikelihood(data, covariance, weights):
     -----
     The mean is assumed to be zero for all points.
     """
+
+    from scipy.stats import multivariate_normal
 
     # NOTE: 90 % of time is spent in multivariate_normal.logpdf - not much point
     # optimizing the rest


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Removes 0.5s from `import mesmer` (about 40%). Could be made even faster by moving the imports of pooch and regionmask, but that would require moving several statements.



```
# import.py
import mesmer
```

```bash
# pip install tuna

python -X importtime import.py 2> import.log
tuna import.log
```