### PR TITLE
drop python 3.9 support

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.10", "3.12"]
         env: [""]
         include:
           - env: "min-all-deps"
-            python-version: "3.9"
+            python-version: "3.10"
             os: "ubuntu-latest"
           - env: ""
             python-version: "3.12"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Breaking changes
   (`#495 <https://github.com/MESMER-group/mesmer/pull/495>`_). By `Victoria Bauer`_.
 - Using Cholesky decomposition for finding covariance localization radius and drawing from the multivariate normal distribution (`#408 <https://github.com/MESMER-group/mesmer/pull/408>`_)
   By `Victoria Bauer`_.
+- Removed support for python 3.9 (`#513 <https://github.com/MESMER-group/mesmer/pull/513>`_)
+  By `Mathias Hauser`_.
 - The supported versions of some dependencies were changed
   (`#399 <https://github.com/MESMER-group/mesmer/pull/399>`_,
   `#405 <https://github.com/MESMER-group/mesmer/pull/405>`_, and

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
- - python=3.9
+ - python=3.10
  - cartopy=0.22
  - dask=2023.8
  - joblib=1.3

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 Required dependencies
 ---------------------
 
-- Python (3.9 or later)
+- Python (3.10 or later)
 - `dask <https://dask.org/>`__
 - `numpy <http://www.numpy.org/>`__
 - `pandas <https://pandas.pydata.org/>`__

--- a/mesmer/core/_data.py
+++ b/mesmer/core/_data.py
@@ -1,5 +1,4 @@
-# TODO: use cache instead of lru_cache once requiring python 3.9+
-from functools import lru_cache
+from functools import cache
 
 import pandas as pd
 import pooch
@@ -31,7 +30,7 @@ def load_stratospheric_aerosol_optical_depth_obs(version="2022", resample=True):
 
 
 # use an inner function as @cache does not nicely preserve the signature
-@lru_cache(None)
+@cache(None)
 def _load_aod_obs(*, version, resample):
 
     filename = _fetch_remote_data(f"isaod_gl_{version}.dat")

--- a/mesmer/core/_data.py
+++ b/mesmer/core/_data.py
@@ -30,7 +30,7 @@ def load_stratospheric_aerosol_optical_depth_obs(version="2022", resample=True):
 
 
 # use an inner function as @cache does not nicely preserve the signature
-@cache(None)
+@cache
 def _load_aod_obs(*, version, resample):
 
     filename = _fetch_remote_data(f"isaod_gl_{version}.dat")

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -1,5 +1,4 @@
 import warnings
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -151,8 +150,8 @@ def _check_dataset_form(
     obj,
     name: str = "obj",
     *,
-    required_vars: Union[str, set[str]] = set(),
-    optional_vars: Union[str, set[str]] = set(),
+    required_vars: str | set[str] = set(),
+    optional_vars: str | set[str] = set(),
     requires_other_vars: bool = False,
 ):
     """check if a dataset conforms to some conditions
@@ -201,7 +200,7 @@ def _check_dataarray_form(
     name: str = "obj",
     *,
     ndim: int = None,
-    required_dims: Union[str, set[str]] = set(),
+    required_dims: str | set[str] = set(),
     shape=None,
 ):
     """check if a dataset conforms to some conditions

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -197,7 +197,7 @@ def _get_size_and_coord_dict(coords_or_size, dim, name):
     # TODO: use public xr.Index when the minimum xarray version is v2023.08.0
     xr_Index = xr.core.indexes.Index
 
-    if not isinstance(coords_or_size, (xr.DataArray, xr_Index, pd.Index)):
+    if not isinstance(coords_or_size, xr.DataArray | xr_Index | pd.Index):
         raise TypeError(
             f"expected '{name}' to be an `int`, pandas or xarray Index or a `DataArray`"
             f" got {type(coords_or_size)}"

--- a/mesmer/stats/_linear_regression.py
+++ b/mesmer/stats/_linear_regression.py
@@ -1,5 +1,4 @@
 from collections.abc import Mapping
-from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -18,7 +17,7 @@ class LinearRegression:
         predictors: Mapping[str, xr.DataArray],
         target: xr.DataArray,
         dim: str,
-        weights: Optional[xr.DataArray] = None,
+        weights: xr.DataArray | None = None,
         fit_intercept: bool = True,
     ):
         """
@@ -191,7 +190,7 @@ def _fit_linear_regression_xr(
     predictors: Mapping[str, xr.DataArray],
     target: xr.DataArray,
     dim: str,
-    weights: Optional[xr.DataArray] = None,
+    weights: xr.DataArray | None = None,
     fit_intercept: bool = True,
 ) -> xr.Dataset:
     """

--- a/mesmer/testing.py
+++ b/mesmer/testing.py
@@ -30,7 +30,7 @@ def assert_dict_allclose(first, second, first_name="left", second_name="right"):
             assert_dict_allclose(first_val, second_val, first_name, second_name)
         elif isinstance(first_val, np.ndarray):
             np.testing.assert_allclose(first_val, second_val, err_msg=key)
-        elif isinstance(first_val, (xr.DataArray, xr.Dataset)):
+        elif isinstance(first_val, xr.DataArray | xr.Dataset):
             xr.testing.assert_allclose(first_val, second_val)
         elif np.issubdtype(np.array(first_val).dtype, np.number):
             np.testing.assert_allclose(first_val, second_val, err_msg=key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version_scheme = "no-guess-dev"
 [tool.ruff]
 # also check notebooks
 extend-include = ["*.ipynb"]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 # E402: module level import not at top of file

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Intended Audience :: Science/Research
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -30,7 +29,7 @@ classifiers =
 packages = find:
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     dask[array,distributed] >=2023.8
     joblib >=1.3


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

[SPEC 0](https://scientific-python.org/specs/spec-0000) suggests we can drop python 3.9. So let's do that.

1. I removed the CI for 3.11 on purpose - I think testing 3.10 and 3.12 is enough (I never really had a failure due to the python version).
2. I did not know that a new syntax is supported for `isinstance` - interesting
   ```diff
   - isinstance(3, (int, str))
   + isinstance(3, int | str)
   ```