### PR TITLE
numpy 2 compatibility

### DIFF
--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -142,7 +142,7 @@ def select_ar_order(data, dim, maxlag, ic="bic"):
     )
 
     # remove zeros
-    selected_ar_order.data[selected_ar_order.data == 0] = np.NaN
+    selected_ar_order.data[selected_ar_order.data == 0] = np.nan
 
     selected_ar_order.name = "selected_ar_order"
 
@@ -177,7 +177,7 @@ def _select_ar_order_np(data, maxlag, ic="bic"):
     ar_lags = ar_select_order(data, maxlag=maxlag, ic=ic).ar_lags
 
     # None is returned if no lag is selected
-    selected_ar_order = np.NaN if ar_lags is None else ar_lags[-1]
+    selected_ar_order = np.nan if ar_lags is None else ar_lags[-1]
 
     return selected_ar_order
 

--- a/tests/integration/test_load_cmipng.py
+++ b/tests/integration/test_load_cmipng.py
@@ -102,7 +102,7 @@ def test_load_cmipng_ref_two_ens_all(test_data_root_dir, varn, start, end):
     result = np.mean(dta_arr[sel, :, :], axis=(0, -1))
 
     expected = np.zeros_like(result)
-    expected[np.isnan(result)] = np.NaN
+    expected[np.isnan(result)] = np.nan
     np.testing.assert_allclose(expected, result, atol=1e-6)
 
     # test global mean is 0 (over reference period)
@@ -131,7 +131,7 @@ def test_load_cmipng_ref_two_ens_indiv(test_data_root_dir, varn, start, end):
     for arr in dta.values():
         result = np.mean(arr[sel, :, :], axis=0)
         expected = np.zeros_like(result)
-        expected[np.isnan(result)] = np.NaN
+        expected[np.isnan(result)] = np.nan
         np.testing.assert_allclose(expected, result, atol=1e-6)
 
     # test global mean is 0 (over reference period)
@@ -155,7 +155,7 @@ def test_load_cmipng_ref(test_data_root_dir, varn, start, end):
     # test individual gridpoints are 0 (over reference period)
     result = np.mean(dta[1][sel, :, :], axis=0)
     expected = np.zeros_like(result)
-    expected[np.isnan(result)] = np.NaN
+    expected[np.isnan(result)] = np.nan
     np.testing.assert_allclose(expected, result, atol=1e-6)
 
     # test global mean is 0 (over reference period)

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -134,10 +134,10 @@ def test_to_unstructured_dropna(dropna, coords, time_pos):
         da, expected = data_2D_coords(as_dataset=False)
         kwargs = {"x_dim": "x", "y_dim": "y"}
 
-    da[slice(time_pos), 0, 0] = np.NaN
+    da[slice(time_pos), 0, 0] = np.nan
 
     # the gridpoint is dropped if ANY time step is NaN
-    expected[:, 0] = np.NaN
+    expected[:, 0] = np.nan
 
     if dropna:
         expected = expected.dropna("gridcell")
@@ -159,7 +159,7 @@ def test_unstructured_roundtrip_dropna_row(coords):
 
     coords_orig = da_structured.coords.to_dataset()[list(kwargs.values())]
 
-    da_structured[:, :, 0] = np.NaN
+    da_structured[:, :, 0] = np.nan
     expected = da_structured
 
     da_unstructured = mesmer.grid.stack_lat_lon(da_structured, **kwargs)


### PR DESCRIPTION

numpy v2.0 removes `np.NaN` of favor of `np.nan`