### PR TITLE
make AR functions public

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,20 +28,20 @@ New Features
      By `Mathias Hauser`_.
 
 - Extracted statistical functionality for auto regression:
-   - Add ``mesmer.stats.auto_regression._fit_auto_regression_xr``: xarray wrapper to fit an
+   - Add ``mesmer.stats.auto_regression.fit_auto_regression``: xarray wrapper to fit an
      auto regression model (`#139 <https://github.com/MESMER-group/mesmer/pull/139>`_).
      By `Mathias Hauser`_.
-   - Have ``mesmer.stats.auto_regression._fit_auto_regression_xr`` return the variance instead
+   - Have ``mesmer.stats.auto_regression.fit_auto_regression`` return the variance instead
      of the standard deviation (
      `#306 <https://github.com/MESMER-group/mesmer/issues/306>`_
      `#318 <https://github.com/MESMER-group/mesmer/pull/318>`_). By `Mathias Hauser`_.
-   - Add ``_draw_auto_regression_correlated`` and ``_draw_auto_regression_uncorrelated``: to draw samples of a
+   - Add ``draw_auto_regression_correlated`` and ``draw_auto_regression_uncorrelated``: to draw samples of a
      (spatially-)correlated and uncorrelated auto regression model (
      `#322 <https://github.com/MESMER-group/mesmer/pull/322>`_,
      `#161 <https://github.com/MESMER-group/mesmer/pull/161>`_ and
      `#313 <https://github.com/MESMER-group/mesmer/pull/313>`_).
      By `Mathias Hauser`_.
-   - Add ``mesmer.stats.auto_regression._select_ar_order_xr`` to select the order of an
+   - Add ``mesmer.stats.auto_regression.select_ar_order`` to select the order of an
      auto regressive model
      (`#176 <https://github.com/MESMER-group/mesmer/pull/176>`_).
      By `Mathias Hauser`_.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -28,9 +28,10 @@ Auto regression
 .. autosummary::
    :toctree: generated/
 
-   ~stats.auto_regression._select_ar_order_xr
-   ~stats.auto_regression._fit_auto_regression_xr
-   ~stats.auto_regression._draw_auto_regression_correlated_np
+   ~stats.auto_regression.select_ar_order
+   ~stats.auto_regression.fit_auto_regression
+   ~stats.auto_regression.draw_auto_regression_uncorrelated
+   ~stats.auto_regression.draw_auto_regression_correlated
 
 Localized covariance
 --------------------

--- a/mesmer/calibrate_mesmer/train_gv.py
+++ b/mesmer/calibrate_mesmer/train_gv.py
@@ -12,7 +12,7 @@ import xarray as xr
 from packaging.version import Version
 
 from mesmer.io.save_mesmer_bundle import save_mesmer_data
-from mesmer.stats.auto_regression import _fit_auto_regression_xr, _select_ar_order_xr
+from mesmer.stats.auto_regression import fit_auto_regression, select_ar_order
 
 
 def train_gv(gv, targ, esm, cfg, save_params=True, **kwargs):
@@ -182,7 +182,7 @@ def train_gv_AR(params_gv, gv, max_lag, sel_crit):
         # create temporary DataArray
         data = xr.DataArray(gv[scen], dims=["run", "time"])
 
-        AR_order = _select_ar_order_xr(data, dim="time", maxlag=max_lag, ic=sel_crit)
+        AR_order = select_ar_order(data, dim="time", maxlag=max_lag, ic=sel_crit)
 
         # median over all ensemble members ("nearest" ensures an 'existing' lag is selected)
         AR_order = AR_order.quantile(q=0.5, **{method: "nearest"})
@@ -200,7 +200,7 @@ def train_gv_AR(params_gv, gv, max_lag, sel_crit):
         # create temporary DataArray
         data = xr.DataArray(data, dims=("run", "time"))
 
-        params = _fit_auto_regression_xr(data, dim="time", lags=AR_order_sel)
+        params = fit_auto_regression(data, dim="time", lags=AR_order_sel)
         # BUG/ TODO: we wrongfully average over the standard deviation
         # see https://github.com/MESMER-group/mesmer/issues/307
         params["standard_deviation"] = np.sqrt(params.variance)

--- a/mesmer/calibrate_mesmer/train_lv.py
+++ b/mesmer/calibrate_mesmer/train_lv.py
@@ -10,7 +10,7 @@ import numpy as np
 import xarray as xr
 
 from mesmer.io.save_mesmer_bundle import save_mesmer_data
-from mesmer.stats.auto_regression import _fit_auto_regression_xr
+from mesmer.stats.auto_regression import fit_auto_regression
 from mesmer.stats.localized_covariance import (
     adjust_covariance_ar1,
     find_localized_empirical_covariance,
@@ -236,7 +236,7 @@ def train_lv_AR1_sci(params_lv, targs, y, wgt_scen_eq, aux, cfg):
             # create temporary DataArray
             data = xr.DataArray(data, dims=("run", "time", "cell"))
 
-            params = _fit_auto_regression_xr(data, dim="time", lags=1)
+            params = fit_auto_regression(data, dim="time", lags=1)
             # BUG/ TODO: we wrongfully average over the standard deviation
             # see https://github.com/MESMER-group/mesmer/issues/307
             params["standard_deviation"] = np.sqrt(params.variance)

--- a/mesmer/create_emulations/create_emus_gv.py
+++ b/mesmer/create_emulations/create_emus_gv.py
@@ -10,7 +10,7 @@ import numpy as np
 import xarray as xr
 
 from mesmer.io.save_mesmer_bundle import save_mesmer_data
-from mesmer.stats.auto_regression import _draw_auto_regression_uncorrelated
+from mesmer.stats.auto_regression import draw_auto_regression_uncorrelated
 
 
 def create_emus_gv(params_gv, preds_gv, cfg, save_emus=True):
@@ -179,7 +179,7 @@ def create_emus_gv_AR(params_gv, nr_emus_v, nr_ts_emus_v, seed):
         {"intercept": intercept, "coeffs": coeffs, "variance": variance}
     )
 
-    emus_gv = _draw_auto_regression_uncorrelated(
+    emus_gv = draw_auto_regression_uncorrelated(
         ar_params,
         time=nr_ts_emus_v,
         realisation=nr_emus_v,

--- a/mesmer/create_emulations/create_emus_lv.py
+++ b/mesmer/create_emulations/create_emus_lv.py
@@ -13,7 +13,7 @@ import xarray as xr
 import mesmer.stats
 from mesmer.create_emulations.utils import _gather_lr_params, _gather_lr_preds
 from mesmer.io.save_mesmer_bundle import save_mesmer_data
-from mesmer.stats.auto_regression import _draw_auto_regression_correlated
+from mesmer.stats.auto_regression import draw_auto_regression_correlated
 
 
 def create_emus_lv(params_lv, preds_lv, cfg, save_emus=True, submethod=""):
@@ -196,7 +196,7 @@ def create_emus_lv_AR1_sci(emus_lv, params_lv, preds_lv, cfg):
             dims = ("gridpoint_i", "gridpoint_j")
             covariance = xr.DataArray(params_lv["loc_ecov_AR1_innovs"][targ], dims=dims)
 
-            emus_ar = _draw_auto_regression_correlated(
+            emus_ar = draw_auto_regression_correlated(
                 ar_params,
                 covariance,
                 time=nr_ts_emus_stoch_v,

--- a/mesmer/stats/auto_regression.py
+++ b/mesmer/stats/auto_regression.py
@@ -5,7 +5,7 @@ import xarray as xr
 from mesmer.core.utils import _check_dataarray_form, _check_dataset_form
 
 
-def _select_ar_order_xr(data, dim, maxlag, ic="bic"):
+def select_ar_order(data, dim, maxlag, ic="bic"):
     """Select the order of an autoregressive process - xarray wrapper
 
     Parameters
@@ -107,7 +107,7 @@ def _get_size_and_coord_dict(coords_or_size, dim, name):
     return size, coord_dict
 
 
-def _draw_auto_regression_uncorrelated(
+def draw_auto_regression_uncorrelated(
     ar_params,
     *,
     time,
@@ -190,7 +190,7 @@ def _draw_auto_regression_uncorrelated(
     return result
 
 
-def _draw_auto_regression_correlated(
+def draw_auto_regression_correlated(
     ar_params,
     covariance,
     *,
@@ -395,7 +395,7 @@ def _draw_auto_regression_correlated_np(
     return out[:, buffer:, :]
 
 
-def _fit_auto_regression_xr(data, dim, lags):
+def fit_auto_regression(data, dim, lags):
     """
     fit an auto regression - xarray wrapper
 

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -10,22 +10,22 @@ from mesmer.core.utils import _check_dataarray_form, _check_dataset_form
 from mesmer.testing import trend_data_1D, trend_data_2D, trend_data_3D
 
 
-def test_select_ar_order_xr_1d():
+def test_select_ar_order_1d():
 
     data = trend_data_1D()
 
-    result = mesmer.stats.auto_regression._select_ar_order_xr(data, "time", 4)
+    result = mesmer.stats.auto_regression.select_ar_order(data, "time", 4)
 
     _check_dataarray_form(result, "selected_ar_order", ndim=0, shape=())
 
 
 @pytest.mark.parametrize("n_lon", [1, 2])
 @pytest.mark.parametrize("n_lat", [3, 4])
-def test_select_ar_order_xr_3d(n_lon, n_lat):
+def test_select_ar_order_3d(n_lon, n_lat):
 
     data = trend_data_3D(n_lat=n_lat, n_lon=n_lon)
 
-    result = mesmer.stats.auto_regression._select_ar_order_xr(data, "time", 1)
+    result = mesmer.stats.auto_regression.select_ar_order(data, "time", 1)
 
     _check_dataarray_form(
         result,
@@ -36,21 +36,21 @@ def test_select_ar_order_xr_3d(n_lon, n_lat):
     )
 
 
-def test_select_ar_order_xr_dim():
+def test_select_ar_order_dim():
 
     data = trend_data_3D(n_timesteps=4, n_lon=5)
-    result = mesmer.stats.auto_regression._select_ar_order_xr(data, "lon", 1)
+    result = mesmer.stats.auto_regression.select_ar_order(data, "lon", 1)
 
     _check_dataarray_form(
         result, "selected_ar_order", ndim=2, required_dims={"time", "lat"}, shape=(4, 3)
     )
 
 
-def test_select_ar_order_xr():
+def test_select_ar_order():
 
     data = trend_data_2D()
 
-    result = mesmer.stats.auto_regression._select_ar_order_xr(data, "time", 4)
+    result = mesmer.stats.auto_regression.select_ar_order(data, "time", 4)
 
     coords = data.drop_vars("time").coords
 
@@ -119,7 +119,7 @@ def test_draw_auto_regression_uncorrelated_wrong_input(ar_params_1D, drop):
         ValueError, match=f"ar_params is missing the required data_vars: {drop}"
     ):
 
-        mesmer.stats.auto_regression._draw_auto_regression_uncorrelated(
+        mesmer.stats.auto_regression.draw_auto_regression_uncorrelated(
             ar_params,
             time=1,
             realisation=1,
@@ -135,7 +135,7 @@ def test_draw_auto_regression_uncorrelated_2D_errors(ar_params_2D):
         match="``_draw_auto_regression_uncorrelated`` can currently only handle single points",
     ):
 
-        mesmer.stats.auto_regression._draw_auto_regression_uncorrelated(
+        mesmer.stats.auto_regression.draw_auto_regression_uncorrelated(
             ar_params_2D,
             time=1,
             realisation=1,
@@ -152,7 +152,7 @@ def test_draw_auto_regression_uncorrelated(
     ar_params_1D, time, realization, time_dim, realization_dim
 ):
 
-    result = mesmer.stats.auto_regression._draw_auto_regression_uncorrelated(
+    result = mesmer.stats.auto_regression.draw_auto_regression_uncorrelated(
         ar_params_1D,
         time=time,
         realisation=realization,
@@ -185,7 +185,7 @@ def test_draw_auto_regression_uncorrelated_wrong_coords(
         TypeError,
         match=f"expected '{dim}' to be an `int`, pandas or xarray Index or a `DataArray`",
     ):
-        mesmer.stats.auto_regression._draw_auto_regression_uncorrelated(
+        mesmer.stats.auto_regression.draw_auto_regression_uncorrelated(
             ar_params_1D,
             **coords,
             seed=0,
@@ -201,7 +201,7 @@ def test_draw_auto_regression_uncorrelated_wrong_coords_2D(ar_params_1D, dim):
     coords[dim] = xr.DataArray([[1, 2]])
 
     with pytest.raises(ValueError, match="Coords must be 1D but have 2 dimensions"):
-        mesmer.stats.auto_regression._draw_auto_regression_uncorrelated(
+        mesmer.stats.auto_regression.draw_auto_regression_uncorrelated(
             ar_params_1D,
             **coords,
             seed=0,
@@ -217,7 +217,7 @@ def test_draw_auto_regression_uncorrelated_coords(ar_params_1D, dim, coords):
 
     coords_[dim] = coords
 
-    result = mesmer.stats.auto_regression._draw_auto_regression_uncorrelated(
+    result = mesmer.stats.auto_regression.draw_auto_regression_uncorrelated(
         ar_params_1D,
         **coords_,
         seed=0,
@@ -237,7 +237,7 @@ def test_draw_auto_regression_correlated_wrong_input(ar_params_2D, covariance, d
         ValueError, match=f"ar_params is missing the required data_vars: {drop}"
     ):
 
-        mesmer.stats.auto_regression._draw_auto_regression_correlated(
+        mesmer.stats.auto_regression.draw_auto_regression_correlated(
             ar_params,
             covariance,
             time=1,
@@ -255,7 +255,7 @@ def test_draw_auto_regression_correlated(
     ar_params_2D, covariance, time, realization, time_dim, realization_dim
 ):
 
-    result = mesmer.stats.auto_regression._draw_auto_regression_correlated(
+    result = mesmer.stats.auto_regression.draw_auto_regression_correlated(
         ar_params_2D,
         covariance,
         time=time,
@@ -291,7 +291,7 @@ def test_draw_auto_regression_correlated_wrong_coords(
         TypeError,
         match=f"expected '{dim}' to be an `int`, pandas or xarray Index or a `DataArray`",
     ):
-        mesmer.stats.auto_regression._draw_auto_regression_correlated(
+        mesmer.stats.auto_regression.draw_auto_regression_correlated(
             ar_params_2D,
             covariance,
             **coords,
@@ -308,7 +308,7 @@ def test_draw_auto_regression_correlated_wrong_coords_2D(ar_params_2D, covarianc
     coords[dim] = xr.DataArray([[1, 2]])
 
     with pytest.raises(ValueError, match="Coords must be 1D but have 2 dimensions"):
-        mesmer.stats.auto_regression._draw_auto_regression_correlated(
+        mesmer.stats.auto_regression.draw_auto_regression_correlated(
             ar_params_2D,
             covariance,
             **coords,
@@ -325,7 +325,7 @@ def test_draw_auto_regression_correlated_coords(ar_params_2D, covariance, dim, c
 
     coords_[dim] = coords
 
-    result = mesmer.stats.auto_regression._draw_auto_regression_correlated(
+    result = mesmer.stats.auto_regression.draw_auto_regression_correlated(
         ar_params_2D,
         covariance,
         **coords_,
@@ -448,7 +448,7 @@ def test_draw_auto_regression_random():
 def test_fit_auto_regression_xr_errors(obj):
 
     with pytest.raises(TypeError, match="Expected a `xr.DataArray`"):
-        mesmer.stats.auto_regression._fit_auto_regression_xr(obj, "dim", lags=1)
+        mesmer.stats.auto_regression.fit_auto_regression(obj, "dim", lags=1)
 
 
 def test_fit_auto_regression_xr_1D_values():
@@ -456,7 +456,7 @@ def test_fit_auto_regression_xr_1D_values():
     # statsmodels.tsa.ar_model.AutoReg
 
     data = trend_data_1D()
-    result = mesmer.stats.auto_regression._fit_auto_regression_xr(data, "time", lags=1)
+    result = mesmer.stats.auto_regression.fit_auto_regression(data, "time", lags=1)
 
     expected = xr.Dataset(
         {
@@ -475,7 +475,7 @@ def test_fit_auto_regression_xr_1D_values_lags():
     # statsmodels.tsa.ar_model.AutoReg
 
     data = trend_data_1D()
-    result = mesmer.stats.auto_regression._fit_auto_regression_xr(
+    result = mesmer.stats.auto_regression.fit_auto_regression(
         data, "time", lags=[2]
     )
 
@@ -495,7 +495,7 @@ def test_fit_auto_regression_xr_1D_values_lags():
 def test_fit_auto_regression_xr_1D(lags):
 
     data = trend_data_1D()
-    res = mesmer.stats.auto_regression._fit_auto_regression_xr(data, "time", lags=lags)
+    res = mesmer.stats.auto_regression.fit_auto_regression(data, "time", lags=lags)
 
     lags = lags if not np.ndim(lags) == 0 else np.arange(lags) + 1
 
@@ -520,7 +520,7 @@ def test_fit_auto_regression_xr_1D(lags):
 def test_fit_auto_regression_xr_2D(lags):
 
     data = trend_data_2D()
-    res = mesmer.stats.auto_regression._fit_auto_regression_xr(data, "time", lags=lags)
+    res = mesmer.stats.auto_regression.fit_auto_regression(data, "time", lags=lags)
 
     (n_cells,) = data.cells.shape
 

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -475,9 +475,7 @@ def test_fit_auto_regression_xr_1D_values_lags():
     # statsmodels.tsa.ar_model.AutoReg
 
     data = trend_data_1D()
-    result = mesmer.stats.auto_regression.fit_auto_regression(
-        data, "time", lags=[2]
-    )
+    result = mesmer.stats.auto_regression.fit_auto_regression(data, "time", lags=[2])
 
     expected = xr.Dataset(
         {


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

Rename the auto regression functions to a public name. I don't particularly like that I have a different approach for the linear regression and the auto regression - but I don't know which is better, so keep this for now.