### PR TITLE
GHA: use codecov token

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -78,6 +78,8 @@ jobs:
 
     - name: Upload code coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
           file: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #506

Follows the instruction at https://docs.codecov.com/docs/adding-the-codecov-token

(I admit opening a issue for this was probably overkill...)