### PR TITLE
change optimize.minimize method from SLSQP to Nelder-Mead

### DIFF
--- a/mesmer/mesmer_m/power_transformer.py
+++ b/mesmer/mesmer_m/power_transformer.py
@@ -153,7 +153,7 @@ class PowerTransformerVariableLambda(PowerTransformer):
             _neg_log_likelihood,
             first_guess,
             bounds=bounds,
-            method="SLSQP",
+            method="Nelder-Mead",
         ).x
 
     def _yeo_johnson_transform(self, local_monthly_residuals, lambdas):


### PR DESCRIPTION
Changing the method in optimize.minimize` to Nelder-Mead from SLSQP should make the coefficients fit more stable, see https://github.com/MESMER-group/mesmer/issues/440#issuecomment-2127172434
