### PR TITLE
docs: clean landing page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to MESMER's documentation!
-==================================
+.. include:: ../../README.rst
 
 .. toctree::
    :maxdepth: 2
@@ -16,12 +15,14 @@ Welcome to MESMER's documentation!
 
 .. toctree::
    :maxdepth: 2
+   :hidden:
    :caption: For developers
 
    development
 
 .. toctree::
    :maxdepth: 2
+   :hidden:
    :caption: API Reference
 
    api
@@ -29,8 +30,7 @@ Welcome to MESMER's documentation!
 
 .. toctree::
    :maxdepth: 2
+   :hidden:
    :caption: Versions
 
    changelog
-
-.. include:: ../../README.rst


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Currently our landing page looks a bit strange - some parts of the index is hidden, some part is not, and there are two titles (one above and one below the index) see https://mesmer-emulator.readthedocs.io/en/v0.10.0/.

This PR hides the whole index, relegating it entirely to the side bar. Then it only shows the readme text, which makes much more sense. (Moving `.. include:: ../../README.rst` up is just a formality).

