### PR TITLE
updates for pandas v2.2 and xarray v2024.02

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,8 @@ Internal Changes
 
 - Start testing the minimum versions of required dependencies (`#398 <https://github.com/MESMER-group/mesmer/pull/398>`_).
   By `Mathias Hauser`_.
+- Restore compatibility with pandas version v2.2 and xarray version v2024.02 (`#404 <https://github.com/MESMER-group/mesmer/pull/404>`_).
+  By `Mathias Hauser`_.
 
 
 v0.10.0 - 2024.01.04

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
+from packaging.version import Version
 
 from mesmer.core._data import load_stratospheric_aerosol_optical_depth_obs
 
@@ -9,7 +10,9 @@ def test_load_stratospheric_aerosol_optical_depth_data():
 
     aod = load_stratospheric_aerosol_optical_depth_obs(version="2022", resample=True)
 
-    time = pd.date_range("1850", "2023", freq="A")
+    freq = "YE" if Version(pd.__version__) >= Version("2.2") else "A"
+
+    time = pd.date_range("1850", "2023", freq=freq)
     time = xr.DataArray(time, dims="time", coords={"time": time})
 
     xr.testing.assert_equal(aod.time, time)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #397
 - [ ] Fully documented, including `CHANGELOG.rst`

Updates for pandas v2.2 and xarray v2024.02:
- pandas made some changes to the date parsing in `read_csv`
- pandas and xarray made changes to the frequency strings (e.g. `"A"` -> `"YE"`)
- also we set the minimum xarray version at v2023.04

For this PR it is now very helpful that we merged #398. (There may, however, be some intermediate xr & pd combinations that still create warnings)