### PR TITLE
linear regression: remove all dim coords on target

### DIFF
--- a/mesmer/stats/linear_regression.py
+++ b/mesmer/stats/linear_regression.py
@@ -246,15 +246,15 @@ def _fit_linear_regression_xr(
         fit_intercept,
     )
 
+    # remove (non-dimension) coords from target (#332, #333)
+    target = target.drop_vars(target[dim].coords)
+
     # split `out` into individual DataArrays
     keys = ["intercept"] + list(predictors)
-    dataarrays = {key: (target_dim, out[:, i]) for i, key in enumerate(keys)}
-    out = xr.Dataset(dataarrays, coords=target.coords)
+    data_vars = {key: (target_dim, out[:, i]) for i, key in enumerate(keys)}
+    out = xr.Dataset(data_vars, coords=target.coords)
 
     out["fit_intercept"] = fit_intercept
-
-    if dim in out.coords:
-        out = out.drop_vars(dim)
 
     if weights is not None:
         out["weights"] = weights


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #332 
 - [x] Closes #333
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

I already fixed this in #142, but only partly. (1) The coords were removed after creating the dataset - this could lead to the dataarray and one coord having the same name. (2) non-dimension coords were not removed...
