### PR TITLE
adjust bounds of power transformer fit

### DIFF
--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -143,8 +143,7 @@ class PowerTransformerVariableLambda(PowerTransformer):
         ]
         local_yearly_T = local_yearly_T[~np.isnan(local_yearly_T)]
 
-        # choosing bracket -2, 2 like for boxcox
-        bounds = np.c_[[0, -0.1], [1, 0.1]]
+        bounds = np.array([[0, np.inf], [-0.1, 0.1]])
         # first guess is that data is already normal distributed
         first_guess = np.array([1, 0])
 

--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -143,6 +143,8 @@ class PowerTransformerVariableLambda(PowerTransformer):
         ]
         local_yearly_T = local_yearly_T[~np.isnan(local_yearly_T)]
 
+        # first coefficient only positive for logistic function
+        # second coefficient bounded to avoid very steep function
         bounds = np.array([[0, np.inf], [-0.1, 0.1]])
         # first guess is that data is already normal distributed
         first_guess = np.array([1, 0])


### PR DESCRIPTION
The bounds for the fit of lambda should be positive for the first coefficient, to have a logistic lambda function. Also rewrote it as a normal array.

A step towards solving #440 