### PR TITLE
Infer harmonic model order from coefficients

### DIFF
--- a/mesmer/mesmer_m/harmonic_model.py
+++ b/mesmer/mesmer_m/harmonic_model.py
@@ -14,15 +14,13 @@ from scipy import optimize
 import mesmer
 
 
-def generate_fourier_series_np(coeffs, order, yearly_T, months):
+def generate_fourier_series_np(coeffs, yearly_T, months):
     """construct the Fourier Series
 
     Parameters
     ----------
     coeffs : array-like of shape (4*order)
         coefficients of Fourier Series.
-    order : Integer
-        Order of the Fourier Series.
     yearly_T : array-like of shape (n_years*12,)
         yearly temperature values.
     months : array-like of shape (n_years*12,)
@@ -34,7 +32,7 @@ def generate_fourier_series_np(coeffs, order, yearly_T, months):
         Fourier Series of order n calculated over yearly_T and months with coeffs.
 
     """
-    # TODO: infer order from coeffs
+    order = int(len(coeffs) / 4)
 
     # fix these parameters, according to paper
     # we could also fit them and give an inital guess of 0 and 1 in the coeffs array as before

--- a/mesmer/mesmer_m/harmonic_model.py
+++ b/mesmer/mesmer_m/harmonic_model.py
@@ -14,15 +14,15 @@ from scipy import optimize
 import mesmer
 
 
-def generate_fourier_series_np(coeffs, yearly_T, months):
+def generate_fourier_series_np(yearly_T, coeffs, months):
     """construct the Fourier Series
 
     Parameters
     ----------
-    coeffs : array-like of shape (4*order)
-        coefficients of Fourier Series.
     yearly_T : array-like of shape (n_years*12,)
         yearly temperature values.
+    coeffs : array-like of shape (4*order)
+        coefficients of Fourier Series.
     months : array-like of shape (n_years*12,)
         month values (1-12).
 
@@ -94,7 +94,7 @@ def fit_fourier_series_np(yearly_predictor, monthly_target, order):
 
         loss = np.mean(
             (
-                generate_fourier_series_np(coeffs, order, yearly_predictor, mon_train)
+                generate_fourier_series_np(yearly_predictor, coeffs, mon_train)
                 - mon_target
             )
             ** 2
@@ -115,7 +115,7 @@ def fit_fourier_series_np(yearly_predictor, monthly_target, order):
     ).x
 
     preds = generate_fourier_series_np(
-        coeffs=coeffs, order=order, yearly_T=yearly_predictor, months=mon_train
+        yearly_T=yearly_predictor, coeffs=coeffs, months=mon_train
     )
 
     return coeffs, preds

--- a/mesmer/mesmer_m/harmonic_model.py
+++ b/mesmer/mesmer_m/harmonic_model.py
@@ -32,7 +32,7 @@ def generate_fourier_series_np(yearly_T, coeffs, months):
         Fourier Series of order n calculated over yearly_T and months with coeffs.
 
     """
-    order = int(len(coeffs) / 4)
+    order = int(coeffs.size / 4)
 
     # fix these parameters, according to paper
     # we could also fit them and give an inital guess of 0 and 1 in the coeffs array as before


### PR DESCRIPTION
In the harmonic model `generate_fourier_series` we passed the order as an argument instead of inferring it from the length of the coefficients array. This is changed here. Additionally, I reordered the arguments to facilitate testing on xarrays.