### PR TITLE
lin reg: only warn on superfluous predictors

### DIFF
--- a/mesmer/stats/_linear_regression.py
+++ b/mesmer/stats/_linear_regression.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Mapping, Optional
 
 import numpy as np
@@ -88,7 +89,7 @@ class LinearRegression:
         if available_predictors - required_predictors:
             superfluous = sorted(available_predictors - required_predictors)
             superfluous = "', '".join(superfluous)
-            raise ValueError(f"Superfluous predictors: '{superfluous}'")
+            warnings.warn(f"Superfluous predictors: '{superfluous}'")
 
         if "intercept" in exclude:
             prediction = xr.zeros_like(params.intercept)

--- a/tests/unit/test_linear_regression.py
+++ b/tests/unit/test_linear_regression.py
@@ -110,17 +110,25 @@ def test_lr_predict_missing_superfluous():
     )
     lr.params = params
 
+    da = xr.DataArray([0, 1, 2], dims="time")
+
     with pytest.raises(ValueError, match="Missing predictors: 'tas', 'tas2'"):
         lr.predict({})
 
     with pytest.raises(ValueError, match="Missing predictors: 'tas'"):
         lr.predict({"tas2": None})
 
-    with pytest.raises(ValueError, match="Superfluous predictors: 'something else'"):
-        lr.predict({"tas": None, "tas2": None, "something else": None})
+    with pytest.warns(UserWarning, match="Superfluous predictors: 'something else'"):
+        result = lr.predict({"tas": da, "tas2": da, "something else": None})
 
-    with pytest.raises(ValueError, match="Superfluous predictors: 'bar', 'foo'"):
-        lr.predict({"tas": None, "tas2": None, "foo": None, "bar": None})
+    expected = xr.DataArray([[5, 9, 13]], dims=("x", "time"))
+    xr.testing.assert_equal(result, expected)
+
+    with pytest.warns(UserWarning, match="Superfluous predictors: 'bar', 'foo'"):
+        result = lr.predict({"tas": da, "tas2": da, "foo": None, "bar": None})
+
+    expected = xr.DataArray([[5, 9, 13]], dims=("x", "time"))
+    xr.testing.assert_equal(result, expected)
 
 
 @pytest.mark.parametrize("as_2D", [True, False])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

Just had a use case for this. Not sure if a good idea or not.