### PR TITLE
align equality check in yeo johnson transform

### DIFF
--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -165,7 +165,7 @@ class PowerTransformerVariableLambda(PowerTransformer):
 
         transformed = np.zeros_like(local_monthly_residuals)
         # get positions of four cases:
-        # NOTE: this code is copied from sklearn's PowerTransformer, see 
+        # NOTE: this code is copied from sklearn's PowerTransformer, see
         # https://github.com/scikit-learn/scikit-learn/blob/8721245511de2f225ff5f9aa5f5fadce663cd4a3/sklearn/preprocessing/_data.py#L3396
         # we acknowledge there is an inconsistency in the comarison of lambdas
         pos_a = (local_monthly_residuals >= 0) & (np.abs(lambdas) < eps)

--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -165,6 +165,9 @@ class PowerTransformerVariableLambda(PowerTransformer):
 
         transformed = np.zeros_like(local_monthly_residuals)
         # get positions of four cases:
+        # NOTE: this code is copied from sklearn's PowerTransformer, see 
+        # https://github.com/scikit-learn/scikit-learn/blob/8721245511de2f225ff5f9aa5f5fadce663cd4a3/sklearn/preprocessing/_data.py#L3396
+        # we acknowledge there is an inconsistency in the comarison of lambdas
         pos_a = (local_monthly_residuals >= 0) & (np.abs(lambdas) < eps)
         pos_b = (local_monthly_residuals >= 0) & (np.abs(lambdas) >= eps)
         pos_c = (local_monthly_residuals < 0) & (np.abs(lambdas - 2) > eps)

--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -161,8 +161,8 @@ class PowerTransformerVariableLambda(PowerTransformer):
 
         transformed = np.zeros_like(local_monthly_residuals)
         # get positions of four cases:
-        pos_a = (local_monthly_residuals >= 0) & (np.abs(lambdas) <= np.spacing(1.0))
-        pos_b = (local_monthly_residuals >= 0) & (np.abs(lambdas) > np.spacing(1.0))
+        pos_a = (local_monthly_residuals >= 0) & (np.abs(lambdas) < np.spacing(1.0))
+        pos_b = (local_monthly_residuals >= 0) & (np.abs(lambdas) >= np.spacing(1.0))
         pos_c = (local_monthly_residuals < 0) & (np.abs(lambdas - 2) > np.spacing(1.0))
         pos_d = (local_monthly_residuals < 0) & (np.abs(lambdas - 2) <= np.spacing(1.0))
 


### PR DESCRIPTION
Changing the comparison to eps in `_yeo_johnson_transform` to be consistent with [sklearn's yet-johnsons power transform](https://github.com/scikit-learn/scikit-learn/blob/8721245511de2f225ff5f9aa5f5fadce663cd4a3/sklearn/preprocessing/_data.py#L3396).