### PR TITLE
add axis = 0 for nansum

### DIFF
--- a/mesmer/mesmer_m/harmonic_model.py
+++ b/mesmer/mesmer_m/harmonic_model.py
@@ -46,8 +46,8 @@ def generate_fourier_series_np(yearly_T, coeffs, months):
             + (coeffs[idx * 4 + 2] * yearly_T + coeffs[idx * 4 + 3])
             * np.cos(np.pi * i * (months) / 6)
             for idx, i in enumerate(range(1, order + 1))
-        ]
-    )
+        ],
+    axis=0)
     return beta0 + beta1 * yearly_T + seasonal_cycle
 
 

--- a/mesmer/mesmer_m/harmonic_model.py
+++ b/mesmer/mesmer_m/harmonic_model.py
@@ -47,7 +47,8 @@ def generate_fourier_series_np(yearly_T, coeffs, months):
             * np.cos(np.pi * i * (months) / 6)
             for idx, i in enumerate(range(1, order + 1))
         ],
-    axis=0)
+        axis=0,
+    )
     return beta0 + beta1 * yearly_T + seasonal_cycle
 
 


### PR DESCRIPTION
Fix for mistake made in #433. `nansum` needs an axis to sum along, otherwise it will just sum over all dimensions and output a single number.