### PR TITLE
upgrade code to pyhon 3.8 and xarray 2022.03

### DIFF
--- a/mesmer/__init__.py
+++ b/mesmer/__init__.py
@@ -7,6 +7,8 @@ The mesmer package provides tools to train the MESMER emulator, create emulation
 analyze the results.
 """
 
+from importlib.metadata import version as _get_version
+
 from . import calibrate_mesmer, core, create_emulations, io, stats, testing, utils
 from .core import _data as data
 from .core import geospatial, grid, mask, volc, weighted
@@ -32,13 +34,6 @@ __all__ += [
     "weighted",
 ]
 
-try:
-    from importlib.metadata import version as _get_version
-except ImportError:
-    # importlib.metadata not available in python 3.7
-    import pkg_resources
-
-    _get_version = lambda pkg: pkg_resources.get_distribution(pkg).version
 
 try:
     __version__ = _get_version("mesmer-emulator")

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
-from packaging.version import Version
 
 from mesmer.core.utils import _check_dataarray_form, _check_dataset_form
 
@@ -36,23 +35,18 @@ def _select_ar_order_scen_ens(*objs, dim, ens_dim, maxlag, ic="bic"):
     then over all scenarios.
     """
 
-    if Version(xr.__version__) >= Version("2022.03.0"):
-        method = "method"
-    else:
-        method = "interpolation"
-
     ar_order_scen = list()
     for obj in objs:
         res = select_ar_order(obj, dim=dim, maxlag=maxlag, ic=ic)
 
         if ens_dim in res.dims:
-            res = res.quantile(dim=ens_dim, q=0.5, **{method: "nearest"})
+            res = res.quantile(dim=ens_dim, q=0.5, method="nearest")
 
         ar_order_scen.append(res)
 
     ar_order_scen = xr.concat(ar_order_scen, dim="scen")
 
-    ar_order = ar_order_scen.quantile(0.5, dim="scen", **{method: "nearest"})
+    ar_order = ar_order_scen.quantile(0.5, dim="scen", method="nearest")
 
     if not np.isnan(ar_order).any():
         ar_order = ar_order.astype(int)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Moving to python 3.8+ allows some simplifications. Also the lowest xarray version supporting py3.8 is v2022.03.0 which allows further code clean ups. Could have done this in #365...

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`
