### PR TITLE
drop python 3.7 support

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.9", "3.11"]
+        python-version: ["3.8", "3.9", "3.11"]
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ the legacy calibration routines used `np.unique`, which shuffles them. See `#338
 (`#339 <https://github.com/MESMER-group/mesmer/pull/339>`_).
 By `Mathias Hauser`_.
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+
+- Removed support for Python 3.7 (`#163 <https://github.com/MESMER-group/mesmer/issues/163>`_.).
+  By `Mathias Hauser`_.
 
 v0.9.0 - 2023.12.19
 -------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 Required dependencies
 ---------------------
 
-- Python (3.7 or later)
+- Python (3.8 or later)
 - `dask <https://dask.org/>`__
 - `numpy <http://www.numpy.org/>`__
 - `pandas <https://pandas.pydata.org/>`__

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Intended Audience :: Science/Research
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -31,7 +30,7 @@ classifiers =
 packages = find:
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     dask[complete]
     numpy


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #163
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`
