### PR TITLE
lowess: allow to pool along dim

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,11 +54,14 @@ New Features
      (`#224 <https://github.com/MESMER-group/mesmer/pull/224>`__).
      By `Mathias Hauser`_.
 
-- Other refactorings:
+- Update LOWESS smoothing:
    - Extract the LOWESS smoothing for xarray objects: :py:func:`mesmer.stats.smoothing.lowess`.
      (`#193 <https://github.com/MESMER-group/mesmer/pull/193>`_,
      `#283 <https://github.com/MESMER-group/mesmer/pull/283>`_, and
      `#285 <https://github.com/MESMER-group/mesmer/pull/285>`_).
+     By `Mathias Hauser`_.
+   - Allow to pool data along a dimension to estimate the LOWESS smoothing.
+     (`#331 <https://github.com/MESMER-group/mesmer/pull/331>`_).
      By `Mathias Hauser`_.
 
 - Added helper functions to process xarray-based model data:

--- a/mesmer/stats/smoothing.py
+++ b/mesmer/stats/smoothing.py
@@ -91,9 +91,6 @@ def lowess(
 
     if combine_dim is not None:
         # remove non-dimension coords along combine_dims
-
-        print(data[combine_dim].coords.keys())
-
         data = data.drop_vars(data[combine_dim].coords.keys())
 
         # need to broadcast and stack due to the datetime shenanigans above

--- a/tests/unit/test_smoothing.py
+++ b/tests/unit/test_smoothing.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
@@ -145,3 +146,56 @@ def test_lowess_2D():
     _check_dataarray_form(
         result, "result", ndim=2, required_dims=("time", "cells"), shape=data.shape
     )
+
+
+def test_lowess_2D_combine_dim():
+
+    data = trend_data_2D()
+
+    arr = np.concatenate(np.vsplit(data.values, 6), 1).squeeze()
+    x = np.concatenate([data.time.values.tolist()] * 6)
+
+    expected = lowess(arr, x, xvals=data.time.values, frac=0.3, it=0)
+    expected = xr.DataArray(expected, coords={"time": data.time.values})
+
+    result = mesmer.stats.smoothing.lowess(data, "time", combine_dim="cells", frac=0.3)
+
+    xr.testing.assert_allclose(expected, result)
+
+    # numpy datetime
+    time = pd.date_range("2000-01-01", periods=30)
+    data = data.assign_coords(time=time)
+
+    result = mesmer.stats.smoothing.lowess(
+        data, "time", combine_dim="cells", frac=0.3, use_coords=False
+    )
+    expected = expected.assign_coords(time=time)
+
+    xr.testing.assert_allclose(expected, result)
+
+    # TODO: remove check once we drop python 3.7
+    if Version(xr.__version__) >= Version("21.0"):
+
+        # cftime datetime
+        time = xr.date_range("2000-01-01", periods=30, calendar="noleap")
+        data = data.assign_coords(time=time)
+
+        result = mesmer.stats.smoothing.lowess(
+            data, "time", combine_dim="cells", frac=0.3, use_coords=False
+        )
+        expected = expected.assign_coords(time=time)
+
+        xr.testing.assert_allclose(expected, result)
+
+
+def test_lowess_2D_combine_dim_it():
+    # interestingly, the result is the same for it=0
+
+    data = trend_data_2D()
+
+    r1 = mesmer.stats.smoothing.lowess(data.mean("cells"), "time", frac=0.3)
+    r2 = mesmer.stats.smoothing.lowess(data, "time", combine_dim="cells", frac=0.3)
+    r3 = mesmer.stats.smoothing.lowess(data, "time", frac=0.3).mean("cells")
+
+    xr.testing.assert_allclose(r1, r2)
+    xr.testing.assert_allclose(r1, r3)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`


Add `combine_dim` argument to `lowess` so data can be pooled to estimate the lowess smoothing. This will probably never be used, but I only realized this once I finished implementing it...