### PR TITLE
check_dataarray_form: can pass several ndims

### DIFF
--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -166,7 +166,7 @@ def _check_dataarray_form(
     name : str, default: 'obj'
         Name to use in error messages.
     ndim, int, optional
-        Number of required dimensions
+        Number of required dimensions, can be a tuple of int if several are possible.
     required_dims: str, set of str, optional
         Names of dims that are required for obj
     shape : tuple of ints, default: None
@@ -184,8 +184,11 @@ def _check_dataarray_form(
     if not isinstance(obj, xr.DataArray):
         raise TypeError(f"Expected {name} to be an xr.DataArray, got {type(obj)}")
 
-    if ndim is not None and ndim != obj.ndim:
-        raise ValueError(f"{name} should be {ndim}-dimensional, but is {obj.ndim}D")
+    ndim = (ndim,) if np.isscalar(ndim) else ndim
+    if ndim is not None and obj.ndim not in ndim:
+        *a, b = map(lambda x: f"{x}D", ndim)
+        ndim = (a and ", ".join(a) + " or " or "") + b
+        raise ValueError(f"{name} should be {ndim}, but is {obj.ndim}D")
 
     if required_dims - set(obj.dims):
         missing_dims = " ,".join(required_dims - set(obj.dims))

--- a/tests/unit/test_linear_regression.py
+++ b/tests/unit/test_linear_regression.py
@@ -170,7 +170,7 @@ def test_linear_regression_errors(lr_method_or_function):
     test_wrong_type(pred0, pred1, tgt, xr.Dataset(), name="weights")
 
     def test_wrong_shape(pred0, pred1, tgt, weights, name, ndim):
-        with pytest.raises(ValueError, match=f"{name} should be {ndim}-dimensional"):
+        with pytest.raises(ValueError, match=f"{name} should be {ndim}D"):
             lr_method_or_function(
                 {"pred0": pred0, "pred1": pred1}, tgt, dim="time", weights=weights
             )

--- a/tests/unit/test_smoothing.py
+++ b/tests/unit/test_smoothing.py
@@ -16,7 +16,7 @@ def test_lowess_errors():
     with pytest.raises(ValueError, match="Can only pass a single dimension."):
         mesmer.stats.smoothing.lowess(data, ("lat", "lon"), frac=0.3)
 
-    with pytest.raises(ValueError, match="data should be 1-dimensional"):
+    with pytest.raises(ValueError, match="data should be 1D"):
         mesmer.stats.smoothing.lowess(data.to_dataset(), "data", frac=0.3)
 
     with pytest.raises(ValueError, match="Exactly one of ``n_steps`` and ``frac``"):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -139,14 +139,25 @@ def test_check_dataarray_form_ndim(ndim):
 
     da = xr.DataArray(np.ones((2, 2)))
 
-    with pytest.raises(ValueError, match=f"obj should be {ndim}-dimensional"):
+    with pytest.raises(ValueError, match=f"obj should be {ndim}D"):
         mesmer.core.utils._check_dataarray_form(da, ndim=ndim)
 
-    with pytest.raises(ValueError, match=f"test should be {ndim}-dimensional"):
+    with pytest.raises(ValueError, match=f"test should be {ndim}D"):
         mesmer.core.utils._check_dataarray_form(da, ndim=ndim, name="test")
 
     # no error
     mesmer.core.utils._check_dataarray_form(da, ndim=2)
+
+
+def test_check_dataarray_form_ndim_several():
+
+    da = xr.DataArray(np.ones((2, 2)))
+
+    with pytest.raises(ValueError, match="obj should be 1D or 3D"):
+        mesmer.core.utils._check_dataarray_form(da, ndim=(1, 3))
+
+    with pytest.raises(ValueError, match="test should be 0D, 1D or 3D"):
+        mesmer.core.utils._check_dataarray_form(da, ndim=(0, 1, 3), name="test")
 
 
 @pytest.mark.parametrize("required_dims", ("foo", ["foo"], ["foo", "bar"]))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`


Allows the following:
```python
mesmer.core.utils._check_dataarray_form(da, ndim=(1, 2))
```