### PR TITLE
move and rename geodist and gaspari_cohn

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -86,7 +86,7 @@ New Features
 
 - Allow passing `xr.DataArray` to ``gaspari_cohn`` (`#298 <https://github.com/MESMER-group/mesmer/pull/298>`__).
   By `Mathias Hauser`_.
-- Allow passing `xr.DataArray` to ``calc_geodist_exact`` (`#299 <https://github.com/MESMER-group/mesmer/pull/299>`__).
+- Allow passing `xr.DataArray` to ``geodist_exact`` (`#299 <https://github.com/MESMER-group/mesmer/pull/299>`__).
   By `Zeb Nicholls`_ and `Mathias Hauser`_.
 - Add ``calc_gaspari_cohn_correlation_matrices`` a function to calculate Gaspari-Cohn correlation
   matrices for a range of localisation radii (`#300 <https://github.com/MESMER-group/mesmer/pull/300>`__).

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -57,8 +57,8 @@ Gaspari-Cohn correlation matrix
 .. autosummary::
    :toctree: generated/
 
-   ~core.stats.gaspari_cohn.gaspari_cohn_correlation_matrices
-   ~core.stats.gaspari_cohn.gaspari_cohn
+   ~stats.gaspari_cohn.gaspari_cohn_correlation_matrices
+   ~stats.gaspari_cohn.gaspari_cohn
 
 Data handling
 =============

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -49,14 +49,15 @@ Smoothing
 
    ~stats.smoothing.lowess
 
-Geo-spatial
------------
+
+Gaspari-Cohn correlation matrix
+-------------------------------
 
 .. autosummary::
    :toctree: generated/
 
-   ~core.computation.calc_geodist_exact
-   ~core.computation.gaspari_cohn
+   ~core.stats.gaspari_cohn.gaspari_cohn_correlation_matrices
+   ~core.stats.gaspari_cohn.gaspari_cohn
 
 Data handling
 =============
@@ -94,3 +95,11 @@ Weighted operations: calculate global mean
    ~core.weighted.global_mean
    ~core.weighted.lat_weights
    ~core.weighted.weighted_mean
+
+Geospatial
+----------
+
+.. autosummary::
+   :toctree: generated/
+
+   ~core.geospatial.geodist_exact

--- a/mesmer/__init__.py
+++ b/mesmer/__init__.py
@@ -9,7 +9,7 @@ analyze the results.
 
 from . import calibrate_mesmer, core, create_emulations, io, utils
 from .core import _data as data
-from .core import grid, mask, weighted
+from .core import geospatial, grid, mask, weighted
 
 # "legacy" modules
 __all__ = [
@@ -23,6 +23,7 @@ __all__ = [
 __all__ += [
     "core",
     "data",
+    "geospatial",
     "grid",
     "mask",
     "weighted",

--- a/mesmer/core/geospatial.py
+++ b/mesmer/core/geospatial.py
@@ -1,0 +1,84 @@
+# MESMER, land-climate dynamics group, S.I. Seneviratne
+# Copyright (c) 2021 ETH Zurich, MESMER contributors listed in AUTHORS.
+# Licensed under the GNU General Public License v3.0 or later see LICENSE or
+# https://www.gnu.org/licenses/
+
+import numpy as np
+import pyproj
+import xarray as xr
+
+from .utils import create_equal_dim_names
+
+
+def geodist_exact(lon, lat, equal_dim_suffixes=("_i", "_j")):
+    """exact great circle distance based on WSG 84
+
+    Parameters
+    ----------
+    lon : xr.DataArray, np.ndarray
+        1D array of longitudes
+    lat : xr.DataArray, np.ndarray
+        1D array of latitudes
+    equal_dim_suffixes : tuple of str, default: ("_i", "_j")
+        Suffixes to add to the the name of ``dim`` for the geodist array (xr.DataArray
+        cannot have two dimensions with the same name).
+
+    Returns
+    -------
+    geodist : xr.DataArray, np.ndarray
+        2D array of great circle distances.
+    """
+
+    # TODO: allow Dataset (e.g. using cf_xarray)
+    if isinstance(lon, xr.Dataset) or isinstance(lat, xr.Dataset):
+        raise TypeError("Dataset is not supported, please pass a DataArray")
+
+    # handle numpy arrays
+    if not isinstance(lon, xr.DataArray) or not isinstance(lat, xr.DataArray):
+        return _geodist_exact(np.asarray(lon), np.asarray(lat))
+
+    # TODO: allow differently named lon and lat dims?
+    if lon.dims != lat.dims:
+        raise AssertionError(
+            f"lon and lat have different dims: {lon.dims} vs. {lat.dims}. Expected "
+            "equally named dimensions from a stacked array"
+        )
+
+    geodist = _geodist_exact(lon.values, lat.values)
+
+    (dim,) = lon.dims
+    dims = create_equal_dim_names(dim, equal_dim_suffixes)
+
+    # TODO: assign coords?
+    geodist = xr.DataArray(geodist, dims=dims)
+
+    return geodist
+
+
+def _geodist_exact(lon, lat):
+
+    # ensure correct shape
+    if lon.shape != lat.shape or lon.ndim != 1:
+        raise ValueError("lon and lat must be 1D arrays of the same shape")
+
+    geod = pyproj.Geod(ellps="WGS84")
+
+    n_points = lon.size
+
+    geodist = np.zeros([n_points, n_points])
+
+    # calculate only the upper right half of the triangle
+    for i in range(n_points - 1):
+
+        # need to duplicate gridpoint (required by geod.inv)
+        lt = np.repeat(lat[i : i + 1], n_points - (i + 1))
+        ln = np.repeat(lon[i : i + 1], n_points - (i + 1))
+
+        geodist[i, i + 1 :] = geod.inv(ln, lt, lon[i + 1 :], lat[i + 1 :])[2]
+
+    # convert m to km
+    geodist /= 1000
+    # fill the lower left half of the triangle (in-place)
+    geodist += np.transpose(geodist)
+
+    return geodist

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -80,7 +80,8 @@ def load_phi_gc(lon, lat, ls, cfg, L_start=1500, L_end=10000, L_interval=250):
       matrix must be positive semidefinite in train_lv())
     """
 
-    from mesmer.core.computation import calc_geodist_exact, gaspari_cohn
+    from mesmer.core.geospatial import geodist_exact
+    from mesmer.stats.gaspari_cohn import gaspari_cohn
 
     dir_aux = cfg.dir_aux
     threshold_land = cfg.threshold_land
@@ -106,7 +107,7 @@ def load_phi_gc(lon, lat, ls, cfg, L_start=1500, L_end=10000, L_interval=250):
         lon_l_vec = lon["grid"][ls["idx_grid_l"]]
         lat_l_vec = lat["grid"][ls["idx_grid_l"]]
 
-        geodist = calc_geodist_exact(lon_l_vec, lat_l_vec)
+        geodist = geodist_exact(lon_l_vec, lat_l_vec)
 
         # create auxiliary directory if does not exist already
         os.makedirs(dir_aux, exist_ok=True)

--- a/mesmer/stats/__init__.py
+++ b/mesmer/stats/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from mesmer.stats import auto_regression, linear_regression
+from mesmer.stats import auto_regression, gaspari_cohn, linear_regression

--- a/mesmer/stats/gaspari_cohn.py
+++ b/mesmer/stats/gaspari_cohn.py
@@ -4,19 +4,16 @@
 # https://www.gnu.org/licenses/
 
 import numpy as np
-import pyproj
 import xarray as xr
 
-from .utils import create_equal_dim_names
 
-
-def calc_gaspari_cohn_correlation_matrices(geodist, localisation_radii):
+def gaspari_cohn_correlation_matrices(geodist, localisation_radii):
     """Gaspari-Cohn correlation matrices for a range of localisation radii
 
     Parameters
     ----------
     geodist : xr.DataArray, np.ndarray
-        2D array of great circle distances. Calculated from e.g. ``calc_geodist_exact``.
+        2D array of great circle distances. Calculated from e.g. ``geodist_exact``.
     localisation_radii : iterable of float
         Localisation radii to test (in km)
 
@@ -32,7 +29,7 @@ def calc_gaspari_cohn_correlation_matrices(geodist, localisation_radii):
 
     See Also
     --------
-    gaspari_cohn, calc_geodist_exact
+    gaspari_cohn, geodist_exact
 
     """
 
@@ -120,77 +117,3 @@ def _gaspari_cohn_np(r):
     )
 
     return out
-
-
-def calc_geodist_exact(lon, lat, equal_dim_suffixes=("_i", "_j")):
-    """exact great circle distance based on WSG 84
-
-    Parameters
-    ----------
-    lon : xr.DataArray, np.ndarray
-        1D array of longitudes
-    lat : xr.DataArray, np.ndarray
-        1D array of latitudes
-    equal_dim_suffixes : tuple of str, default: ("_i", "_j")
-        Suffixes to add to the the name of ``dim`` for the geodist array (xr.DataArray
-        cannot have two dimensions with the same name).
-
-    Returns
-    -------
-    geodist : xr.DataArray, np.ndarray
-        2D array of great circle distances.
-    """
-
-    # TODO: allow Dataset (e.g. using cf_xarray)
-    if isinstance(lon, xr.Dataset) or isinstance(lat, xr.Dataset):
-        raise TypeError("Dataset is not supported, please pass a DataArray")
-
-    # handle numpy arrays
-    if not isinstance(lon, xr.DataArray) or not isinstance(lat, xr.DataArray):
-        return _calc_geodist_exact(np.asarray(lon), np.asarray(lat))
-
-    # TODO: allow differently named lon and lat dims?
-    if lon.dims != lat.dims:
-        raise AssertionError(
-            f"lon and lat have different dims: {lon.dims} vs. {lat.dims}. Expected "
-            "equally named dimensions from a stacked array"
-        )
-
-    geodist = _calc_geodist_exact(lon.values, lat.values)
-
-    (dim,) = lon.dims
-    dims = create_equal_dim_names(dim, equal_dim_suffixes)
-
-    # TODO: assign coords?
-    geodist = xr.DataArray(geodist, dims=dims)
-
-    return geodist
-
-
-def _calc_geodist_exact(lon, lat):
-
-    # ensure correct shape
-    if lon.shape != lat.shape or lon.ndim != 1:
-        raise ValueError("lon and lat must be 1D arrays of the same shape")
-
-    geod = pyproj.Geod(ellps="WGS84")
-
-    n_points = lon.size
-
-    geodist = np.zeros([n_points, n_points])
-
-    # calculate only the upper right half of the triangle
-    for i in range(n_points - 1):
-
-        # need to duplicate gridpoint (required by geod.inv)
-        lt = np.repeat(lat[i : i + 1], n_points - (i + 1))
-        ln = np.repeat(lon[i : i + 1], n_points - (i + 1))
-
-        geodist[i, i + 1 :] = geod.inv(ln, lt, lon[i + 1 :], lat[i + 1 :])[2]
-
-    # convert m to km
-    geodist /= 1000
-    # fill the lower left half of the triangle (in-place)
-    geodist += np.transpose(geodist)
-
-    return geodist

--- a/tests/unit/test_computation.py
+++ b/tests/unit/test_computation.py
@@ -2,11 +2,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from mesmer.core.geospatial import (
-    calc_gaspari_cohn_correlation_matrices,
-    geodist_exact,
-    gaspari_cohn,
-)
+from mesmer.core.geospatial import geodist_exact
+from mesmer.stats.gaspari_cohn import gaspari_cohn, gaspari_cohn_correlation_matrices
 from mesmer.testing import assert_dict_allclose
 
 
@@ -169,7 +166,7 @@ def test_gaspari_cohn_correlation_matrices(localisation_radii, as_dataarray):
 
     geodist = geodist_exact(lon, lat)
 
-    result = calc_gaspari_cohn_correlation_matrices(geodist, localisation_radii)
+    result = gaspari_cohn_correlation_matrices(geodist, localisation_radii)
 
     expected = {lr: gaspari_cohn(geodist / lr) for lr in localisation_radii}
 

--- a/tests/unit/test_computation.py
+++ b/tests/unit/test_computation.py
@@ -2,9 +2,9 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from mesmer.core.computation import (
+from mesmer.core.geospatial import (
     calc_gaspari_cohn_correlation_matrices,
-    calc_geodist_exact,
+    geodist_exact,
     gaspari_cohn,
 )
 from mesmer.testing import assert_dict_allclose
@@ -64,13 +64,13 @@ def test_calc_geodist_dataset_error():
     da = xr.DataArray()
 
     with pytest.raises(TypeError, match="Dataset is not supported"):
-        calc_geodist_exact(ds, ds)
+        geodist_exact(ds, ds)
 
     with pytest.raises(TypeError, match="Dataset is not supported"):
-        calc_geodist_exact(ds, da)
+        geodist_exact(ds, da)
 
     with pytest.raises(TypeError, match="Dataset is not supported"):
-        calc_geodist_exact(da, ds)
+        geodist_exact(da, ds)
 
 
 def test_calc_geodist_dataarray_equal_dims_required():
@@ -79,7 +79,7 @@ def test_calc_geodist_dataarray_equal_dims_required():
     lat = xr.DataArray([0], dims="lat")
 
     with pytest.raises(AssertionError, match="lon and lat have different dims"):
-        calc_geodist_exact(lon, lat)
+        geodist_exact(lon, lat)
 
 
 @pytest.mark.parametrize("as_dataarray", [True, False])
@@ -91,7 +91,7 @@ def test_calc_geodist_not_same_shape_error(as_dataarray):
         lon, lat = xr.DataArray(lon), xr.DataArray(lat)
 
     with pytest.raises(ValueError, match="lon and lat must be 1D arrays"):
-        calc_geodist_exact(lon, lat)
+        geodist_exact(lon, lat)
 
 
 @pytest.mark.parametrize("as_dataarray", [True, False])
@@ -103,12 +103,12 @@ def test_calc_geodist_not_1D_error(as_dataarray):
         lon, lat = xr.DataArray(lon), xr.DataArray(lat)
 
     with pytest.raises(ValueError, match=".*of the same shape"):
-        calc_geodist_exact(lon, lat)
+        geodist_exact(lon, lat)
 
 
 @pytest.mark.parametrize("lon", [[0, 0], [0, 360], [1, 361], [180, -180]])
 @pytest.mark.parametrize("as_dataarray", [True, False])
-def test_calc_geodist_exact_equal(lon, as_dataarray):
+def test_geodist_exact_equal(lon, as_dataarray):
     """test points with distance 0"""
 
     expected = np.array([[0, 0], [0, 0]])
@@ -118,14 +118,14 @@ def test_calc_geodist_exact_equal(lon, as_dataarray):
     if as_dataarray:
         lon = xr.DataArray(lon)
 
-    result = calc_geodist_exact(lon, lat)
+    result = geodist_exact(lon, lat)
     np.testing.assert_equal(result, expected)
     # when passing only one DataArray it's also returned as np.array
     assert isinstance(result, np.ndarray)
 
 
 @pytest.mark.parametrize("as_dataarray", [True, False])
-def test_calc_geodist_exact(as_dataarray):
+def test_geodist_exact(as_dataarray):
     """test some random points"""
 
     lon = [-180, 0, 3]
@@ -135,7 +135,7 @@ def test_calc_geodist_exact(as_dataarray):
         lon = xr.DataArray(lon, dims="gp", coords={"lon": ("gp", lon)})
         lat = xr.DataArray(lat, dims="gp", coords={"lat": ("gp", lat)})
 
-    result = calc_geodist_exact(lon, lat)
+    result = geodist_exact(lon, lat)
     expected = np.array(
         [
             [0.0, 20003.93145863, 19366.51816487],
@@ -167,7 +167,7 @@ def test_gaspari_cohn_correlation_matrices(localisation_radii, as_dataarray):
         lon = xr.DataArray(lon, dims="gridpoint")
         lat = xr.DataArray(lat, dims="gridpoint")
 
-    geodist = calc_geodist_exact(lon, lat)
+    geodist = geodist_exact(lon, lat)
 
     result = calc_gaspari_cohn_correlation_matrices(geodist, localisation_radii)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

This renames the geodist and gaspari_cohn functions. I am still not sure if the names are good :slightly_frowning_face: 
