### PR TITLE
RTD: remove transitive deps from docs env

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,10 @@ build:
     pre_install:
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged docs/environment.yml docs/source/conf.py
-      # install mesmer, needs to be editable
-      - python -m pip install -e .
+      # install mesmer
+      # * needs to be editable
+      # * --no-deps to ensure minimal required deps
+      - python -m pip install --no-deps -e .
   tools:
     python: mambaforge-22.9
 sphinx:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,8 @@ channels:
   - conda-forge
   - nodefaults
 
+# NOTE: transitive dependencies are commented
+
 dependencies:
   - python=3.11
 #   - cartopy

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,15 +6,22 @@ channels:
 
 dependencies:
   - python=3.11
-  - cartopy
-  - dask[complete]
-  - netcdf4
+#   - cartopy
+#   - dask
+  - joblib
+#   - matplotlib-base
+#   - nc-time-axis
+#   - netcdf4
   - numpy
-  - pandas>=2.0
+  - packaging
+  - pandas
+  - pooch
+  - pyproj
+  - regionmask
   - scikit-learn
+  - scipy
   - statsmodels
-  - regionmask>=0.9
-  - xarray>=2023.04 # because pandas 2 is required
+  - xarray
 # required for docs
   - sphinx-book-theme
   - numpydoc


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This adds all of our direct dependencies to the docs environment (following #448) but removes the transitive ones. The direct ones were installed before, just not explicitly listed. Unfortunately sphinx (or maybe just the autosummary extension) imports the functions it wants to create the docs for, so they _must_ be installed. However, leaving the optional transitive deps away should lead to a small speed up.

---

Alternatively we could install everything using pip but that would be more work (c.f. regionmask/regionmask#450)
