### PR TITLE
add monthly AR1 process utilities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,8 +61,8 @@ that this led to some numerical changes compared to the MESMER-M publication
 **Auto-Regression**
 
 - Implement functions performing the monthly (cyclo-stationary) auto-regression and adapt these functions to
-work with xarray (`#473 <https://github.com/MESMER-group/mesmer/pull/473>_`). This includes extracting the
-drawing of spatially correlated innovations to a stand-alone function.
+  work with xarray. This includes extracting the drawing of spatially correlated innovations to a
+  stand-alone function. (`#473 <https://github.com/MESMER-group/mesmer/pull/473>`_)
 
 **Yeo-Johnson power transformer**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,12 @@ that this led to some numerical changes compared to the MESMER-M publication
   `#419 <https://github.com/MESMER-group/mesmer/pull/419>`_, and
   `#421 <https://github.com/MESMER-group/mesmer/pull/421>`_).
 
+**Auto-Regression**
+
+- Implement functions performing the monthly (cyclo-stationary) auto-regression and adapt these functions to 
+work with xarray (`#473 <https://github.com/MESMER-group/mesmer/pull/473>_`). This includes extracting the 
+drawing of spatially correlated innovations to a stand-alone function.
+
 **Yeo-Johnson power transformer**
 
 -  Ensure the power transformer yields the correct normalization for more cases (

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,8 +60,8 @@ that this led to some numerical changes compared to the MESMER-M publication
 
 **Auto-Regression**
 
-- Implement functions performing the monthly (cyclo-stationary) auto-regression and adapt these functions to 
-work with xarray (`#473 <https://github.com/MESMER-group/mesmer/pull/473>_`). This includes extracting the 
+- Implement functions performing the monthly (cyclo-stationary) auto-regression and adapt these functions to
+work with xarray (`#473 <https://github.com/MESMER-group/mesmer/pull/473>_`). This includes extracting the
 drawing of spatially correlated innovations to a stand-alone function.
 
 **Yeo-Johnson power transformer**

--- a/mesmer/stats/__init__.py
+++ b/mesmer/stats/__init__.py
@@ -4,9 +4,9 @@ from mesmer.stats._auto_regression import (
     draw_auto_regression_correlated,
     draw_auto_regression_uncorrelated,
     fit_auto_regression,
-    select_ar_order,
     fit_auto_regression_monthly,
     predict_auto_regression_monthly,
+    select_ar_order,
 )
 from mesmer.stats._gaspari_cohn import gaspari_cohn, gaspari_cohn_correlation_matrices
 from mesmer.stats._linear_regression import LinearRegression

--- a/mesmer/stats/__init__.py
+++ b/mesmer/stats/__init__.py
@@ -5,6 +5,8 @@ from mesmer.stats._auto_regression import (
     draw_auto_regression_uncorrelated,
     fit_auto_regression,
     select_ar_order,
+    fit_auto_regression_monthly,
+    predict_auto_regression_monthly,
 )
 from mesmer.stats._gaspari_cohn import gaspari_cohn, gaspari_cohn_correlation_matrices
 from mesmer.stats._linear_regression import LinearRegression
@@ -22,6 +24,8 @@ __all__ = [
     "draw_auto_regression_uncorrelated",
     "fit_auto_regression",
     "select_ar_order",
+    "fit_auto_regression_monthly",
+    "predict_auto_regression_monthly",
     # gaspari cohn
     "gaspari_cohn_correlation_matrices",
     "gaspari_cohn",

--- a/mesmer/stats/__init__.py
+++ b/mesmer/stats/__init__.py
@@ -6,6 +6,7 @@ from mesmer.stats._auto_regression import (
     fit_auto_regression,
     fit_auto_regression_monthly,
     predict_auto_regression_monthly,
+    draw_auto_regression_monthly,
     select_ar_order,
 )
 from mesmer.stats._gaspari_cohn import gaspari_cohn, gaspari_cohn_correlation_matrices
@@ -26,6 +27,7 @@ __all__ = [
     "select_ar_order",
     "fit_auto_regression_monthly",
     "predict_auto_regression_monthly",
+    "draw_auto_regression_monthly",
     # gaspari cohn
     "gaspari_cohn_correlation_matrices",
     "gaspari_cohn",

--- a/mesmer/stats/__init__.py
+++ b/mesmer/stats/__init__.py
@@ -2,11 +2,11 @@ from mesmer.stats._auto_regression import (
     _fit_auto_regression_scen_ens,
     _select_ar_order_scen_ens,
     draw_auto_regression_correlated,
+    draw_auto_regression_monthly,
     draw_auto_regression_uncorrelated,
     fit_auto_regression,
     fit_auto_regression_monthly,
     predict_auto_regression_monthly,
-    draw_auto_regression_monthly,
     select_ar_order,
 )
 from mesmer.stats._gaspari_cohn import gaspari_cohn, gaspari_cohn_correlation_matrices

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -622,7 +622,7 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
         Dataset containing the estimated parameters of the AR(1) process, the ``intercept``and the
         ``slope`` for each month and gridpoint.
     """
-    _check_dataarray_form(monthly_data, "monthly_data", ndim=2)
+    _check_dataarray_form(monthly_data, "monthly_data", ndim=2, required_dims=time_dim)
 
     monthly_data = monthly_data.groupby(f"{time_dim}.month")
     ar_params = []

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -723,18 +723,21 @@ def predict_auto_regression_monthly(intercept, slope, time, buffer):
     n_months, n_gridpoints = intercept.shape
     
     covariance = xr.DataArray(np.zeros((n_months, n_gridpoints, n_gridpoints)), dims=("month", "gridcell_i", "gridcell_j"))
-
-    result = _draw_ar_corr_monthly_xr_internal(
-        intercept=intercept,
-        slope=slope,
-        covariance=covariance,
-        time=time,
-        realisation=1,
-        seed=0,
-        buffer=buffer,
-        time_dim="time",
-        realisation_dim="realisation",
-    ).squeeze("realisation", drop = True)
+    
+    # ignore that covariance is all zeros and thus not positive-definite
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LinAlgWarning)
+        result = _draw_ar_corr_monthly_xr_internal(
+            intercept=intercept,
+            slope=slope,
+            covariance=covariance,
+            time=time,
+            realisation=1,
+            seed=0,
+            buffer=buffer,
+            time_dim="time",
+            realisation_dim="realisation",
+        ).squeeze("realisation", drop = True)
     
     return result
 

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -893,13 +893,7 @@ def _draw_ar_corr_monthly_xr_internal(
 
 
 def _draw_auto_regression_monthly_np(
-    intercept, 
-    slope, 
-    covariance, 
-    n_samples, 
-    n_ts, 
-    seed, 
-    buffer
+    intercept, slope, covariance, n_samples, n_ts, seed, buffer
 ):
     """predict time series of an auto regression process with lag one
     using individual parameters for each month - numpy wrapper

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -852,7 +852,7 @@ def _draw_ar_corr_monthly_xr_internal(
     # make sure non-dimension coords are properly caught
     gridpoint_coords = dict(slope[gridpoint_dim].coords)
 
-    if not covariance is None:
+    if covariance is not None:
         covariance = covariance.values
 
     out = _draw_auto_regression_monthly_np(
@@ -917,7 +917,7 @@ def _draw_auto_regression_monthly_np(
 
     # draw innovations for each month
     innovations = np.zeros([n_samples, n_ts // 12 + buffer, 12, n_gridcells])
-    if not covariance is None:
+    if covariance is not None:
         for month in range(12):
             cov_month = covariance[month, :, :]
             innovations[:, :, month, :] = _draw_innovations_correlated_np(

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -720,7 +720,6 @@ def predict_auto_regression_monthly(intercept, slope, time, buffer, month_dim="m
     if not isinstance(time, xr.DataArray):
         raise TypeError(f"Expected a `xr.DataArray`, got {type(time)}")
 
-
     AR_predictions = xr.apply_ufunc(
         _predict_auto_regression_monthly_np,
         intercept,
@@ -734,14 +733,14 @@ def predict_auto_regression_monthly(intercept, slope, time, buffer, month_dim="m
     )
 
     AR_predictions = AR_predictions.stack({"time": ["year", month_dim]})
-    AR_predictions = AR_predictions.drop_vars(['time', 'year', month_dim])
+    AR_predictions = AR_predictions.drop_vars(["time", "year", month_dim])
     AR_predictions["time"] = time
 
     return AR_predictions.transpose("time", ...)
 
 
 def _predict_auto_regression_monthly_np(intercept, slope, n_ts, buffer):
-    """predict time series of an auto regression process with lag one 
+    """predict time series of an auto regression process with lag one
     using individual parameters for each month - numpy wrapper
 
     Parameters

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -692,8 +692,8 @@ def _fit_auto_regression_monthly_np(data_month, data_prev_month):
 
 
 def predict_auto_regression_monthly(ar_params, time, buffer):
-    """deterministically predict time series of an auto regression process 
-    with lag one (AR(1)) using individual parameters for each month. 
+    """deterministically predict time series of an auto regression process
+    with lag one (AR(1)) using individual parameters for each month.
     This function is deterministic, i.e. does not produce random noise!
 
     Parameters
@@ -721,7 +721,7 @@ def predict_auto_regression_monthly(ar_params, time, buffer):
 
     """
     _check_dataset_form(ar_params, "ar_params", required_vars=("intercept", "slope"))
-    
+
     (month_dim, gridcell_dim) = ar_params.intercept.dims
     (n_months, n_gridpoints) = ar_params.intercept.shape
 

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -632,9 +632,9 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
             # and last December has no following January
             n_ts = monthly_data[12].sizes[time_dim]
             prev_month = monthly_data[12].isel({time_dim: slice(0, n_ts - 1)})
-            
+
             n_ts = monthly_data[month].sizes[time_dim]
-            cur_month = monthly_data[month].isel({time_dim:slice(1, n_ts)})
+            cur_month = monthly_data[month].isel({time_dim: slice(1, n_ts)})
         else:
             prev_month = monthly_data[month - 1]
             cur_month = monthly_data[month]

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -939,7 +939,7 @@ def _draw_auto_regression_monthly_np(
 
     # predict auto-regressive process using innovations
     out = np.zeros([n_samples, n_ts + buffer * 12, n_gridcells])
-    for t in range(n_ts + buffer * 12):
+    for t in range(1, n_ts + buffer * 12):
         month = t % 12
         out[:, t, :] = (
             intercept[month, :]

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -648,7 +648,7 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
             _fit_auto_regression_monthly_np,
             cur_month,
             prev_month,
-            input_core_dims=[["time"], ["time"]],
+            input_core_dims=[[time_dim], [time_dim]],
             output_core_dims=[[], []],
             vectorize=True,
         )

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -721,8 +721,6 @@ def predict_auto_regression_monthly(ar_params, time, buffer):
         shape n_timesteps x n_gridpoints.
 
     """
-    # the AR process alone is deterministic so we dont need realisations here
-    # or a seed
     _check_dataset_form(ar_params, "ar_params", required_vars=("intercept", "slope"))
     (month_dim, gridcell_dim), (n_months, n_gridpoints) = (
         ar_params.intercept.dims,
@@ -738,6 +736,8 @@ def predict_auto_regression_monthly(ar_params, time, buffer):
         ar_params.slope, "slope", ndim=2, required_dims=(month_dim, gridcell_dim)
     )
 
+    # here we only want the deterministic part of the AR1 process so we set the covariance to zero
+    # so that the innovations are zero
     covariance = xr.DataArray(
         np.zeros((n_months, n_gridpoints, n_gridpoints)),
         dims=("month", "gridcell_i", "gridcell_j"),
@@ -893,7 +893,13 @@ def _draw_ar_corr_monthly_xr_internal(
 
 
 def _draw_auto_regression_monthly_np(
-    intercept, slope, covariance, n_samples, n_ts, seed, buffer
+    intercept, 
+    slope, 
+    covariance, 
+    n_samples, 
+    n_ts, 
+    seed, 
+    buffer
 ):
     """predict time series of an auto regression process with lag one
     using individual parameters for each month - numpy wrapper

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -652,7 +652,7 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
         ar_params.append(xr.Dataset({"slope": slope, "intercept": intercept}))
 
     month = xr.Variable("month", np.arange(1, 13))
-    
+
     return xr.concat(ar_params, dim=month)
 
 

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -636,7 +636,8 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
             prev_month = monthly_data[month - 1]
             cur_month = monthly_data[month]
 
-        prev_month[time_dim] = cur_month[time_dim]
+        # need to align time dimension for apply_ufunc
+        prev_month = prev_month.assign_coords({time_dim: cur_month[time_dim]})
 
         slope, intercept = xr.apply_ufunc(
             _fit_auto_regression_monthly_np,
@@ -734,7 +735,7 @@ def predict_auto_regression_monthly(intercept, slope, time, buffer, month_dim="m
 
     AR_predictions = AR_predictions.stack({"time": ["year", month_dim]})
     AR_predictions = AR_predictions.drop_vars(["time", "year", month_dim])
-    AR_predictions["time"] = time
+    AR_predictions = AR_predictions.assign_coords({"time": time})
 
     return AR_predictions.transpose("time", ...)
 

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -480,7 +480,9 @@ def _draw_auto_regression_correlated_np(
     # ensure reproducibility (TODO: https://github.com/MESMER-group/mesmer/issues/35)
     np.random.seed(seed)
 
-    innovations = _draw_innovations_correlated_np(covariance, n_coeffs, n_samples, n_ts, buffer)
+    innovations = _draw_innovations_correlated_np(
+        covariance, n_coeffs, n_samples, n_ts, buffer
+    )
 
     out = np.zeros([n_samples, n_ts + buffer, n_coeffs])
     for t in range(ar_order + 1, n_ts + buffer):
@@ -490,6 +492,7 @@ def _draw_auto_regression_correlated_np(
         out[:, t, :] = intercept + ar + innovations[:, t, :]
 
     return out[:, buffer:, :]
+
 
 def _draw_innovations_correlated_np(covariance, n_gridcells, n_samples, n_ts, buffer):
     # NOTE: 'innovations' is the error or noise term.

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -604,22 +604,39 @@ def _fit_auto_regression_np(data, lags):
 
 
 def fit_auto_regression_monthly(monthly_data, time_dim="time"):
-    """fit an auto regression of lag one (AR(1)) on monthly data
-    The parameters are estimated for each month and gridpoint separately.
+    """fit a cyclo-stationary auto-regressive process of lag one (AR(1)) on monthly 
+    data. The parameters are estimated for each month and gridpoint separately.
     This is based on the assuption that e.g. June depends on May differently
     than July on June. The auto regression is fit along `time_dim`.
 
+    A cyclo-stationary AR(1) process is defined as follows:
+
+    .. math::
+
+        \\mathbf{X}_{t, \\tau} = \\alpha_{0, \\tau} + \\alpha_{1, \\tau} \\mathbf{X}_{t, \\tau -1} 
+        + \\epsilon_{t, \\tau}
+
+
+    where :math:`\\tau \\in \\{1, \\ldots, N\\}` counts the seasons of some seasonal cycle, here the 
+    months of a year :math:`(N=12)` and :math:`t` counts the repetitions of this seasonal cycle,
+    here the years. Here :math:`\\epsilon` is a white noise process, i.e. :math:`\\epsilon \\sim N(0, \\sigma^2)`.
+    For more information refer to Storch and Zwiers (1999) Chapter 10.3.8 [1].
+
+    [1] Storch H von, Zwiers FW. Statistical Analysis in Climate Research. 
+        **Cambridge University Press; 1999,** `DOI:10.1017/CBO9780511612336 <https://doi.org/10.1017/CBO9780511612336>`_. 
+
+
     Parameters
     ----------
-    monthly_data : `xr.DataArray` of shape (n_timesteps, n_gridpoints)
+    monthly_data : ``xr.DataArray`` of shape (n_timesteps, n_gridpoints)
         A ``xr.DataArray`` to estimate the auto regression over. Each month has a value.
     time_dim : str
         Name of the time dimension (dimension along which to fit the auto regression).
 
     Returns
     -------
-    ar_params : `xr.Dataset`
-        Dataset containing the estimated parameters of the AR(1) process, the ``intercept``and the
+    ar_params : ``xr.Dataset``
+        Dataset containing the estimated parameters of the AR(1) process, the ``intercept`` and the
         ``slope`` for each month and gridpoint.
     """
     _check_dataarray_form(monthly_data, "monthly_data", ndim=2, required_dims=time_dim)
@@ -658,8 +675,8 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
 
 def _fit_auto_regression_monthly_np(data_month, data_prev_month):
     """fit an auto regression of lag one (AR(1)) on monthly data - numpy wrapper
-    We use a linear function to relate the independent previous month's
-    data to the dependent current month's data.
+    We use a linear function to relate the previous month's
+    data (predictor/independent variable) to the current month's data (target/ dependent variable).
 
     Parameters
     ----------

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -769,10 +769,6 @@ def _predict_auto_regression_monthly_np(intercept, slope, n_ts, buffer):
     for y in range(n_years + buffer):
         for month in range(12):
             prev_month = 11 if month == 0 else month - 1
-            if month == 0:
-                prev_month = 11
-            else:
-                prev_month = month - 1
 
             out[y, month] = intercept[month] + slope[month] * out[y - 1, prev_month]
 

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -651,7 +651,9 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
 
         ar_params.append(xr.Dataset({"slope": slope, "intercept": intercept}))
 
-    return xr.concat(ar_params, dim="month")
+    month = xr.Variable("month", np.arange(1, 13))
+    
+    return xr.concat(ar_params, dim=month)
 
 
 def _fit_auto_regression_monthly_np(data_month, data_prev_month):

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -747,7 +747,8 @@ def predict_auto_regression_monthly(ar_params, time, buffer):
         required_dims=(month_dim, gridcell_dim),
     )
     _check_dataarray_form(
-        ar_params.slope, "slope", ndim=2, required_dims=(month_dim, gridcell_dim)
+        ar_params.slope, "slope", ndim=2, required_dims=(month_dim, gridcell_dim),
+        shape=(n_months, n_gridpoints),
     )
     result = _draw_ar_corr_monthly_xr_internal(
         intercept=ar_params.intercept,
@@ -815,7 +816,7 @@ def draw_auto_regression_monthly(
     """
     # check input
     _check_dataset_form(ar_params, "ar_params", required_vars=("intercept", "slope"))
-    month_dim, gridcell_dim = (ar_params.intercept.dims,)
+    month_dim, gridcell_dim = ar_params.intercept.dims
     n_months, size = ar_params.intercept.shape
     _check_dataarray_form(
         ar_params.intercept,

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -717,12 +717,16 @@ def predict_auto_regression_monthly(ar_params, time, buffer):
     """
     # the AR process alone is deterministic so we dont need realisations here
     # or a seed
-    _check_dataset_form(
-        ar_params, "ar_params", required_vars=("intercept", "slope")
+    _check_dataset_form(ar_params, "ar_params", required_vars=("intercept", "slope"))
+    (month_dim, gridcell_dim), (n_months, n_gridpoints) = (
+        ar_params.intercept.dims,
+        ar_params.intercept.shape,
     )
-    (month_dim, gridcell_dim), (n_months, n_gridpoints) = ar_params.intercept.dims, ar_params.intercept.shape
     _check_dataarray_form(
-        ar_params.intercept, "intercept", ndim=2, required_dims=(month_dim, gridcell_dim)
+        ar_params.intercept,
+        "intercept",
+        ndim=2,
+        required_dims=(month_dim, gridcell_dim),
     )
     _check_dataarray_form(
         ar_params.slope, "slope", ndim=2, required_dims=(month_dim, gridcell_dim)
@@ -801,12 +805,16 @@ def draw_auto_regression_monthly(
 
     """
     # check input
-    _check_dataset_form(
-        ar_params, "ar_params", required_vars=("intercept", "slope")
+    _check_dataset_form(ar_params, "ar_params", required_vars=("intercept", "slope"))
+    (month_dim, gridcell_dim), (n_months, size) = (
+        ar_params.intercept.dims,
+        ar_params.intercept.shape,
     )
-    (month_dim, gridcell_dim), (n_months, size) = ar_params.intercept.dims, ar_params.intercept.shape
     _check_dataarray_form(
-        ar_params.intercept, "intercept", ndim=2, required_dims=(month_dim, gridcell_dim)
+        ar_params.intercept,
+        "intercept",
+        ndim=2,
+        required_dims=(month_dim, gridcell_dim),
     )
     _check_dataarray_form(
         ar_params.slope, "slope", ndim=2, required_dims=(month_dim, gridcell_dim)

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -761,7 +761,7 @@ def _predict_auto_regression_monthly_np(intercept, slope, n_ts, buffer):
     out : np.array of shape (n_ts/12, 12)
         Predicted time series of the specified AR(1).
     """
-    if not n_ts % 12 == 0:
+    if n_ts % 12 != 0:
         raise ValueError("The number of time steps must be a multiple of 12.")
     n_years = n_ts // 12
 

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -633,8 +633,8 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
             n_ts = monthly_data[12].sizes[time_dim]
             prev_month = monthly_data[12].isel({time_dim: slice(0, n_ts - 1)})
 
-            n_ts = monthly_data[month].sizes[time_dim]
-            cur_month = monthly_data[month].isel({time_dim: slice(1, n_ts)})
+            n_ts = monthly_data[1].sizes[time_dim]
+            cur_month = monthly_data[1].isel({time_dim: slice(1, n_ts)})
         else:
             prev_month = monthly_data[month - 1]
             cur_month = monthly_data[month]

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -604,7 +604,7 @@ def _fit_auto_regression_np(data, lags):
 
 
 def fit_auto_regression_monthly(monthly_data, time_dim="time"):
-    """fit a cyclo-stationary auto-regressive process of lag one (AR(1)) on monthly 
+    """fit a cyclo-stationary auto-regressive process of lag one (AR(1)) on monthly
     data. The parameters are estimated for each month and gridpoint separately.
     This is based on the assuption that e.g. June depends on May differently
     than July on June. The auto regression is fit along `time_dim`.
@@ -613,17 +613,17 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
 
     .. math::
 
-        \\mathbf{X}_{t, \\tau} = \\alpha_{0, \\tau} + \\alpha_{1, \\tau} \\mathbf{X}_{t, \\tau -1} 
+        \\mathbf{X}_{t, \\tau} = \\alpha_{0, \\tau} + \\alpha_{1, \\tau} \\mathbf{X}_{t, \\tau -1}
         + \\epsilon_{t, \\tau}
 
 
-    where :math:`\\tau \\in \\{1, \\ldots, N\\}` counts the seasons of some seasonal cycle, here the 
+    where :math:`\\tau \\in \\{1, \\ldots, N\\}` counts the seasons of some seasonal cycle, here the
     months of a year :math:`(N=12)` and :math:`t` counts the repetitions of this seasonal cycle,
     here the years. Here :math:`\\epsilon` is a white noise process, i.e. :math:`\\epsilon \\sim N(0, \\sigma^2)`.
     For more information refer to Storch and Zwiers (1999) Chapter 10.3.8 [1].
 
-    [1] Storch H von, Zwiers FW. Statistical Analysis in Climate Research. 
-        **Cambridge University Press; 1999,** `DOI:10.1017/CBO9780511612336 <https://doi.org/10.1017/CBO9780511612336>`_. 
+    [1] Storch H von, Zwiers FW. Statistical Analysis in Climate Research.
+        **Cambridge University Press; 1999,** `DOI:10.1017/CBO9780511612336 <https://doi.org/10.1017/CBO9780511612336>`_.
 
 
     Parameters
@@ -747,7 +747,10 @@ def predict_auto_regression_monthly(ar_params, time, buffer):
         required_dims=(month_dim, gridcell_dim),
     )
     _check_dataarray_form(
-        ar_params.slope, "slope", ndim=2, required_dims=(month_dim, gridcell_dim),
+        ar_params.slope,
+        "slope",
+        ndim=2,
+        required_dims=(month_dim, gridcell_dim),
         shape=(n_months, n_gridpoints),
     )
     result = _draw_ar_corr_monthly_xr_internal(

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -798,10 +798,8 @@ def draw_auto_regression_monthly(
     """
     # check input
     _check_dataset_form(ar_params, "ar_params", required_vars=("intercept", "slope"))
-    (month_dim, gridcell_dim), (n_months, size) = (
-        ar_params.intercept.dims,
-        ar_params.intercept.shape,
-    )
+    month_dim, gridcell_dim = ar_params.intercept.dims,
+    n_months, size = ar_params.intercept.shape
     _check_dataarray_form(
         ar_params.intercept,
         "intercept",

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -917,8 +917,6 @@ def _draw_auto_regression_monthly_np(
                     "Covariance matrix is not positive definite, using eigh instead of cholesky.",
                     LinAlgWarning,
                 )
-            else:
-                raise
 
         innovations[:, :, month, :] = scipy.stats.multivariate_normal.rvs(
             mean=np.zeros(n_gridcells),

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -726,7 +726,7 @@ def predict_auto_regression_monthly(intercept, slope, time, buffer, month_dim="m
         intercept,
         slope,
         input_core_dims=[[month_dim], [month_dim]],
-        output_core_dims=[['time']],
+        output_core_dims=[["time"]],
         vectorize=True,
         # dask="parallelized",
         output_dtypes=[float],
@@ -768,7 +768,7 @@ def _predict_auto_regression_monthly_np(intercept, slope, n_ts, buffer):
     out = np.zeros([n_ts + buffer])
 
     for t in range(n_ts + buffer):
-            month = t % 12
-            out[t] = intercept[month] + slope[month] * out[t-1]
+        month = t % 12
+        out[t] = intercept[month] + slope[month] * out[t - 1]
 
     return out[buffer:]

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -798,7 +798,7 @@ def draw_auto_regression_monthly(
     """
     # check input
     _check_dataset_form(ar_params, "ar_params", required_vars=("intercept", "slope"))
-    month_dim, gridcell_dim = ar_params.intercept.dims,
+    month_dim, gridcell_dim = (ar_params.intercept.dims,)
     n_months, size = ar_params.intercept.shape
     _check_dataarray_form(
         ar_params.intercept,

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -769,7 +769,8 @@ def _predict_auto_regression_monthly_np(intercept, slope, n_ts, buffer):
     for y in range(n_years + buffer):
         for month in range(12):
             prev_month = 11 if month == 0 else month - 1
+            yy = y - 1 if month == 0 else y
 
-            out[y, month] = intercept[month] + slope[month] * out[y - 1, prev_month]
+            out[y, month] = intercept[month] + slope[month] * out[yy, prev_month]
 
     return out[buffer:, :]

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -771,6 +771,7 @@ def predict_auto_regression_monthly(ar_params, time, buffer):
 def draw_auto_regression_monthly(
     ar_params,
     covariance,
+    *,
     time,
     n_realisations,
     seed,

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -619,7 +619,7 @@ def fit_auto_regression_monthly(monthly_data, time_dim="time"):
     if not isinstance(monthly_data, xr.DataArray):
         raise TypeError(f"Expected a `xr.DataArray`, got {type(monthly_data)}")
 
-    monthly_data = monthly_data.groupby(time_dim + ".month")
+    monthly_data = monthly_data.groupby(f"{time_dim}.month")
     coeffs = []
 
     for month in range(1, 13):

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -595,8 +595,8 @@ def test_fit_auto_regression_np(lags):
         mocked_auto_regression_result.fit.assert_called_with()
 
 
-@pytest.mark.parametrize("slope", [0.2, -0.3])
 @pytest.mark.parametrize("intercept", [1.0, -4.0])
+@pytest.mark.parametrize("slope", [0.2, -0.3])
 def test_fit_autoregression_monthly_np(slope, intercept):
     # test if autoregrerssion can fit using previous month as independent variable
     # and current month as dependent variable

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -668,7 +668,7 @@ def test_predict_auto_regression_monthly_np():
         intercept, slope, 120, 0
     )
 
-    expected = np.tile(intercept, 10).reshape(10, 12)
+    expected = np.tile(intercept, 10)
     np.testing.assert_allclose(result, expected)
 
     with pytest.raises(
@@ -679,7 +679,7 @@ def test_predict_auto_regression_monthly_np():
         )
 
 
-@pytest.mark.parametrize("buffer", [2, 5, 10])
+@pytest.mark.parametrize("buffer", [2, 12, 12*5])
 def test_predict_auto_regression_monthly_np_buffer(buffer):
     slope = np.random.normal(size=12)
     intercept = np.ones(12)
@@ -691,7 +691,7 @@ def test_predict_auto_regression_monthly_np_buffer(buffer):
         intercept, slope, n_ts, buffer
     )
 
-    np.testing.assert_allclose(res_wo_buffer[buffer:, :], res_w_buffer[:-buffer, :])
+    np.testing.assert_allclose(res_wo_buffer[buffer:], res_w_buffer[:-buffer])
 
 
 def test_predict_auto_regression_monthly():
@@ -738,7 +738,7 @@ def test_predict_auto_regression_monthly():
 def test_fit_predict_autoregression_monthly_roundtrip():
     n_gridcells = 10
     n_years = 150
-    buffer = 30
+    buffer = 30*12
     np.random.seed(0)
     slopes = xr.DataArray(
         np.random.uniform(-0.99, 0.99, size=(12, n_gridcells)),

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -807,10 +807,10 @@ def test_draw_auto_regression_monthly():
     result = mesmer.stats.draw_auto_regression_monthly(
         ar_params,
         covariance,
-        time,
-        n_realisations,
-        seed,
-        buffer,
+        time = time,
+        n_realisations = n_realisations,
+        seed = seed,
+        buffer = buffer,
     )
 
     _check_dataarray_form(

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -763,6 +763,7 @@ def test_fit_predict_autoregression_monthly_roundtrip():
 
     np.testing.assert_allclose(predicted, data)
 
+
 @pytest.mark.parametrize("buffer", [2, 12, 12 * 5])
 def test_draw_auto_regression_monthly_np_buffer(buffer):
     n_realisations = 1
@@ -817,14 +818,14 @@ def test_draw_auto_regression_monthly():
     time = xr.DataArray(time, dims="time", coords={"time": time})
 
     result = mesmer.stats.draw_auto_regression_monthly(
-        intercepts, 
-        slopes, 
+        intercepts,
+        slopes,
         covariance,
-        time, 
+        time,
         n_realisations,
         seed,
         buffer,
-        )
+    )
 
     _check_dataarray_form(
         result,

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -680,7 +680,8 @@ def test_predict_auto_regression_monthly_intercept():
     n_years = 10
     time = pd.date_range("2000-01-01", periods=12 * n_years, freq="M")
     time = xr.DataArray(time, dims="time", coords={"time": time})
-    result = mesmer.stats.predict_auto_regression_monthly(ar_params, time, 0)
+
+    result = mesmer.stats.predict_auto_regression_monthly(ar_params, time, buffer=0)
 
     expected = np.tile(np.arange(1, 13), [n_gridcells, n_years]).T
     expected[0] = 0

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -662,7 +662,7 @@ def test_fit_auto_regression_monthly():
 
 
 def test_predict_auto_regression_monthly_np():
-    slope = np.repeat(0.0, 12)
+    slope = np.zeros(12)
     intercept = np.arange(1, 13)
     result = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
         intercept, slope, 120, 0

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -712,7 +712,7 @@ def test_predict_auto_regression_monthly():
     time = pd.date_range("2000-01-01", periods=n_years * 12, freq="M")
     time = xr.DataArray(time, dims="time", coords={"time": time})
 
-    result = mesmer.stats.predict_auto_regression_monthly(ar_params, time, 10)
+    result = mesmer.stats.predict_auto_regression_monthly(ar_params, time, buffer=10)
 
     _check_dataarray_form(
         result,

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -668,7 +668,8 @@ def test_predict_auto_regression_monthly_np():
         intercept, slope, 120, 0
     )
 
-    np.testing.assert_allclose(result, np.tile(intercept, 10).reshape(10, 12))
+    expected = np.tile(intercept, 10).reshape(10, 12)
+    np.testing.assert_allclose(result, expected)
 
     with pytest.raises(
         ValueError, match="The number of time steps must be a multiple of 12"

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -682,16 +682,17 @@ def test_predict_auto_regression_monthly_np():
 def test_predict_auto_regression_monthly_np_buffer(buffer):
     slope = np.random.normal(size=12)
     intercept = np.ones(12)
+    n_ts = 120
     result_wo_buffer = (
         mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
-            intercept, slope, 120, 0
+            intercept, slope, n_ts, 0
         )
     )
     result_w_buffer = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
-        intercept, slope, 120, buffer
+        intercept, slope, n_ts, buffer
     )
 
-    np.testing.assert_allclose(result_wo_buffer[buffer:, :], result_w_buffer)
+    np.testing.assert_allclose(result_wo_buffer[buffer:, :], result_w_buffer[:-buffer, :])
 
 
 def test_predict_auto_regression_monthly():

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -683,6 +683,7 @@ def test_predict_auto_regression_monthly_intercept():
     result = mesmer.stats.predict_auto_regression_monthly(ar_params, time, 0)
 
     expected = np.tile(np.arange(1, 13), [n_gridcells, n_years]).T
+    expected[0] = 0
     expected = xr.DataArray(
         expected,
         dims=("time", "gridcell"),

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -747,9 +747,7 @@ def test_fit_predict_autoregression_monthly_roundtrip():
 
     data = mesmer.stats.predict_auto_regression_monthly(ar_params, time, buffer)
     AR_fit = mesmer.stats.fit_auto_regression_monthly(data)
-    predicted = mesmer.stats.predict_auto_regression_monthly(
-        AR_fit, data.time, buffer
-    )
+    predicted = mesmer.stats.predict_auto_regression_monthly(AR_fit, data.time, buffer)
 
     np.testing.assert_allclose(predicted, data)
 

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -684,7 +684,7 @@ def test_predict_auto_regression_monthly_np_buffer(buffer):
     slope = np.random.normal(size=12)
     intercept = np.ones(12)
     n_ts = 120
-    result_wo_buffer = (
+    res_wo_buffer = (
         mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
             intercept, slope, n_ts, 0
         )

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -664,23 +664,37 @@ def test_fit_auto_regression_monthly():
 def test_predict_auto_regression_monthly_intercept():
     n_gridcells = 2
     slope = np.zeros((12, n_gridcells))
-    slope = xr.DataArray(slope, dims=("month", "gridcell"), coords={"month": np.arange(1, 13), "gridcell": np.arange(n_gridcells)})
+    slope = xr.DataArray(
+        slope,
+        dims=("month", "gridcell"),
+        coords={"month": np.arange(1, 13), "gridcell": np.arange(n_gridcells)},
+    )
     intercept = np.tile(np.arange(1, 13), n_gridcells).reshape(n_gridcells, 12).T
-    intercept = xr.DataArray(intercept, dims=("month", "gridcell"), coords={"month": np.arange(1, 13), "gridcell": np.arange(n_gridcells)})
-
-    n_years = 10
-    time = pd.date_range("2000-01-01", periods=12*n_years, freq="M")
-    time = xr.DataArray(time, dims = "time", coords={"time": time})
-    result = mesmer.stats.predict_auto_regression_monthly(
-        intercept, slope, time, 0
+    intercept = xr.DataArray(
+        intercept,
+        dims=("month", "gridcell"),
+        coords={"month": np.arange(1, 13), "gridcell": np.arange(n_gridcells)},
     )
 
-    expected = np.tile(np.arange(1, 13), n_gridcells * n_years).reshape(n_gridcells, 12 * n_years).T
-    expected = xr.DataArray(expected, dims=("time", "gridcell"), coords={"time": time, "gridcell": np.arange(n_gridcells)})
+    n_years = 10
+    time = pd.date_range("2000-01-01", periods=12 * n_years, freq="M")
+    time = xr.DataArray(time, dims="time", coords={"time": time})
+    result = mesmer.stats.predict_auto_regression_monthly(intercept, slope, time, 0)
+
+    expected = (
+        np.tile(np.arange(1, 13), n_gridcells * n_years)
+        .reshape(n_gridcells, 12 * n_years)
+        .T
+    )
+    expected = xr.DataArray(
+        expected,
+        dims=("time", "gridcell"),
+        coords={"time": time, "gridcell": np.arange(n_gridcells)},
+    )
     np.testing.assert_allclose(result, expected)
 
 
-@pytest.mark.parametrize("buffer", [2, 12, 12*5])
+@pytest.mark.parametrize("buffer", [2, 12, 12 * 5])
 def test_draw_auto_regression_monthly_np_buffer(buffer):
     n_realisations = 1
     n_gridcells = 10
@@ -689,15 +703,17 @@ def test_draw_auto_regression_monthly_np_buffer(buffer):
     intercept = np.ones((12, n_gridcells))
     covariance = np.tile(np.eye(n_gridcells), 12).reshape(12, n_gridcells, n_gridcells)
     n_ts = 120
-    
+
     res_wo_buffer = mesmer.stats._auto_regression._draw_auto_regression_monthly_np(
-        intercept, slope, covariance, n_realisations,  n_ts, seed, buffer = 0
+        intercept, slope, covariance, n_realisations, n_ts, seed, buffer=0
     )
     res_w_buffer = mesmer.stats._auto_regression._draw_auto_regression_monthly_np(
-        intercept, slope, covariance, n_realisations,  n_ts, seed, buffer = buffer
+        intercept, slope, covariance, n_realisations, n_ts, seed, buffer=buffer
     )
 
-    np.testing.assert_allclose(res_wo_buffer[:, buffer:, :], res_w_buffer[:, :-buffer, :])
+    np.testing.assert_allclose(
+        res_wo_buffer[:, buffer:, :], res_w_buffer[:, :-buffer, :]
+    )
 
 
 def test_predict_auto_regression_monthly():

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -745,9 +745,7 @@ def test_fit_predict_autoregression_monthly_roundtrip():
     time = pd.date_range("2000-01-01", periods=n_years * 12, freq="M")
     time = xr.DataArray(time, dims="time", coords={"time": time})
 
-    data = mesmer.stats.predict_auto_regression_monthly(
-        ar_params, time, buffer
-    )
+    data = mesmer.stats.predict_auto_regression_monthly(ar_params, time, buffer)
     AR_fit = mesmer.stats.fit_auto_regression_monthly(data)
     predicted = mesmer.stats.predict_auto_regression_monthly(
         ar_params, data.time, buffer

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -692,7 +692,9 @@ def test_predict_auto_regression_monthly_np_buffer(buffer):
         intercept, slope, n_ts, buffer
     )
 
-    np.testing.assert_allclose(result_wo_buffer[buffer:, :], result_w_buffer[:-buffer, :])
+    np.testing.assert_allclose(
+        result_wo_buffer[buffer:, :], result_w_buffer[:-buffer, :]
+    )
 
 
 def test_predict_auto_regression_monthly():

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -748,7 +748,7 @@ def test_fit_predict_autoregression_monthly_roundtrip():
     data = mesmer.stats.predict_auto_regression_monthly(ar_params, time, buffer)
     AR_fit = mesmer.stats.fit_auto_regression_monthly(data)
     predicted = mesmer.stats.predict_auto_regression_monthly(
-        ar_params, data.time, buffer
+        AR_fit, data.time, buffer
     )
 
     np.testing.assert_allclose(predicted, data)

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -669,7 +669,7 @@ def test_predict_auto_regression_monthly_intercept():
         dims=("month", "gridcell"),
         coords={"month": np.arange(1, 13), "gridcell": np.arange(n_gridcells)},
     )
-    intercept = np.tile(np.arange(1, 13), n_gridcells).reshape(n_gridcells, 12).T
+    intercept = np.tile(np.arange(1, 13), [n_gridcells, 1]).T
     intercept = xr.DataArray(
         intercept,
         dims=("month", "gridcell"),
@@ -682,11 +682,7 @@ def test_predict_auto_regression_monthly_intercept():
     time = xr.DataArray(time, dims="time", coords={"time": time})
     result = mesmer.stats.predict_auto_regression_monthly(ar_params, time, 0)
 
-    expected = (
-        np.tile(np.arange(1, 13), n_gridcells * n_years)
-        .reshape(n_gridcells, 12 * n_years)
-        .T
-    )
+    expected = np.tile(np.arange(1, 13), [n_gridcells, n_years]).T
     expected = xr.DataArray(
         expected,
         dims=("time", "gridcell"),
@@ -757,9 +753,9 @@ def test_draw_auto_regression_monthly_np_buffer(buffer):
     n_realisations = 1
     n_gridcells = 10
     seed = 0
-    slope = np.random.normal(size=(12, n_gridcells))
+    slope = np.random.uniform(-1, 1, size=(12, n_gridcells))
     intercept = np.ones((12, n_gridcells))
-    covariance = np.tile(np.eye(n_gridcells), 12).reshape(12, n_gridcells, n_gridcells)
+    covariance = None
     n_ts = 120
 
     res_wo_buffer = mesmer.stats._auto_regression._draw_auto_regression_monthly_np(
@@ -770,7 +766,7 @@ def test_draw_auto_regression_monthly_np_buffer(buffer):
     )
 
     np.testing.assert_allclose(
-        res_wo_buffer[:, buffer:, :], res_w_buffer[:, :-buffer, :]
+        res_wo_buffer[:, buffer*12:, :], res_w_buffer[:, :-buffer*12, :]
     )
 
 
@@ -794,7 +790,7 @@ def test_draw_auto_regression_monthly():
     ar_params = xr.Dataset({"intercept": intercepts, "slope": slopes})
 
     covariance = xr.DataArray(
-        np.tile(np.eye(n_gridcells), 12).T.reshape(12, n_gridcells, n_gridcells),
+        np.tile(np.eye(n_gridcells), [12, 1, 1]),
         dims=("month", "gridcell_i", "gridcell_j"),
         coords={
             "month": np.arange(1, 13),

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -689,7 +689,7 @@ def test_predict_auto_regression_monthly_np_buffer(buffer):
             intercept, slope, n_ts, 0
         )
     )
-    result_w_buffer = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
+    res_w_buffer = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
         intercept, slope, n_ts, buffer
     )
 

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -657,7 +657,7 @@ def test_fit_auto_regression_monthly():
         shape=(12, n_gridcells),
     )
 
-    with pytest.raises(TypeError, match="Expected a `xr.DataArray`"):
+    with pytest.raises(TypeError, match="Expected monthly_data to be an xr.DataArray"):
         mesmer.stats.fit_auto_regression_monthly(data.values)
 
 

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -691,9 +691,7 @@ def test_predict_auto_regression_monthly_np_buffer(buffer):
         intercept, slope, n_ts, buffer
     )
 
-    np.testing.assert_allclose(
-        res_wo_buffer[buffer:, :], res_w_buffer[:-buffer, :]
-    )
+    np.testing.assert_allclose(res_wo_buffer[buffer:, :], res_w_buffer[:-buffer, :])
 
 
 def test_predict_auto_regression_monthly():

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -679,7 +679,7 @@ def test_predict_auto_regression_monthly_np():
         )
 
 
-@pytest.mark.parametrize("buffer", [2, 12, 12*5])
+@pytest.mark.parametrize("buffer", [2, 12, 12 * 5])
 def test_predict_auto_regression_monthly_np_buffer(buffer):
     slope = np.random.normal(size=12)
     intercept = np.ones(12)
@@ -738,7 +738,7 @@ def test_predict_auto_regression_monthly():
 def test_fit_predict_autoregression_monthly_roundtrip():
     n_gridcells = 10
     n_years = 150
-    buffer = 30*12
+    buffer = 30 * 12
     np.random.seed(0)
     slopes = xr.DataArray(
         np.random.uniform(-0.99, 0.99, size=(12, n_gridcells)),

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -807,10 +807,10 @@ def test_draw_auto_regression_monthly():
     result = mesmer.stats.draw_auto_regression_monthly(
         ar_params,
         covariance,
-        time = time,
-        n_realisations = n_realisations,
-        seed = seed,
-        buffer = buffer,
+        time=time,
+        n_realisations=n_realisations,
+        seed=seed,
+        buffer=buffer,
     )
 
     _check_dataarray_form(

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -684,10 +684,8 @@ def test_predict_auto_regression_monthly_np_buffer(buffer):
     slope = np.random.normal(size=12)
     intercept = np.ones(12)
     n_ts = 120
-    res_wo_buffer = (
-        mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
-            intercept, slope, n_ts, 0
-        )
+    res_wo_buffer = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
+        intercept, slope, n_ts, 0
     )
     res_w_buffer = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(
         intercept, slope, n_ts, buffer

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -752,7 +752,7 @@ def test_fit_predict_autoregression_monthly_roundtrip():
     np.testing.assert_allclose(predicted, data)
 
 
-@pytest.mark.parametrize("buffer", [2, 12, 12 * 5])
+@pytest.mark.parametrize("buffer", [1, 10, 20])
 def test_draw_auto_regression_monthly_np_buffer(buffer):
     n_realisations = 1
     n_gridcells = 10

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -694,7 +694,7 @@ def test_predict_auto_regression_monthly_np_buffer(buffer):
     )
 
     np.testing.assert_allclose(
-        result_wo_buffer[buffer:, :], result_w_buffer[:-buffer, :]
+        res_wo_buffer[buffer:, :], res_w_buffer[:-buffer, :]
     )
 
 

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -593,3 +593,109 @@ def test_fit_auto_regression_np(lags):
 
         mocked_auto_regression_result.fit.assert_called_once()
         mocked_auto_regression_result.fit.assert_called_with()
+
+
+@pytest.mark.parametrize("slope", [0.2, -0.3])
+@pytest.mark.parametrize("intercept", [1., -4.])
+def test_fit_autoregression_monthly_np(slope, intercept):
+    # test if autoregrerssion can fit using previous month as independent variable
+    # and current month as dependent variable
+    # NOTE: the fit for the slope is bounded between -1 and 1
+    np.random.seed(0)
+    prev_month = np.random.normal(size=100)
+    cur_month = prev_month * slope + intercept
+
+    result = mesmer.stats._auto_regression._fit_auto_regression_monthly_np(cur_month, prev_month)
+    expected = (slope, intercept)
+    np.testing.assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize("slope", [2., -2])
+def test_fit_autoregression_monthly_np_outside_bounds(slope):
+    # test that given a slope outside the bounds of -1 and 1, the slope is clipped
+    np.random.seed(0)
+    prev_month = np.random.normal(size=100)
+    cur_month = prev_month * slope + 3
+
+    result = mesmer.stats._auto_regression._fit_auto_regression_monthly_np(cur_month, prev_month)
+    expected_slope = 1. * np.sign(slope)
+    np.testing.assert_allclose(result[0], expected_slope)
+
+
+def test_fit_auto_regression_monthly():
+    n_years = 20
+    n_gridcells = 10
+    np.random.seed(0)
+    data = xr.DataArray(np.random.normal(size=(n_years*12, n_gridcells)), dims=("time", "gridcell"),
+                        coords={"time": pd.date_range("2000-01-01", periods=n_years*12, freq="M"),
+                                "gridcell": np.arange(n_gridcells)})
+
+    result = mesmer.stats.fit_auto_regression_monthly(data)
+    
+    _check_dataset_form(result, "result", required_vars={"slope", "intercept"})
+    _check_dataarray_form(result.slope, "slope", ndim=2, required_dims={"month", "gridcell"}, shape=(12, n_gridcells))
+    _check_dataarray_form(result.intercept, "intercept", ndim=2, required_dims={"month", "gridcell"}, shape=(12,n_gridcells))
+    
+    with pytest.raises(TypeError, match="Expected a `xr.DataArray`"):
+        mesmer.stats.fit_auto_regression_monthly(data.values)
+
+def test_predict_auto_regression_monthly_np():
+    slope = np.repeat(0.0, 12)
+    intercept = np.arange(1,13)
+    result = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(intercept, slope, 120, 0)
+
+    np.testing.assert_allclose(result, np.tile(intercept, 10).reshape(10, 12))
+
+    with pytest.raises(ValueError, match="The number of time steps must be a multiple of 12"):
+        mesmer.stats._auto_regression._predict_auto_regression_monthly_np(intercept, slope, 100, 0)
+
+@pytest.mark.parametrize("buffer", [2, 5, 10])
+def test_predict_auto_regression_monthly_np_buffer(buffer):
+    slope = np.random.normal(size=12)
+    intercept = np.ones(12)
+    result_wo_buffer = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(intercept, slope, 120, 0)
+    result_w_buffer = mesmer.stats._auto_regression._predict_auto_regression_monthly_np(intercept, slope, 120, buffer)
+
+    np.testing.assert_allclose(result_wo_buffer[buffer:, :], result_w_buffer)
+
+def test_predict_auto_regression_monthly():
+    n_gridcells = 10
+    n_years = 10
+    np.random.seed(0)
+    slopes = xr.DataArray(np.random.normal(-0.99,0.99, size=(12, n_gridcells)), dims=("month", "gridcell"),
+                              coords={"month": np.arange(1,13), "gridcell": np.arange(n_gridcells)})
+    intercepts = xr.DataArray(np.random.normal(-10,10, size=(12, n_gridcells)), dims=("month", "gridcell"),
+                            coords={"month": np.arange(1,13), "gridcell": np.arange(n_gridcells)})
+    time = pd.date_range("2000-01-01", periods=n_years*12, freq="M")
+    time = xr.DataArray(time, dims="time", coords={"time": time})
+    
+    result = mesmer.stats.predict_auto_regression_monthly(intercepts, slopes, time, 10)
+
+    _check_dataarray_form(result, "result", ndim=2, required_dims={"time", "gridcell"}, shape=(len(time), n_gridcells))
+
+    with pytest.raises(TypeError, match="Expected a `xr.DataArray`"):
+        mesmer.stats.predict_auto_regression_monthly(intercepts.values, slopes, time, 10)
+    with pytest.raises(TypeError, match="Expected a `xr.DataArray`"):
+        mesmer.stats.predict_auto_regression_monthly(intercepts, slopes.values, time, 10)
+    with pytest.raises(TypeError, match="Expected a `xr.DataArray`"):
+        mesmer.stats.predict_auto_regression_monthly(intercepts, slopes, time.values, 10)
+
+
+def test_fit_predict_autoregression_monthly_roundtrip():
+    n_gridcells = 10
+    n_years = 150
+    buffer = 30
+    np.random.seed(0)
+    slopes = xr.DataArray(np.random.uniform(-0.99,0.99, size=(12, n_gridcells)), dims=("month", "gridcell"),
+                              coords={"month": np.arange(1,13), "gridcell": np.arange(n_gridcells)})
+    intercepts = xr.DataArray(np.random.normal(-10,10, size=(12, n_gridcells)), dims=("month", "gridcell"),
+                            coords={"month": np.arange(1,13), "gridcell": np.arange(n_gridcells)})
+    time = pd.date_range("2000-01-01", periods=n_years*12, freq="M")
+    time = xr.DataArray(time, dims="time", coords={"time": time})
+    
+    data = mesmer.stats.predict_auto_regression_monthly(intercepts, slopes, time, buffer)
+    AR_fit = mesmer.stats.fit_auto_regression_monthly(data)
+    predicted = mesmer.stats.predict_auto_regression_monthly(AR_fit.intercept, AR_fit.slope, data.time, buffer)
+
+    np.testing.assert_allclose(predicted, data)
+

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -767,7 +767,7 @@ def test_draw_auto_regression_monthly_np_buffer(buffer):
     )
 
     np.testing.assert_allclose(
-        res_wo_buffer[:, buffer*12:, :], res_w_buffer[:, :-buffer*12, :]
+        res_wo_buffer[:, buffer * 12 :, :], res_w_buffer[:, : -buffer * 12, :]
     )
 
 


### PR DESCRIPTION
 - [x] Tests added
 - [x] Fully documented, including `CHANGELOG.rst`

Similar to MESMER, we also use an AR1 process to emulate local variability in MESMER-M. However, we cannot recycle the original AR functionalities since MESMER-M fits AR parameters for each month individually (➡️ how does June depend on May, how does July depend on June?). In this PR I add the functionalities to achieve this. 