### PR TITLE
ensure aod data is not altered in-place

### DIFF
--- a/mesmer/core/_data.py
+++ b/mesmer/core/_data.py
@@ -25,7 +25,7 @@ def load_stratospheric_aerosol_optical_depth_obs(version="2022", resample=True):
 
     aod = _load_aod_obs(version=version, resample=resample)
 
-    return aod
+    return aod.copy()
 
 
 # use an inner function as @cache does not nicely preserve the signature

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -18,6 +18,20 @@ def test_load_stratospheric_aerosol_optical_depth_data():
     np.testing.assert_allclose(0.0, aod[-1])
 
 
+def test_load_stratospheric_aerosol_optical_depth_data_not_changed_inplace():
+
+    aod = load_stratospheric_aerosol_optical_depth_obs(version="2022", resample=True)
+
+    aod.loc[{"time": slice("1900", "2000")}] = 0.25
+
+    aod_orig = load_stratospheric_aerosol_optical_depth_obs(
+        version="2022", resample=True
+    )
+
+    assert aod is not aod_orig
+    assert not aod.equals(aod_orig)
+
+
 def test_load_stratospheric_aerosol_optical_depth_data_no_resample():
 
     aod = load_stratospheric_aerosol_optical_depth_obs(version="2022", resample=False)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`
