### PR TITLE
lin reg: add exclude to predict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,9 @@ New Features
    - Allow to pass 1-dimensional targets to :py:meth:`mesmer.stats.LinearRegression.fit`
      (`#221 <https://github.com/MESMER-group/mesmer/pull/221>`_).
      By `Mathias Hauser`_.
+   - Allow to `exclude` predictor variables in :py:meth:`mesmer.stats.LinearRegression.predict`
+     (`#354 <https://github.com/MESMER-group/mesmer/pull/354>`_).
+     By `Mathias Hauser`_.
    - Fixed two bugs related to (non-dimension) coordinates (
      `#332 <https://github.com/MESMER-group/mesmer/issues/332>`_,
      `#333 <https://github.com/MESMER-group/mesmer/issues/333>`_ and

--- a/mesmer/stats/_linear_regression.py
+++ b/mesmer/stats/_linear_regression.py
@@ -63,7 +63,8 @@ class LinearRegression:
         predictors : dict of xr.DataArray
             A dict of DataArray objects used as predictors. Must be 1D and contain `dim`.
         exclude : str or set of str, default: None
-            Set of variables to exclude in the prediction.
+            Set of variables to exclude in the prediction. May include ``"intercept"``
+            to initialize the prediction with 0.
 
         Returns
         -------
@@ -82,7 +83,11 @@ class LinearRegression:
         if required_predictors != available_predictors:
             raise ValueError("Missing or superfluous predictors.")
 
-        prediction = params.intercept
+        if "intercept" in exclude:
+            prediction = xr.zeros_like(params.intercept)
+        else:
+            prediction = params.intercept
+
         for key in required_predictors:
             prediction = prediction + predictors[key] * params[key]
 

--- a/mesmer/stats/_linear_regression.py
+++ b/mesmer/stats/_linear_regression.py
@@ -3,7 +3,7 @@ from typing import Mapping, Optional
 import numpy as np
 import xarray as xr
 
-from mesmer.core.utils import _check_dataarray_form, _check_dataset_form
+from mesmer.core.utils import _check_dataarray_form, _check_dataset_form, _to_set
 
 
 class LinearRegression:
@@ -53,6 +53,7 @@ class LinearRegression:
     def predict(
         self,
         predictors: Mapping[str, xr.DataArray],
+        exclude=None,
     ):
         """
         Predict using the linear model.
@@ -61,6 +62,8 @@ class LinearRegression:
         ----------
         predictors : dict of xr.DataArray
             A dict of DataArray objects used as predictors. Must be 1D and contain `dim`.
+        exclude : str or set of str, default: None
+            Set of variables to exclude in the prediction.
 
         Returns
         -------
@@ -70,8 +73,10 @@ class LinearRegression:
 
         params = self.params
 
+        exclude = _to_set(exclude)
+
         non_predictor_vars = {"intercept", "weights", "fit_intercept"}
-        required_predictors = set(params.data_vars) - non_predictor_vars
+        required_predictors = set(params.data_vars) - non_predictor_vars - exclude
         available_predictors = set(predictors.keys())
 
         if required_predictors != available_predictors:

--- a/tests/unit/test_linear_regression.py
+++ b/tests/unit/test_linear_regression.py
@@ -119,9 +119,6 @@ def test_lr_predict_exclude(as_2D):
 
     tas = xr.DataArray([0, 1, 2], dims="time")
 
-    with pytest.raises(ValueError, match="Missing or superfluous predictors"):
-        lr.predict({"tas": tas})
-
     result = lr.predict({"tas": tas}, exclude="tas2")
     expected = xr.DataArray([[5, 8, 11]], dims=("x", "time"))
     expected = expected if as_2D else expected.squeeze()
@@ -136,6 +133,34 @@ def test_lr_predict_exclude(as_2D):
 
     result = lr.predict({}, exclude={"tas", "tas2"})
     expected = xr.DataArray([5], dims="x")
+    expected = expected if as_2D else expected.squeeze()
+
+    xr.testing.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize("as_2D", [True, False])
+def test_lr_predict_exclude_intercept(as_2D):
+    lr = mesmer.stats.LinearRegression()
+
+    params = xr.Dataset(
+        data_vars={
+            "intercept": ("x", [5]),
+            "fit_intercept": True,
+            "tas": ("x", [3]),
+        }
+    )
+    lr.params = params if as_2D else params.squeeze()
+
+    tas = xr.DataArray([0, 1, 2], dims="time")
+
+    result = lr.predict({"tas": tas}, exclude="intercept")
+    expected = xr.DataArray([[0, 3, 6]], dims=("x", "time"))
+    expected = expected if as_2D else expected.squeeze()
+
+    xr.testing.assert_equal(result, expected)
+
+    result = lr.predict({}, exclude={"tas", "intercept"})
+    expected = xr.DataArray([0], dims="x")
     expected = expected if as_2D else expected.squeeze()
 
     xr.testing.assert_equal(result, expected)

--- a/tests/unit/test_linear_regression.py
+++ b/tests/unit/test_linear_regression.py
@@ -104,6 +104,44 @@ def test_LR_predict(as_2D):
 
 
 @pytest.mark.parametrize("as_2D", [True, False])
+def test_lr_predict_exclude(as_2D):
+    lr = mesmer.stats.LinearRegression()
+
+    params = xr.Dataset(
+        data_vars={
+            "intercept": ("x", [5]),
+            "fit_intercept": True,
+            "tas": ("x", [3]),
+            "tas2": ("x", [1]),
+        }
+    )
+    lr.params = params if as_2D else params.squeeze()
+
+    tas = xr.DataArray([0, 1, 2], dims="time")
+
+    with pytest.raises(ValueError, match="Missing or superfluous predictors"):
+        lr.predict({"tas": tas})
+
+    result = lr.predict({"tas": tas}, exclude="tas2")
+    expected = xr.DataArray([[5, 8, 11]], dims=("x", "time"))
+    expected = expected if as_2D else expected.squeeze()
+
+    xr.testing.assert_equal(result, expected)
+
+    result = lr.predict({"tas": tas}, exclude={"tas2"})
+    expected = xr.DataArray([[5, 8, 11]], dims=("x", "time"))
+    expected = expected if as_2D else expected.squeeze()
+
+    xr.testing.assert_equal(result, expected)
+
+    result = lr.predict({}, exclude={"tas", "tas2"})
+    expected = xr.DataArray([5], dims="x")
+    expected = expected if as_2D else expected.squeeze()
+
+    xr.testing.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize("as_2D", [True, False])
 def test_LR_residuals(as_2D):
 
     lr = mesmer.stats.LinearRegression()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #321
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `CHANGELOG.rst`

I need to think a bit more about this - I wrote this so we can split up the linear regression. However, this will include the intercept twice. So I may have to add the possibility to add the `intercept` in `exclude`.

```python
if "intercept" in exclude:
    prediction = xr.zeros_like(params.intercept)
else:
    prediction = params.intercept
```




