### PR TITLE
FIX: list_coefficients -> coefficients_list

### DIFF
--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -666,14 +666,14 @@ class distrib_cov:
         # checking set boundaries on coefficients
         for coeff in self.boundaries_coeffs:
             bottom, top = self.boundaries_coeffs[coeff]
-            if coeff not in self.expr_fit.list_coefficients:
+            if coeff not in self.expr_fit.coefficients_list:
                 raise ValueError(
                     "Provided wrong boundaries on coefficient, "
                     + coeff
                     + " does not exist in expr_fit"
                 )
             else:
-                values = values_coeffs[self.expr_fit.list_coefficients.index(coeff)]
+                values = values_coeffs[self.expr_fit.coefficients_list.index(coeff)]
             if np.any(values < bottom) or np.any(top < values):
                 test = False  # out of boundaries
         return test


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.rst`

The `Expression` class defines `coefficients_list` and not `list_coefficients` - or did I miss something?

https://github.com/MESMER-group/mesmer/blob/02169332a342275bf7e12db0dade60b5312ecc93/mesmer/mesmer_x/train_utils_mesmerx.py#L192