### PR TITLE
deprecate mask_3D_frac_approx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Breaking changes
 Deprecations
 ^^^^^^^^^^^^
 
+- Deprecated ``mask_3D_frac_approx`` as the functionality is now offered in regionmask
+  v0.12.0 (`#451 <https://github.com/MESMER-group/mesmer/pull/451>`_).
+
 Bug fixes
 ^^^^^^^^^
 

--- a/mesmer/core/mask.py
+++ b/mesmer/core/mask.py
@@ -56,7 +56,7 @@ def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
     land_110 = regionmask.defined_regions.natural_earth_v5_0_0.land_110
 
     try:
-        mask_fraction = mesmer.core.regionmaskcompat.mask_3D_frac_approx(
+        mask_fraction = mesmer.core.regionmaskcompat._mask_3D_frac_approx(
             land_110, data[x_coords], data[y_coords]
         )
     except mesmer.core.regionmaskcompat.InvalidCoordsError as e:

--- a/mesmer/core/regionmaskcompat.py
+++ b/mesmer/core/regionmaskcompat.py
@@ -17,7 +17,7 @@ def mask_percentage(regions, lon, lat, **kwargs):
     warnings.warn(
         "`mask_percentage` has been renamed to `mask_3D_frac_approx`", FutureWarning
     )
-    return mask_3D_frac_approx(regions, lon, lat, **kwargs)
+    return _mask_3D_frac_approx(regions, lon, lat, **kwargs)
 
 
 def mask_3D_frac_approx(regions, lon, lat, **kwargs):
@@ -47,6 +47,17 @@ def mask_3D_frac_approx(regions, lon, lat, **kwargs):
     - prototype of what will eventually be integrated in his regionmask package
 
     """
+
+    warnings.warn(
+        "`mask_3D_frac_approx` has been deprecated. Please use "
+        "`regions.mask_3D_frac_approx` directly (requires regionmask v0.12 or later).",
+        FutureWarning,
+    )
+
+    return _mask_3D_frac_approx(regions, lon, lat, **kwargs)
+
+
+def _mask_3D_frac_approx(regions, lon, lat, **kwargs):
 
     backend = regionmask.core.mask._determine_method(lon, lat)
     if "rasterize" not in backend:

--- a/mesmer/io/load_constant_files.py
+++ b/mesmer/io/load_constant_files.py
@@ -17,7 +17,7 @@ import regionmask
 
 from mesmer.stats import gaspari_cohn
 
-from ..core.regionmaskcompat import mask_3D_frac_approx
+from ..core.regionmaskcompat import _mask_3D_frac_approx
 
 
 def load_phi_gc(lon, lat, ls, cfg, L_start=1500, L_end=10000, L_interval=250):
@@ -186,7 +186,7 @@ def load_regs_ls_wgt_lon_lat(reg_type=None, lon=None, lat=None):
 
     # gives fraction of land -> in extract_land() script decide above which land
     # fraction threshold to consider a grid point as a land grid point
-    ls["grid_raw"] = mask_3D_frac_approx(land_110, lon["c"], lat["c"]).values.squeeze()
+    ls["grid_raw"] = _mask_3D_frac_approx(land_110, lon["c"], lat["c"]).values.squeeze()
 
     # remove Antarctica
     idx_ANT = lat["c"] < -60

--- a/tests/unit/test_regionmaskcompat.py
+++ b/tests/unit/test_regionmaskcompat.py
@@ -6,7 +6,6 @@ import xarray as xr
 
 from mesmer.core.regionmaskcompat import (
     InvalidCoordsError,
-    _mask_3D_frac_approx,
     mask_3D_frac_approx,
     sample_coord,
 )
@@ -49,7 +48,7 @@ def test_mask_percentage_wrong_coords(dim, invalid_coords):
     with pytest.raises(
         InvalidCoordsError, match="'lon' and 'lat' must be 1D and equally spaced."
     ):
-        _mask_3D_frac_approx(None, **latlon)
+        mask_3D_frac_approx(None, **latlon)
 
 
 @pytest.mark.parametrize("lat", ((-91, 90), (-90, 92), (-91, 92)))
@@ -59,7 +58,7 @@ def test_mask_percentage_lon_beyond_90(lat):
     lon = np.arange(0, 360, 10)
 
     with pytest.raises(InvalidCoordsError, match=r"lat must be between \-90 and \+90"):
-        _mask_3D_frac_approx(None, lon, lat)
+        mask_3D_frac_approx(None, lon, lat)
 
 
 def test_mask_percentage_coords():
@@ -71,7 +70,7 @@ def test_mask_percentage_coords():
     r = shapely.geometry.box(0, -90, 120, 90)
     r = regionmask.Regions([r])
 
-    result = _mask_3D_frac_approx(r, lon, lat)
+    result = mask_3D_frac_approx(r, lon, lat)
 
     np.testing.assert_equal(result.lon.values, lon)
     np.testing.assert_equal(result.lat.values, lat)
@@ -90,7 +89,7 @@ def test_mask_percentage_poles():
     r = shapely.geometry.box(0, -90, 360, 90)
     r = regionmask.Regions([r])
 
-    result = _mask_3D_frac_approx(r, lon, lat)
+    result = mask_3D_frac_approx(r, lon, lat)
     assert (result == 1).all()
 
 
@@ -105,7 +104,7 @@ def test_mask_percentage_southpole():
 
     for offset in np.arange(0, 1, 0.05):
         lat = np.arange(-90, -80, 1) + offset
-        result = _mask_3D_frac_approx(r, lon, lat)
+        result = mask_3D_frac_approx(r, lon, lat)
         assert (result.isel(lat=0) == 1).all()
 
 
@@ -120,7 +119,7 @@ def test_mask_percentage_northpole():
 
     for offset in np.arange(0, 1, 0.05):
         lat = np.arange(90, 80, -1) - offset
-        result = _mask_3D_frac_approx(r, lon, lat)
+        result = mask_3D_frac_approx(r, lon, lat)
         assert (result.isel(lat=0) == 1).all()
 
 
@@ -133,7 +132,7 @@ def test_mask_percentage():
     r = shapely.geometry.box(0, 0, 30, 30)
     r = regionmask.Regions([r])
 
-    result = _mask_3D_frac_approx(r, lon, lat)
+    result = mask_3D_frac_approx(r, lon, lat)
 
     expected = [[[1, 0.5], [0.5, 0.25]]]
     expected = xr.DataArray(
@@ -163,7 +162,7 @@ def test_mask_percentage_coord_names(lat_name, lon_name):
     r = shapely.geometry.box(0, 0, 30, 30)
     r = regionmask.Regions([r])
 
-    result = _mask_3D_frac_approx(r, ds[lon_name], ds[lat_name])
+    result = mask_3D_frac_approx(r, ds[lon_name], ds[lat_name])
 
     expected = [[[1, 0.5], [0.5, 0.25]]]
     expected = xr.DataArray(

--- a/tests/unit/test_regionmaskcompat.py
+++ b/tests/unit/test_regionmaskcompat.py
@@ -10,6 +10,10 @@ from mesmer.core.regionmaskcompat import (
     sample_coord,
 )
 
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:`mask_3D_frac_approx` has been deprecated")
+]
+
 
 @pytest.fixture
 def small_region():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

regionmask 0.12.0 offers it's own implementation of `mask_3D_frac_approx`, so at some point we can remove this function from mesmer. This takes the first step by marking it as deprecated.