### PR TITLE
rename i and j in power transformer transform & inverse transform

### DIFF
--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -267,8 +267,10 @@ class PowerTransformerVariableLambda(PowerTransformer):
         for gridcell, lmbda in enumerate(lambdas.T):
             for year, y_lmbda in enumerate(lmbda):
                 with np.errstate(invalid="ignore"):  # hide NaN warnings
-                    inverted_monthly_T[year, gridcell] = self._yeo_johnson_inverse_transform(
-                        transformed_monthly_T[year, gridcell], y_lmbda
+                    inverted_monthly_T[year, gridcell] = (
+                        self._yeo_johnson_inverse_transform(
+                            transformed_monthly_T[year, gridcell], y_lmbda
+                        )
                     )
 
             # clip values to not exceed original range

--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -200,13 +200,13 @@ class PowerTransformerVariableLambda(PowerTransformer):
 
         transformed_monthly_resids = np.zeros_like(monthly_residuals)
 
-        # for i, lmbda in enumerate(lambdas.T):
-        #     for j,j_lmbda in enumerate(lmbda):
+        # for gridcell, lmbda in enumerate(lambdas.T):
+        #     for year,year_lmbda in enumerate(lmbda):
         #         with np.errstate(invalid='ignore'):  # hide NaN warnings
-        #             transformed_monthly_resids[j, i] = self._yeo_johnson_transform(monthly_residuals[j, i], j_lmbda)
-        for i, lmbda in enumerate(lambdas.T):
-            transformed_monthly_resids[:, i] = self._yeo_johnson_transform(
-                monthly_residuals[:, i], lmbda
+        #             transformed_monthly_resids[year, gridcell] = self._yeo_johnson_transform(monthly_residuals[year, gridcell], year_lmbda)
+        for gridcell, lmbda in enumerate(lambdas.T):
+            transformed_monthly_resids[:, gridcell] = self._yeo_johnson_transform(
+                monthly_residuals[:, gridcell], lmbda
             )
 
         if self.standardize:
@@ -264,25 +264,24 @@ class PowerTransformerVariableLambda(PowerTransformer):
 
         lambdas = self._get_yeo_johnson_lambdas(yearly_T)
 
-        # TODO: what actually is i? years or gridcells
-        for i, lmbda in enumerate(lambdas.T):
-            # TODO: what is j? years or gridcells?
-            for j, j_lmbda in enumerate(lmbda):
+        for gridcell, lmbda in enumerate(lambdas.T):
+            for year, y_lmbda in enumerate(lmbda):
                 with np.errstate(invalid="ignore"):  # hide NaN warnings
-                    inverted_monthly_T[j, i] = self._yeo_johnson_inverse_transform(
-                        transformed_monthly_T[j, i], j_lmbda
+                    inverted_monthly_T[year, gridcell] = self._yeo_johnson_inverse_transform(
+                        transformed_monthly_T[year, gridcell], y_lmbda
                     )
 
-            # TODO: what does this mean?
-            inverted_monthly_T[:, i] = np.where(
-                inverted_monthly_T[:, i] < self.mins_[i],
-                self.mins_[i],
-                inverted_monthly_T[:, i],
+            # clip values to not exceed original range
+            # apparently a relict from when lambda was not constrained to [0,2]
+            inverted_monthly_T[:, gridcell] = np.where(
+                inverted_monthly_T[:, gridcell] < self.mins_[gridcell],
+                self.mins_[gridcell],
+                inverted_monthly_T[:, gridcell],
             )
-            inverted_monthly_T[:, i] = np.where(
-                inverted_monthly_T[:, i] > self.maxs_[i],
-                self.maxs_[i],
-                inverted_monthly_T[:, i],
+            inverted_monthly_T[:, gridcell] = np.where(
+                inverted_monthly_T[:, gridcell] > self.maxs_[gridcell],
+                self.maxs_[gridcell],
+                inverted_monthly_T[:, gridcell],
             )
 
         return inverted_monthly_T

--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -201,7 +201,7 @@ class PowerTransformerVariableLambda(PowerTransformer):
         transformed_monthly_resids = np.zeros_like(monthly_residuals)
 
         # for gridcell, lmbda in enumerate(lambdas.T):
-        #     for year,year_lmbda in enumerate(lmbda):
+        #     for year, year_lmbda in enumerate(lmbda):
         #         with np.errstate(invalid='ignore'):  # hide NaN warnings
         #             transformed_monthly_resids[year, gridcell] = self._yeo_johnson_transform(monthly_residuals[year, gridcell], year_lmbda)
         for gridcell, lmbda in enumerate(lambdas.T):


### PR DESCRIPTION
Renamed i and j indexes to gridcell and year for better readability in `PowerTransformerVariableLambda.transform()` and `inverse_transform`. 