### PR TITLE
MESMER-X: reflow and fix comments and docstrings

### DIFF
--- a/mesmer/mesmer_x/OLD_train_l_distrib.py
+++ b/mesmer/mesmer_x/OLD_train_l_distrib.py
@@ -83,21 +83,16 @@ def train_l_distrib(preds, targs, cfg, form_fit_distrib, save_params=True, **kwa
     ----------
     preds : dict
         dictionnary[target][name_covariant] = covariant. The covariants must be dictionnaries with scenarios as keys.
-
     targs : dict
         nested dictionary of targets with keys
         - [targ][scen] (3d array (run, time, gp) of target for specific scenario)
-
     cfg : module
         config file containing metadata
-
     form_fit_distrib : str
         string containing information on which fit to do: transformation and evolution of parameters
         Examples: transfo-_loc-gttasL-gthfdsL_scale-_shape-gttasS; transfo-logistic_loc-gttasL_scale-
-
     save_params : bool, optional
         determines if parameters are saved or not, default = True
-
     **kwargs : additional parameters that will be fed to the class 'distrib_cov' for fit of a distribution
 
     Returns
@@ -307,14 +302,11 @@ def transf_distrib2normal(preds, targs, params_l_distrib, threshold_sigma=6.0):
     preds : dict
         nested dictionary with 3 keys: cov_loc, cov_scale, cov_shape. Each one may be empty for no variation of the parameter of the distribution. If not empty, the variables will be used as covariants.
         - [targ][cov_...][covariant][scen]  (1d array (time) of predictor for specific scenario)
-
     targs : dict
         nested dictionary of targets with keys
         - [targ][scen] (3d array (run, time, gp) of target for specific scenario)
-
     params_l_distrib : dict
         nested dictionary of local variability paramters. Result of the function 'train_l_distrib'.
-
     threshold_sigma : float
         If a distribution is not correctly fitted, some values to transform may lead to unlikely values for a standard normal distribution. If above, they will be set to the threshold. Default : 6 (~happens once every 1e9 times)
 

--- a/mesmer/mesmer_x/OLD_train_l_distrib.py
+++ b/mesmer/mesmer_x/OLD_train_l_distrib.py
@@ -511,7 +511,8 @@ def transf_distrib2normal(preds, targs, params_l_distrib, threshold_sigma=6.0):
             print(
                 "WARNING: some transformed values of "
                 + var_targ
-                + " are very unlikely, a possible cause is a fit missing strong signals. Action taken: blocking them at a limit."
+                + " are very unlikely, a possible cause is a fit missing strong"
+                " signals. Action taken: blocking them at a limit."
             )
 
     return transf_inputs
@@ -1785,7 +1786,8 @@ class distrib_cov:
                 # checking if that one failed as well
                 if self.error_failedfit and not m.success:
                     raise Exception(
-                        "The fast detrend provides with a valid first guess, but not good enough."
+                        "The fast detrend provides with a valid first guess, but not"
+                        " good enough."
                     )
 
             return self.translate_m_sol(m.x)

--- a/mesmer/mesmer_x/create_emus_l_distrib.py
+++ b/mesmer/mesmer_x/create_emus_l_distrib.py
@@ -63,7 +63,8 @@ def backtransf_normal2distrib(transf_emus_lv, preds, params_distrib, force_scen=
     # checking that the provided inputs are transformed.
     if list(transf_emus_lv.keys()) != ["all"]:
         raise Exception(
-            "Data to backtransform must be emulations from 'create_emus_lv' with only the key 'all'"
+            "Data to backtransform must be emulations from 'create_emus_lv' with only"
+            " the key 'all'"
         )
 
     # creating the dictionary that will be filled in
@@ -111,7 +112,9 @@ def backtransf_normal2distrib(transf_emus_lv, preds, params_distrib, force_scen=
             # checking if different scenarios are provided
             elif np.any(list_scens != maybe_scens):
                 raise Exception(
-                    "The different covariants for the parameters have different list of scenarios, please provide the same ones. NB: 'all' applies to all other scenarios, thus did not cause this issue."
+                    "The different covariants for the parameters have different list of"
+                    " scenarios, please provide the same ones. NB: 'all' applies to all"
+                    " other scenarios, thus did not cause this issue."
                 )
 
         if force_scen is not None:

--- a/mesmer/mesmer_x/create_emus_l_distrib.py
+++ b/mesmer/mesmer_x/create_emus_l_distrib.py
@@ -34,14 +34,11 @@ def backtransf_normal2distrib(transf_emus_lv, preds, params_distrib, force_scen=
     transf_emus_lv : dict
         nested dictionary for transformed emulators, result of 'create_emus_lv'
         - [targ][scen] (3d array (emus, time, gp) of target for specific scenario)
-
     preds : dict
         nested dictionary with 3 keys: cov_loc, cov_scale, cov_shape. Each one may be empty for no variation of the parameter of the distribution. If not empty, the variables will be used as covariants.
         - [targ][cov_...][covariant][scen]  (1d array (time) of predictor for specific scenario)
-
     params_distrib : dict
         nested dictionary of local variability paramters. Result of the function 'train_l_distrib'.
-
     force_scen : None or iterable (list, set, 1d array)
         Used to prescribe a specific list of scenarios. If None, they will be deduced from the covariants. Important if no covariants, otherwise the parameters would not depend on scenarios, but using 'force_scen', we can have the desired scenarios.
 

--- a/mesmer/mesmer_x/temporary_config_all.py
+++ b/mesmer/mesmer_x/temporary_config_all.py
@@ -68,7 +68,8 @@ class ConfigMesmerX:
                 "dir_plots",
             ]:
                 raise Exception(
-                    'Unknown type of directory provided in "paths", please check available options.'
+                    'Unknown type of directory provided in "paths", please check'
+                    " available options."
                 )
 
         # cmip-ng

--- a/mesmer/mesmer_x/temporary_config_all.py
+++ b/mesmer/mesmer_x/temporary_config_all.py
@@ -7,19 +7,24 @@ import os.path
 
 
 class ConfigMesmerX:
-    """
-    This class defines the full configuration of MESMER.
-
-    Inputs:
-     - paths: information on what paths to use.
-        If nothing is provided in 'paths', default is to assume paths for tests.
-        If any known keyword is provided in 'paths', they will be used instead of default.
-        Unknown keywords in 'paths' cause an error.
-     - gen: generation of CMIP data (default: 6). If some paths are provided in 'paths', it MUST be consistent with 'gen'.
-     - esms: list of the ESMs used. The default is 'all', BUT if no paths are provided, it is assumed that only data for tests are used, then only ["IPSL-CM6A-LR"].
-    """
 
     def __init__(self, paths={}, gen=6, esms="all"):
+        """full configuration of MESMER.
+
+        Parameters
+        ----------
+        paths : dict
+            Information on what paths to use. If nothing is provided in 'paths', default
+            is to assume paths for tests. If any known keyword is provided in 'paths',
+            they will be used instead of default.
+            Unknown keywords in 'paths' cause an error.
+        gen : int, default: 6
+            Generation of CMIP data. If some paths are provided in 'paths', it MUST be
+            consistent with 'gen'.
+        esms : list of str, default: "all"
+            The ESMs used. The default is 'all', BUT if no paths are provided, it is
+            assumed that only data for tests are used, then only ["IPSL-CM6A-LR"].
+        """
 
         # preparing some parameters
         self.paths = paths
@@ -39,7 +44,6 @@ class ConfigMesmerX:
 
     def paths_directories(self):
 
-        # ---------------------------------------------------------------------------------
         # PATHS
 
         # path to mesmer root directory can be found in a slightly sneaky way
@@ -53,7 +57,6 @@ class ConfigMesmerX:
             MESMER_ROOT, "tests", "test-data", "calibrate-coarse-grid"
         )
 
-        # ---------------------------------------------------------------------------------
         # DIRECTORIES
         # checking if any is unknown:
         for key_path in self.paths:
@@ -124,14 +127,11 @@ class ConfigMesmerX:
         else:
             self.dir_plots = "/net/exo/landclim/yquilcaille/across_scen_T/plots/"
 
-        # ---------------------------------------------------------------------------------
         return
 
     def flex_config(self):
 
-        # ---------------------------------------------------------------------------------
         # ESMs
-
         if self.paths == {}:
             # running in test mode, only using this ESM
             self.esms = ["IPSL-CM6A-LR"]
@@ -164,21 +164,23 @@ class ConfigMesmerX:
                 "NorESM2-MM",
                 "UKESM1-0-LL",
             ]
-            # tmp removed (need to investigate stms soon how can get them in too!):
-            # -CAMS-CSM1-0 (train_lt did not work: nans?!)
-            # -CIESM (sth wrong with GHFDS)
-            # -"EC-Earth3" (sth wrong when reading in files, index issue)
+
+            # temporarily removed
+            # - "CAMS-CSM1-0" (train_lt did not work: nans?!)
+            # - "CIESM" (sth wrong with GHFDS)
+            # - "EC-Earth3" (sth wrong when reading in files, index issue)
             # - "EC-Earth3-Veg" (probably sth wrong with GHFDS)
             # - "EC-Earth3-Veg-LR" (didn't even try. Just assumed same problem)
             # - "GFDL-CM4" (probably sth wrong with GHFDS)
             # - "GFDL-ESM4" (didn't even try. Just assumed same problem)
             # - "GISS-E2-1-G" (sth wrong when reading in files, index issue)
+
+            # TODO: need to investigate stms soon how can get them in too!
             # Check update on this aspect on slack Yann-Lea
 
         else:
             pass  # nothing to change, esms is used as provided.
 
-        # ---------------------------------------------------------------------------------
         # Variables, ensembles, regions
         self.targs = ["tas"]  # emulated variables
 
@@ -187,7 +189,6 @@ class ConfigMesmerX:
 
         self.reg_type = "ar6.land"
 
-        # ---------------------------------------------------------------------------------
         # Time
         self.ref = {}
         self.ref["type"] = "individ"  # alternatives: 'first','all'
@@ -199,26 +200,27 @@ class ConfigMesmerX:
         self.time = {}
         # first included year
         self.time["start"] = "1850"
-        # last included year #TODO: check if even used anywhere??
+        # last included year
+        # TODO: check if even used anywhere??
         self.time["end"] = "2100"
 
-        # ---------------------------------------------------------------------------------
         # Parameters
         self.threshold_land = 1 / 3
 
+        # if True weigh each scenario equally (ie less weight to individ runs of scens
+        # with more ic members)
         self.wgt_scen_tr_eq = True
-        # if True weigh each scenario equally (ie less weight to individ runs of scens with more ic members)
 
+        # temporarily made smaller for testing purposes. Normally 6000.
         self.nr_emus_v = 1000
-        # tmp made smaller for testing purposes. Normally 6000.
 
+        # 0 meaning same emulations drawn for each scen, if put a number will have
+        # different ones for each scen
         self.scen_seed_offset_v = 0
-        # 0 meaning same emulations drawn for each scen, if put a number will have different ones for each scen
 
         # max. nr of iterations in cross validation, will increase later
         self.max_iter_cv = 15
 
-        # ---------------------------------------------------------------------------------
         # predictors (for global module)
         self.preds = {}
         self.preds["tas"] = {}
@@ -230,7 +232,6 @@ class ConfigMesmerX:
         self.preds["tas"]["gv"] = []
         self.preds["tas"]["g_all"] = self.preds["tas"]["gt"] + self.preds["tas"]["gv"]
 
-        # ---------------------------------------------------------------------------------
         # methods (for all modules)
         self.methods = {}
 
@@ -305,8 +306,10 @@ class ConfigMesmerX:
 
     def nonflex_config(self):
 
-        # ---------------------------------------------------------------------------------
-        # list of scenarios that could be considered. Right now, complying to previous scripts of configurations, passing scenarios as set configuration, but could be passed in flexible configurations.
+        # list of scenarios that could be considered. Right now, complying to previous
+        # scripts of configurations, passing scenarios as set configuration, but could
+        # be passed in flexible configurations.
+
         if self.paths == {}:
             # running in test mode, only using this ESM
             self.scenarios = ["h-ssp126"]
@@ -323,7 +326,6 @@ class ConfigMesmerX:
                 "h-ssp119",
             ]
 
-        # ---------------------------------------------------------------------------------
         # Emulations of scenarios and seeds
         if self.scen_seed_offset_v == 0:
             self.scenarios_emus_v = ["all"]
@@ -352,6 +354,9 @@ class ConfigMesmerX:
 # information about loaded data:
 
 # cmip-ng
-# Data downloaded from ESGF (https://esgf-node.llnl.gov/projects/esgf-llnl/) and pre-processed according to Brunner et al. 2020 (https://doi.org/10.5281/zenodo.3734128)
-# assumes folder structure / file name as in cmip-ng archives at ETHZ -> see mesmer.io.load_cmipng.file_finder_cmipng() for details
-# - global mean stratospheric AOD, monthly, 1850-"2020" (0 after 2012), downloaded from KNMI climate explorer in August 2020, no pre-processing
+# Data downloaded from ESGF (https://esgf-node.llnl.gov/projects/esgf-llnl/) and
+# pre-processed according to Brunner et al. [2020](https://doi.org/10.5281/zenodo.3734128)
+# assumes folder structure / file name as in cmip-ng archives at ETHZ
+# -> see mesmer.io.load_cmipng.file_finder_cmipng() for details
+# - global mean stratospheric AOD, monthly, 1850-"2020" (0 after 2012),
+# downloaded from KNMI climate explorer in August 2020, no pre-processing

--- a/mesmer/mesmer_x/temporary_support.py
+++ b/mesmer/mesmer_x/temporary_support.py
@@ -98,7 +98,8 @@ def load_inputs_MESMERx(cfg, variables, esms):
         pred_g, reg_dict, wgt_g, ls, threshold_land=cfg.threshold_land
     )
 
-    # prepare the auxiliary files. better results with default values L, but like this much faster + less space needed
+    # prepare the auxiliary files. better results with default values L, but like this
+    # much faster + less space needed
     phi_gc = load_phi_gc(lon, lat, ls, cfg, L_start=1750, L_end=10000, L_interval=250)
 
     lon_mesh, lat_mesh = np.meshgrid(lon["c"], lat["c"])
@@ -108,7 +109,8 @@ def load_inputs_MESMERx(cfg, variables, esms):
     gp2reg = reg_dict["grids"][:, ind[0], ind[1]]  # grid points to regions
     ww_reg = np.nansum((ls["wgt_gp_l"] * gp2reg).T, axis=0)
 
-    # Just checking what ESMs are actually used. Some are removed because not having all drivers
+    # Just checking what ESMs are actually used. Some are removed because not having all
+    # drivers
     used_esms = [esm for esm in esms if len(PRED[esm].keys()) > 0]
 
     # adding few lines for SMA, because some values in NaN  or inf!

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -127,7 +127,6 @@ def xr_train_distrib(
         )
 
     # FIT
-    # --------------------------------------------------------------------------------
     # looping over grid points (to replace with a map function)
     for igp, gp in enumerate(gridpoints):
         print(
@@ -1093,7 +1092,8 @@ class distrib_cov:
         return LL
 
     def find_bound(self, i_c, x0, fact_coeff):
-        # could be accelerated using dichotomy, but 100 iterations max are fast enough not to require to make this part more complex.
+        # could be accelerated using dichotomy, but 100 iterations max are fast enough
+        # not to require to make this part more complex.
         x, iter, itermax, test = np.copy(x0), 0, 100, True
         while test and (iter < itermax):
             test_c, test_p, test_v, _ = self.test_all(x)

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -406,7 +406,8 @@ class distrib_cov:
             (data_targ_addtest is not None) or (data_preds_addtest is not None)
         ):
             raise Exception(
-                "Only one of data_targ_addtest & data_preds_addtest have been provided, not both of them. Please correct."
+                "Only one of data_targ_addtest & data_preds_addtest have been provided,"
+                " not both of them. Please correct."
             )
         self.data_targ_addtest = data_targ_addtest
         self.data_preds_addtest = data_preds_addtest
@@ -530,7 +531,9 @@ class distrib_cov:
             )
         ):
             raise Exception(
-                "Lack of consistency on the options 'type_fun_optim', 'threshold_stopping_rule' and 'ind_year_thres', not sure if the stopping rule will be employed"
+                "Lack of consistency on the options 'type_fun_optim',"
+                " 'threshold_stopping_rule' and 'ind_year_thres', not sure if the"
+                " stopping rule will be employed"
             )
 
     def eval_weights(self, n_bins_density=40):

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -29,7 +29,7 @@ class Expression:
 
         Parameters
         ----------
-        expr: str
+        expr : str
             string describing the expression that will be used. Existing methods for
             flexible conditional distributions don't provide the level of flexibility
             that MESMER-X uses.
@@ -52,7 +52,7 @@ class Expression:
               normally. Names of packages should be included.
               spaces dont matter in the equations
 
-        expr_name: str
+        expr_name : str
             Name of the expression.
 
         Notes

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -95,6 +95,7 @@ class Expression:
     def interpret_distrib(self):
         """interpreting the expression"""
 
+        dist = str.split(self.expression, "(")[0]
         if (
             dist
             in ss._discrete_distns._distn_names + ss._continuous_distns._distn_names

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -17,61 +17,66 @@ import xarray as xr
 
 
 class Expression:
-    """interpret string of conditional distribution, interpret them, and evaluate them
-
-    When initialized, the class identifies the distribution, inputs, parameters and
-    coefficients. Then, the next function would be evaluate(coefficients, inputs,
-    forced_shape) to assess the distribution given the provided values of coefficients
-    & inputs. NB language: the distribution depends on parameters (loc, scale, etc),
-    that are functions of inputs and coefficients.
-
-    Parameters
-    ----------
-    expr: str
-        string describing the expression that will be used. Existing methods for
-        flexible conditional distributions don't provide the level of flexibility that
-        MESMER-X uses.
-        Requirements to follow to have the expression being understood:
-        - distribution: must be the name of a distribution in scipy stats (continuous or
-          discrete): https://docs.scipy.org/doc/scipy/reference/stats.html
-        - parameters: all names for the parameters of the distributions must be
-          provided: loc, scale, shape, mu, a, b, c, etc.
-        - coefficients: must be named "c#", with # being the number of the coefficient:
-          e.g. c1, c2, c3.
-        - inputs: any string that can be written as a variable in python, and surrounded
-          with "__": e.g. __GMT__, __X1__, __gmt_tm1__, but NOT __gmt-1__, __#days__,
-          __GMT, _GMT_ etc.
-        - equations: the equations for the evolutions must be written as it would be
-          normally. Names of packages should be included.
-          spaces dont matter in the equations
-
-    expr_name: str
-        Name of the expression.
-
-    Notes
-    -----
-    - Forcing values of certain parameters (eg scale) to be positive: to implement in
-      class 'expression'?
-    - Forcing values of certain parameters (eg mu for poisson) to be integers: to
-      implement in class 'expression'?
-    - Reasons for not using sympy:
-        - sympy.stats does not have all required distributions (e.g. GEV) & all required
-          functions (e.g. log-likelihood)
-          -> so using scipy distributions with parameters as sympy expressions
-        - but these expressions dont deal well with numpy array, or even less with
-          xarray
-          -> could, but tedious.
-        - And the result would be significantly slower than with numpy/xarray based
-        approaches like here.
-
-    Examples
-    --------
-    - "genextreme(loc=c1 + c2 * __pred1__, scale=c3 + c4 * __pred2__**2, c=c5)"
-    - "norm(loc=c1 + (c2 - c1) / ( 1 + np.exp(c3 * __GMT_t__ + c4 * __GMT_tm1__ - c5) ), scale=c6)"
-    - "exponpow(loc=c1, scale=c2+np.min([np.max(np.mean([__GMT_tm1__,__GMT_tp1__],axis=0)), math.gamma(__XYZ__)]), b=c3)"
-    """
 
     def __init__(self, expr, expr_name):
+        """conditional distribution: definition, interpretation and evaluation
+
+        When initialized, the class identifies the distribution, inputs, parameters and
+        coefficients. Then, the next function would be evaluate(coefficients, inputs,
+        forced_shape) to assess the distribution given the provided values of
+        coefficients & inputs. NB language: the distribution depends on parameters
+        (loc, scale, etc), that are functions of inputs and coefficients.
+
+        Parameters
+        ----------
+        expr: str
+            string describing the expression that will be used. Existing methods for
+            flexible conditional distributions don't provide the level of flexibility
+            that MESMER-X uses.
+            Requirements to follow to have the expression being understood:
+
+            - distribution: must be the name of a distribution in scipy stats (discrete
+              or continuous): https://docs.scipy.org/doc/scipy/reference/stats.html
+
+            - parameters: all names for the parameters of the distributions must be
+              provided: loc, scale, shape, mu, a, b, c, etc.
+
+            - coefficients: must be named "c#", with # being the number of the
+              coefficient: e.g. c1, c2, c3.
+
+            - inputs: any string that can be written as a variable in python, and
+              surrounded with "__": e.g. __GMT__, __X1__, __gmt_tm1__, but NOT
+              __gmt-1__, __#days__, __GMT, _GMT_ etc.
+
+            - equations: the equations for the evolutions must be written as it would be
+              normally. Names of packages should be included.
+              spaces dont matter in the equations
+
+        expr_name: str
+            Name of the expression.
+
+        Notes
+        -----
+        - Forcing values of certain parameters (eg scale) to be positive: to implement
+          in class 'expression'?
+        - Forcing values of certain parameters (eg mu for poisson) to be integers: to
+          implement in class 'expression'?
+        - Reasons for not using sympy:
+          - sympy.stats does not have all required distributions (e.g. GEV) & all required
+            functions (e.g. log-likelihood)
+            -> so using scipy distributions with parameters as sympy expressions
+          - but these expressions dont deal well with numpy array, or even less with
+            xarray -> could, but tedious.
+          - And the result would be significantly slower than with numpy/xarray based
+            approaches like here.
+
+        Examples
+        --------
+        - "genextreme(loc=c1 + c2 * __pred1__, scale=c3 + c4 * __pred2__**2, c=c5)"
+        - "norm(loc=c1 + (c2 - c1) / ( 1 + np.exp(c3 * __GMT_t__ + c4 * __GMT_tm1__ - c5) ), scale=c6)"
+        - "exponpow(loc=c1, scale=c2+np.min([np.max(np.mean([__GMT_tm1__,__GMT_tp1__],axis=0)), math.gamma(__XYZ__)]), b=c3)"
+        """
+
         # basic initalization
         self.expression = expr
         self.expression_name = expr_name
@@ -134,7 +139,8 @@ class Expression:
                     + self.distrib.name
                 )
 
-        # recommend not to try to fill in missing information on parameters with constant parameters, but to raise a ValueError instead.
+        # recommend not to try to fill in missing information on parameters with
+        # constant parameters, but to raise a ValueError instead.
         for pot_param in self.parameters_list:
             if pot_param not in self.parameters_expressions.keys():
                 raise ValueError("No information provided for " + pot_param)

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -93,7 +93,8 @@ class Expression:
 
         else:
             raise ValueError(
-                "Please provide a distribution written as in scipy.stats: https://docs.scipy.org/doc/scipy/reference/stats.html"
+                "Please provide a distribution written as in scipy.stats:"
+                " https://docs.scipy.org/doc/scipy/reference/stats.html"
             )
 
     def find_expr_parameters(self):
@@ -117,7 +118,8 @@ class Expression:
                 raise ValueError(
                     "The parameter "
                     + param
-                    + " is not part of prepared expression in scipy.stats: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats."
+                    + " is not part of prepared expression in scipy.stats:"
+                    " https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats."
                     + self.distrib.name
                 )
 

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -17,45 +17,60 @@ import xarray as xr
 
 
 class Expression:
+    """interpret string of conditional distribution, interpret them, and evaluate them
+
+    When initialized, the class identifies the distribution, inputs, parameters and
+    coefficients. Then, the next function would be evaluate(coefficients, inputs,
+    forced_shape) to assess the distribution given the provided values of coefficients
+    & inputs. NB language: the distribution depends on parameters (loc, scale, etc),
+    that are functions of inputs and coefficients.
+
+    Parameters
+    ----------
+    expr: str
+        string describing the expression that will be used. Existing methods for
+        flexible conditional distributions don't provide the level of flexibility that
+        MESMER-X uses.
+        Requirements to follow to have the expression being understood:
+        - distribution: must be the name of a distribution in scipy stats (continuous or
+          discrete): https://docs.scipy.org/doc/scipy/reference/stats.html
+        - parameters: all names for the parameters of the distributions must be
+          provided: loc, scale, shape, mu, a, b, c, etc.
+        - coefficients: must be named "c#", with # being the number of the coefficient:
+          e.g. c1, c2, c3.
+        - inputs: any string that can be written as a variable in python, and surrounded
+          with "__": e.g. __GMT__, __X1__, __gmt_tm1__, but NOT __gmt-1__, __#days__,
+          __GMT, _GMT_ etc.
+        - equations: the equations for the evolutions must be written as it would be
+          normally. Names of packages should be included.
+          spaces dont matter in the equations
+
+    expr_name: str
+        Name of the expression.
+
+    Notes
+    -----
+    - Forcing values of certain parameters (eg scale) to be positive: to implement in
+      class 'expression'?
+    - Forcing values of certain parameters (eg mu for poisson) to be integers: to
+      implement in class 'expression'?
+    - Reasons for not using sympy:
+        - sympy.stats does not have all required distributions (e.g. GEV) & all required
+          functions (e.g. log-likelihood)
+          -> so using scipy distributions with parameters as sympy expressions
+        - but these expressions dont deal well with numpy array, or even less with
+          xarray
+          -> could, but tedious.
+        - And the result would be significantly slower than with numpy/xarray based
+        approaches like here.
+
+    Examples
+    --------
+    - "genextreme(loc=c1 + c2 * __pred1__, scale=c3 + c4 * __pred2__**2, c=c5)"
+    - "norm(loc=c1 + (c2 - c1) / ( 1 + np.exp(c3 * __GMT_t__ + c4 * __GMT_tm1__ - c5) ), scale=c6)"
+    - "exponpow(loc=c1, scale=c2+np.min([np.max(np.mean([__GMT_tm1__,__GMT_tp1__],axis=0)), math.gamma(__XYZ__)]), b=c3)"
     """
-        Class to interpret string of conditional distribution, interpret them, and evaluate them.
-        When initialized, the class identifies the distribution, inputs, parameters and coefficients.
-        Then, the next function would be evaluate(coefficients, inputs, forced_shape) to assess the distribution given the provided values of coefficients & inputs.
-        NB language: the distribution depends on parameters (loc, scale, etc), that are functions of inputs and coefficients.
 
-    Parameters:
-    -------
-        expr: str
-            string describing the expression that will be used. Existing methods for flexible conditional distributions dont provide the level of flexibility that MESMER-X actually uses.
-            Requirements to follow to have the expression being understood:
-                - distribution: must be the name of a distribution in scipy stats (continuous or discrete): https://docs.scipy.org/doc/scipy/reference/stats.html
-                - parameters: all names for the parameters of the distributions must be provided: loc, scale, shape, mu, a, b, c, etc.
-                - coefficients: must be named "c#", with # being the number of the coefficient: e.g. c1, c2, c3.
-                - inputs: any string that can be written as a variable in python, and surrounded with "__": e.g. __GMT__, __X1__, __gmt_tm1__, but NOT __gmt-1__, __#days__, __GMT, _GMT_ etc.
-                - equations: the equations for the evolutions must be written as it would be normally. Names of packages should be included.
-                spaces dont matter in the equiations
-            Examples:
-                - "genextreme(loc=c1 + c2 * __pred1__, scale=c3 + c4 * __pred2__**2, c=c5)"
-                - "norm(loc=c1 + (c2 - c1) / ( 1 + np.exp(c3 * __GMT_t__ + c4 * __GMT_tm1__ - c5) ), scale=c6)"
-                - "exponpow(loc=c1, scale=c2+np.min([np.max(np.mean([__GMT_tm1__,__GMT_tp1__],axis=0)), math.gamma(__XYZ__)]), b=c3)"
-
-        expr_name: str
-            Name of the expression.
-
-    Notes:
-    -------
-        - Forcing values of certain parameters (eg scale) to be positive: to implement in class 'expression'?
-        - Forcing values of certain parameters (eg mu for poisson) to be integers: to implement in class 'expression'?
-        - Reasons for not using sympy:
-            - sympy.stats does not have all required distributions (e.g. GEV) & all required functions (e.g. log-likelihood)
-            -> so using scipy distributions with parameters as sympy expressions
-            - but these expressions dont deal well with numpy array, or even less with xarray
-            -> could, but tedious.
-            - And the result would be significantly slower than with numpy/xarray based approaches like here.
-    """
-
-    # --------------------
-    # INITIALIZATION
     def __init__(self, expr, expr_name):
         # basic initalization
         self.expression = expr
@@ -77,12 +92,8 @@ class Expression:
         # correct expressions of parameters
         self.correct_expr_parameters()
 
-    # --------------------
-
-    # --------------------
-    # INTERPRETING THE EXPRESSION
     def interpret_distrib(self):
-        dist = str.split(self.expression, "(")[0]
+        """interpreting the expression"""
 
         if (
             dist
@@ -108,7 +119,6 @@ class Expression:
         # identifying groups
         sub_expressions = str.split(tmp_expression, ",")
 
-        # creating dictionary
         self.parameters_expressions = {}
         for sub_exp in sub_expressions:
             param, sub = str.split(sub_exp, "=")
@@ -156,10 +166,14 @@ class Expression:
                 "Distribution name not found in discrete or continuous lists."
             )
 
-        # prepary basic boundaries on parameters: incomplete, did not find a way to evaluate automatically the limits on shape parameters
+        # prepary basic boundaries on parameters: incomplete, did not find a way to
+        # evaluate automatically the limits on shape parameters
+
         self.boundaries_parameters = {
             p: [-np.inf, np.inf] for p in self.parameters_list
         }
+
+        # scale must be positive
         if "scale" in self.boundaries_parameters:
             self.boundaries_parameters["scale"][0] = 0
 
@@ -167,7 +181,9 @@ class Expression:
         """
         coefficients are supposed to be written as "c#", with "#" being a number.
         """
+
         self.coefficients_list, self.coefficients_dict = [], {}
+
         for param in self.parameters_expressions:
             self.coefficients_dict[param] = []
             # iniatilize detection
@@ -196,7 +212,9 @@ class Expression:
                         pass
 
     def find_inputs(self):
+
         self.inputs_list = []
+
         for param in self.parameters_expressions:
             terms = str.split(self.parameters_expressions[param], "__")
             for i in np.array(terms)[np.arange(1, len(terms), 2)]:
@@ -207,7 +225,10 @@ class Expression:
         self.inputs_list.sort(key=len, reverse=True)
 
     def correct_expr_parameters(self):
-        # list of inputs and coefficients, sorted by descending length, to be sure that when removing them, will remove the good ones and not those with their short name contained in the long name of another
+        # list of inputs and coefficients, sorted by descending length, to be sure that
+        # when removing them, will remove the good ones and not those with their short
+        # name contained in the long name of another
+
         tmp_list = self.inputs_list + self.coefficients_list + ["__"]
         tmp_list.sort(key=len, reverse=True)
 
@@ -227,7 +248,7 @@ class Expression:
             # adding one space at the end to treat the last term
             for ex in expr + " ":
 
-                # TODO: could do this using regular expressions, think about it
+                # TODO: could do this using regular expressions
                 if ex in [
                     "(",
                     ")",
@@ -281,11 +302,14 @@ class Expression:
                                 + ", but couldnt find an equivalent in numpy or math."
                             )
                     else:
-                        # was a readable character, is still a readable character, nothing to do
+                        # was a readable character, is still a readable character,
+                        # nothing to do
                         pass
                 else:
                     t += ex
-                # TODO: would make sense to invert the logic here - move building t above the validity check - but again let's keep for now
+
+                # TODO: would make sense to invert the logic here - move building 't'
+                # above the validity check
 
             # list of replacements in correct order
             tmp = list(dico_replace.keys())
@@ -303,22 +327,37 @@ class Expression:
                     param
                 ].replace("__" + i + "__", i)
 
-    # --------------------
-
-    # --------------------
-    # EVALUATE THE EXPRESSION
     def evaluate(self, coefficients_values, inputs_values, forced_shape=None):
         """
         Evaluates the distribution with the provided inputs and coefficients
 
-        Parameters:
-        -------
-            coefficients_values: dict(c_i = values or np.array())  or  xr.dataset(c_i)  or  list of values
-            inputs_values: dict(inp_i = values or np.array())  or  xr.dataset(inp_i)
-            forced_shape: tuple or list of dimensions of coefficients_values and inputs_values for transposition of the shape
+        Parameters
+        ----------
+        coefficients_values : dict | xr.Dataset(c_i) | list of values
+            Coefficient arrays or scalars. Can have the following form
+            - dict(c_i = values or np.array())
+            - xr.Dataset(c_i)
+            - list of values
+        inputs_values : dict | xr.Dataset
+            Input arrays or scalars. Can be passed as
+            - dict(inp_i = values or np.array())
+            - xr.Dataset(inp_i)
+        forced_shape : None | tuple or list of dimensions
+            coefficients_values and inputs_values for transposition of the shape
 
-        ! Warning: with xarrays for coefficients_values and inputs_values, the outputs with have for shape first the one of the coefficient, then the one of the inputs --> trying to avoid this issue with 'forced_shape'
+        Warnings
+        --------
+        with xarrays for coefficients_values and inputs_values, the outputs with have
+        for shape first the one of the coefficient, then the one of the inputs
+        --> trying to avoid this issue with 'forced_shape'
         """
+
+        # TODO:
+        # - use broadcasting
+        # - can we avoid using exec & eval?
+        # - only parse the values once? (to avoid doing it repeatedly)
+        # - don't allow list of coefficients_values
+
         # Check 1: are all the coefficients provided?
         if type(coefficients_values) in [dict, xr.Dataset]:
             # case where provide explicit information on coefficients_values
@@ -326,7 +365,8 @@ class Expression:
                 if c not in coefficients_values:
                     raise ValueError("Missing information for the coefficient " + c)
         else:
-            # case where a vector is provided, used for the optimization performed during the training
+            # case where a vector is provided, used for the optimization performed
+            # during the training
             if len(coefficients_values) != len(self.coefficients_list):
                 raise ValueError("Inconsistent information for the coefficients_values")
             else:
@@ -359,8 +399,9 @@ class Expression:
             # may need to silence warnings here, to avoid spamming
             self.parameters_values[param] = eval(self.parameters_expressions[param])
 
-        # Correcting shapes 1: constant parameters must have the shape of the inputs
+        # Correcting shapes 1: scalar parameters must have the shape of the inputs
         if len(self.inputs_list) > 0:
+
             for param in self.parameters_list:
                 if (type(self.parameters_values[param]) in [int, float]) or (
                     self.parameters_values[param].ndim == 0
@@ -405,53 +446,57 @@ def probability_integral_transform(
     coeffs_end=None,
     preds_end=None,
 ):
-    """Probability integral transform of the data given parameters of a given distribution into their equivalent in a standard normal distribution.
+    """
+    Probability integral transform of the data given parameters of a given distribution
+    into their equivalent in a standard normal distribution.
 
     Parameters
     ----------
-    data: not sure yet what data format will be used at the end.
-        Assumed to be a xarray Dataset with coordinates 'time' and 'gridpoint' and one 2D variable with both coordinates
-
-    target_name: str
+    data : not sure yet what data format will be used at the end.
+        Assumed to be a xarray Dataset with coordinates 'time' and 'gridpoint' and one
+        2D variable with both coordinates
+    target_name : str
         name of the variable to train
-
     expr_start : str
         string describing the starting expression
-
     expr_end : str
         string describing the starting expression
-
-    preds_start: not sure yet what data format will be used at the end.
+    preds_start : not sure yet what data format will be used at the end.
         Covariants of the starting expression. Default: empty Dataset.
-
-    coeffs_start: xarray dataset
+    coeffs_start : xarray dataset
         Coefficients of the starting expression. Default: empty Dataset.
-
-    preds_end: not sure yet what data format will be used at the end.
+    preds_end : not sure yet what data format will be used at the end.
         Covariants of the ending expression. Default: empty Dataset.
-
-    coeffs_end: xarray dataset
+    coeffs_end : xarray dataset
         Coefficients of the ending expression. Default: empty Dataset.
 
     Returns
     -------
     transf_inputs : not sure yet what data format will be used at the end.
-        Assumed to be a xarray Dataset with coordinates 'time' and 'gridpoint' and one 2D variable with both coordinates
+        Assumed to be a xarray Dataset with coordinates 'time' and 'gridpoint' and one
+        2D variable with both coordinates
 
     Notes
     -----
-    - Assumptions:
-        Context: The transformation may fail if the values are very unlikely, leading to a CDF equal or too close from 0 or 1, which will raise issues.
-        Current solution: During training, this problem is avoided thanks to the option 'threshold_min_proba', meaning that all points in sample would have a minimum probability.
-        Limit to solution: However, if transforming a sample not used during sample, and in a domain not represented in the training sample, it may cause issues.
-        Additional fix: If this situation is encountered, I suggest to block the CDF values 'cdf_item' within a domain: values with a probability of 1.e-99 could be forced to 1.e-9. Unless someone has a better idea! :D
-    - Disclaimer:
-    - TODO:
+    Assumptions:
+    - Context: The transformation may fail if the values are very unlikely, leading to a
+      CDF equal or too close from 0 or 1, which will raise issues.
+    - Current solution: During training, this problem is avoided thanks to the option
+      'threshold_min_proba', meaning that all points in sample would have a minimum
+      probability.
+    - Limit to solution: However, if transforming a sample not used during sample, and
+      in a domain not represented in the training sample, it may cause issues.
+    - Additional fix: If this situation is encountered, I suggest to block the CDF
+      values 'cdf_item' within a domain: values with a probability of 1.e-99 could be
+      forced to 1.e-9. Unless someone has a better idea! :D
+    Disclaimer:
+    - TODO
 
     """
     # preparation of distributions
     expression_start = Expression(expr_start, "start")
     expression_end = Expression(expr_end, "end")
+
     if coeffs_start is None:
         coeffs_start = xr.Dataset()
     if coeffs_end is None:
@@ -467,6 +512,7 @@ def probability_integral_transform(
             preds_start_item = xr.Dataset()
         else:
             preds_start_item = preds_start[i][0]
+
         if preds_end is None:
             preds_end_item = xr.Dataset()
         else:
@@ -477,6 +523,7 @@ def probability_integral_transform(
         distrib_start = expression_start.evaluate(
             coeffs_start, preds_start_item, forced_shape=data_item[target_name].dims
         )
+
         distrib_end = expression_end.evaluate(
             coeffs_end, preds_end_item, forced_shape=data_item[target_name].dims
         )
@@ -507,6 +554,7 @@ def weighted_median(data, weights):
     data, weights = np.array(data).squeeze(), np.array(weights).squeeze()
     s_data, s_weights = map(np.array, zip(*sorted(zip(data, weights))))
     midpoint = 0.5 * sum(s_weights)
+
     if any(weights > midpoint):
         w_median = (data[weights == np.max(weights)])[0]
     else:
@@ -521,16 +569,21 @@ def weighted_median(data, weights):
 
 def listxrds_to_np(listds, name_var, forcescen, coords=None):
     """
-    **Temporary** function to prepare the format of inputs for training. This is meant to be used ONLY before the format of MESMERv1 data is confirmed.
+    **Temporary** function to prepare the format of inputs for training. This is meant
+    to be used ONLY before the format of MESMERv1 data is confirmed.
 
-    listds: list of xr Dataset
+    Parameters
+    ----------
+    listds : list of xr Dataset
         predictors or target.
-    name_var: str
+    name_var : str
         name of the variable to select.
-    forcescen: list of str
-        names of the scenarios to select, in this specific order. used to ensure the consistency between predictors & target.
-    coords: dict
-        default None (no selection). Otherwise, will loop over keys & values of dictionary to select in listds.
+    forcescen : list of str
+        names of the scenarios to select, in this specific order. used to ensure the
+        consistency between predictors & target.
+    coords : dict
+        default None (no selection). Otherwise, will loop over keys & values of
+        dictionary to select in listds.
     """
     # looping over scenarios
     TMP = []
@@ -541,7 +594,8 @@ def listxrds_to_np(listds, name_var, forcescen, coords=None):
         for item in listds:
 
             if item[1] == scen:
-                # for each scenario, creating one unique serie: consistency of members & scenarios have to be ensured while loading data
+                # for each scenario, creating one unique serie: consistency of members &
+                #  scenarios have to be ensured while loading data
                 if coords is not None:
                     TMP.append(item[0][name_var].loc[coords].values.flatten())
                 else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR
 - reflows comments, docstrings and some of the strings
 - moves the class docstring to `__init__` (which is recommended https://peps.python.org/pep-0257/ & allows velin to know the params and fix the format)
 - does not change any code

There is certainly more to be done here but I will defer that for later. I will also merge more or less right away because I want to open anther PR with some initial code changes.