### PR TITLE
remove unused deploy-pypi workflow

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -114,32 +114,3 @@ jobs:
           env_vars: RUNNER_OS,PYTHON_VERSION
           name: codecov-umbrella
           fail_ci_if_error: false
-
-  deploy-pypi:
-    needs: [linting,test]
-    if: |
-      startsWith(github.ref, 'refs/tags/v')
-      && (github.ref == 'refs/heads/main')
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Setup python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip wheel twine
-    - name: Create package
-      run: python setup.py sdist bdist_wheel --universal
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

We now have a dedicated workflow uploading to pypi copied from xarray (see #373 and #374). Uses "Trusted Publisher" on pypi (see https://pypi.org/manage/project/mesmer-emulator/settings/publishing/). It uploads to pypi when creating a release with the tag name `"v.*"`.

FYI @znicholls
