### PR TITLE
fix preds in `fit_harmonic_model`

### DIFF
--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -147,11 +147,8 @@ def _fit_fourier_coeffs_np(yearly_predictor, monthly_target, first_guess):
 
     coeffs = minimize_result.x
     mse = np.mean(minimize_result.fun**2)
-    preds = _generate_fourier_series_np(
-        yearly_predictor=yearly_predictor, coeffs=coeffs
-    )
 
-    return coeffs, preds, mse
+    return coeffs, mse
 
 
 def _calculate_bic(n_samples, order, mse):
@@ -206,7 +203,7 @@ def _fit_fourier_order_np(yearly_predictor, monthly_target, max_order):
 
     for i_order in range(1, max_order + 1):
 
-        coeffs, predictions, mse = _fit_fourier_coeffs_np(
+        coeffs, mse = _fit_fourier_coeffs_np(
             yearly_predictor,
             monthly_target,
             # use coeffs from last iteration as first guess
@@ -220,6 +217,10 @@ def _fit_fourier_order_np(yearly_predictor, monthly_target, max_order):
             selected_order = i_order
         else:
             break
+
+    predictions = _generate_fourier_series_np(
+        yearly_predictor=yearly_predictor, coeffs=last_coeffs
+    )
 
     # need the coeff array to be the same size for all orders
     coeffs = np.full(max_order * 4, fill_value=np.nan)

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -162,7 +162,7 @@ def test_fit_harmonic_model():
     # test if the model can recover the underlying cycle with noise on top of monthly target
     rng = np.random.default_rng(0)
     noisy_monthly_target = monthly_target + rng.normal(
-        loc=0, scale=0.1, size=monthly_target.values.shape
+        loc=0, scale=0.1, size=monthly_target.shape
     )
 
     result = mesmer.stats.fit_harmonic_model(yearly_predictor, noisy_monthly_target)
@@ -171,27 +171,30 @@ def test_fit_harmonic_model():
     # compare numerically one cell of one year
     expected = np.array(
         [
-            9.975936,
-            9.968497,
-            7.32234,
-            2.750445,
-            -2.520796,
-            -7.081546,
-            -9.713699,
-            -9.71333,
-            -7.077949,
-            -2.509761,
-            2.76855,
-            7.340076,
+            9.970548,
+            9.966644,
+            7.325875,
+            2.755833,
+            -2.518943,
+            -7.085081,
+            -9.719088,
+            -9.715184,
+            -7.074415,
+            -2.504373,
+            2.770403,
+            7.336541,
         ]
     )
 
     result_comp = result.predictions.isel(cells=0, time=slice(0, 12)).values
-    np.testing.assert_allclose(
-        result_comp,
-        expected,
-        atol=1e-6,
+    np.testing.assert_allclose(result_comp, expected, atol=1e-6)
+
+    # ensure coeffs and predictions are consistent
+    expected = mesmer.stats.predict_harmonic_model(
+        yearly_predictor, result.coeffs, result.time
     )
+
+    xr.testing.assert_equal(expected, result.predictions)
 
 
 def test_fit_harmonic_model_checks():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #509
 - [x] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

The colored diff of the numerical changes is misleading - it only changes after the second or third digit after the comma.