### PR TITLE
fit_harmonic_model: n_sel -> selected_order

### DIFF
--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -193,7 +193,7 @@ def _fit_fourier_order_np(yearly_predictor, monthly_target, max_order):
     -------
     selected_order : Integer
         Selected order of Fourier Series.
-    coeffs : array-like of size (4*n_sel,)
+    coeffs : array-like of size (4 * order,)
         Fitted coefficients for the selected order of Fourier Series.
     predictions : array-like of size (n_years*12,)
         Predicted monthly values from final model.
@@ -246,7 +246,7 @@ def fit_harmonic_model(yearly_predictor, monthly_target, max_order=6, time_dim="
     Returns
     -------
     data_vars : `xr.Dataset`
-        Dataset containing the selected order of Fourier Series (n_sel), the estimated
+        Dataset containing the selected order of Fourier Series (order), the estimated
         coefficients of the Fourier Series (coeffs) and the resulting predictions for
         monthly values (predictions).
 
@@ -268,7 +268,7 @@ def fit_harmonic_model(yearly_predictor, monthly_target, max_order=6, time_dim="
     # subtract annual mean to have seasonal anomalies around 0
     seasonal_deviations = monthly_target - yearly_predictor
 
-    n_sel, coeffs, preds = xr.apply_ufunc(
+    order, coeffs, preds = xr.apply_ufunc(
         _fit_fourier_order_np,
         yearly_predictor,
         seasonal_deviations,
@@ -282,7 +282,7 @@ def fit_harmonic_model(yearly_predictor, monthly_target, max_order=6, time_dim="
     preds = yearly_predictor + preds
 
     data_vars = {
-        "n_sel": n_sel,
+        "order": order,
         "coeffs": coeffs,
         "predictions": preds.transpose(time_dim, ...),
     }

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -193,7 +193,7 @@ def _fit_fourier_order_np(yearly_predictor, monthly_target, max_order):
     -------
     selected_order : Integer
         Selected order of Fourier Series.
-    coeffs : array-like of size (4 * order,)
+    coeffs : array-like of size (4 * max_order,)
         Fitted coefficients for the selected order of Fourier Series.
     predictions : array-like of size (n_years*12,)
         Predicted monthly values from final model.
@@ -246,9 +246,9 @@ def fit_harmonic_model(yearly_predictor, monthly_target, max_order=6, time_dim="
     Returns
     -------
     data_vars : `xr.Dataset`
-        Dataset containing the selected order of Fourier Series (order), the estimated
-        coefficients of the Fourier Series (coeffs) and the resulting predictions for
-        monthly values (predictions).
+        Dataset containing the selected order of Fourier Series (selected_order),
+        the estimated coefficients of the Fourier Series (coeffs) and the resulting
+        predictions for monthly values (predictions).
 
     """
 
@@ -268,7 +268,7 @@ def fit_harmonic_model(yearly_predictor, monthly_target, max_order=6, time_dim="
     # subtract annual mean to have seasonal anomalies around 0
     seasonal_deviations = monthly_target - yearly_predictor
 
-    order, coeffs, preds = xr.apply_ufunc(
+    selected_order, coeffs, preds = xr.apply_ufunc(
         _fit_fourier_order_np,
         yearly_predictor,
         seasonal_deviations,
@@ -282,7 +282,7 @@ def fit_harmonic_model(yearly_predictor, monthly_target, max_order=6, time_dim="
     preds = yearly_predictor + preds
 
     data_vars = {
-        "order": order,
+        "selected_order": selected_order,
         "coeffs": coeffs,
         "predictions": preds.transpose(time_dim, ...),
     }

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -156,7 +156,7 @@ def test_fit_harmonic_model():
 
     # test if the model can recover the monthly target from perfect fourier series
     result = mesmer.stats.fit_harmonic_model(yearly_predictor, monthly_target)
-    np.testing.assert_equal(result.order.values, orders)
+    np.testing.assert_equal(result.selected_order.values, orders)
     xr.testing.assert_allclose(result["predictions"], monthly_target)
 
     # test if the model can recover the underlying cycle with noise on top of monthly target

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -156,7 +156,7 @@ def test_fit_harmonic_model():
 
     # test if the model can recover the monthly target from perfect fourier series
     result = mesmer.stats.fit_harmonic_model(yearly_predictor, monthly_target)
-    np.testing.assert_equal(result.n_sel.values, orders)
+    np.testing.assert_equal(result.order.values, orders)
     xr.testing.assert_allclose(result["predictions"], monthly_target)
 
     # test if the model can recover the underlying cycle with noise on top of monthly target


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

I think `order` is more descriptive than `n_sel`. We could also go for `selected_order`

Is there a reason we choose `n_sel` that I forgot about? 
