### PR TITLE
allow nans in generate harmonic model sum

### DIFF
--- a/mesmer/mesmer_m/harmonic_model.py
+++ b/mesmer/mesmer_m/harmonic_model.py
@@ -41,7 +41,7 @@ def generate_fourier_series_np(coeffs, order, yearly_T, months):
     beta0 = 0
     beta1 = 1
 
-    seasonal_cycle = sum(
+    seasonal_cycle = np.nansum(
         [
             (coeffs[idx * 4] * yearly_T + coeffs[idx * 4 + 1])
             * np.sin(np.pi * i * (months) / 6)
@@ -193,7 +193,7 @@ def fit_to_bic_np(yearly_predictor, monthly_target, max_order):
     )
 
     # need the coeff array to be the same size for all orders
-    coeffs = np.zeros([max_order * 4])
+    coeffs = np.zeros([max_order * 4]) * np.nan
     coeffs[: selected_order * 4] = coeffs_fit
 
     return selected_order, coeffs, predictions

--- a/mesmer/mesmer_m/harmonic_model.py
+++ b/mesmer/mesmer_m/harmonic_model.py
@@ -193,7 +193,7 @@ def fit_to_bic_np(yearly_predictor, monthly_target, max_order):
     )
 
     # need the coeff array to be the same size for all orders
-    coeffs = np.zeros([max_order * 4]) * np.nan
+    coeffs = np.zeros([max_order * 4])
     coeffs[: selected_order * 4] = coeffs_fit
 
     return selected_order, coeffs, predictions


### PR DESCRIPTION
In the harmonic model we return the fit coefficient array with nans, for coefficients, higher than the order we chose. We need to fill the array up until the max order, so we have coefficient arrays of the same length for all gridcells, so filling the array up with nans for unfit coefficients might have made sense in the beginning. However, imo it makes more sense to fill it up with zeros because in this way one can still use the fit coefficient array to `generate_fourier_series` and it makes testing easier, see #431.