### PR TITLE
performance optimize `_generate_fourier_series_np`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -128,10 +128,11 @@ Harmonic model
 - de-duplicate the expression of months in their harmonic form (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_)
   move creation of the month array to the deepest level (`#487 <https://github.com/MESMER-group/mesmer/pull/487>`_).
 - fix indexing of harmonic model coefficients (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_)
--  Refactor variable names, small code improvements, fixes and clean docstring (
-   `#415 <https://github.com/MESMER-group/mesmer/pull/415>`_,
-   `#424 <https://github.com/MESMER-group/mesmer/pull/424>`_, and
-   `#433 <https://github.com/MESMER-group/mesmer/pull/433>`_)
+-  Refactor variable names, small code improvements, fixes and clean docstring
+   (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_,
+   `#424 <https://github.com/MESMER-group/mesmer/pull/424>`_,
+   `#433 <https://github.com/MESMER-group/mesmer/pull/433>`_, and
+   `#512 <https://github.com/MESMER-group/mesmer/pull/512>`_)
 - add tests (
   `#431 <https://github.com/MESMER-group/mesmer/pull/431>`_, and
   `#458 <https://github.com/MESMER-group/mesmer/pull/458>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -147,11 +147,12 @@ Harmonic model
 - de-duplicate the expression of months in their harmonic form (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_)
   move creation of the month array to the deepest level (`#487 <https://github.com/MESMER-group/mesmer/pull/487>`_).
 - fix indexing of harmonic model coefficients (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_)
--  Refactor variable names, small code improvements, fixes and clean docstring
+-  Refactor variable names, small code improvements, optimization, fixes and clean docstring
    (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_,
    `#424 <https://github.com/MESMER-group/mesmer/pull/424>`_,
-   `#433 <https://github.com/MESMER-group/mesmer/pull/433>`_, and
-   `#512 <https://github.com/MESMER-group/mesmer/pull/512>`_)
+   `#433 <https://github.com/MESMER-group/mesmer/pull/433>`_,
+   `#512 <https://github.com/MESMER-group/mesmer/pull/512>`_, and
+   `#512 <https://github.com/MESMER-group/mesmer/pull/512>`_).
 - add tests (
   `#431 <https://github.com/MESMER-group/mesmer/pull/431>`_, and
   `#458 <https://github.com/MESMER-group/mesmer/pull/458>`_)

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -48,8 +48,6 @@ def _generate_fourier_series_np(yearly_predictor, coeffs):
     k = np.arange(1.0, order + 1)
     alpha = np.arange(12 * factor, step=factor).reshape(-1, 1) * k
 
-    yearly_predictor = yearly_predictor.reshape(-1, 12)
-
     # combine cosine and sine into one array
     cos_sin = np.empty((12, order * 2))
     cos_sin[:, :order] = np.cos(alpha)
@@ -59,6 +57,8 @@ def _generate_fourier_series_np(yearly_predictor, coeffs):
     coeff_a = cos_sin @ coeffs[0::2]
     coeff_b = cos_sin @ coeffs[1::2]
 
+    # reshape yearly_predictor so the coeffs are correctly broadcast
+    yearly_predictor = yearly_predictor.reshape(-1, 12)
     seasonal_cycle = coeff_a * yearly_predictor + coeff_b
 
     return seasonal_cycle.flatten()

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -35,22 +35,33 @@ def _generate_fourier_series_np(yearly_predictor, coeffs):
         Fourier Series of order n calculated over yearly_predictor and months with coeffs.
 
     """
-    order = int(coeffs.size / 4)
-    n_years = yearly_predictor.size // 12
-    # NOTE: months from 0..11 for consistency with standard fourier series and fft
-    months = np.tile(np.arange(12), n_years)
 
-    seasonal_cycle = np.nansum(
-        [
-            (coeffs[idx * 4] * yearly_predictor + coeffs[idx * 4 + 1])
-            * np.cos(2 * np.pi * i * months / 12)
-            + (coeffs[idx * 4 + 2] * yearly_predictor + coeffs[idx * 4 + 3])
-            * np.sin(2 * np.pi * i * months / 12)
-            for idx, i in enumerate(range(1, order + 1))
-        ],
-        axis=0,
-    )
-    return seasonal_cycle
+    # NOTE: performance-optimized fourier series generation
+
+    coeffs = coeffs[~np.isnan(coeffs)]
+    order = coeffs.size // 4
+
+    # create 2D array of angles with shape (months, order)
+    # as 2 * np.pi * k * np.arange(12).reshape(-1, 1) / 12 but faster
+
+    factor = 2 * np.pi / 12
+    k = np.arange(1.0, order + 1)
+    alpha = np.arange(12 * factor, step=factor).reshape(-1, 1) * k
+
+    yearly_predictor = yearly_predictor.reshape(-1, 12)
+
+    # combine cosine and sine into one array
+    cos_sin = np.empty((12, order * 2))
+    cos_sin[:, :order] = np.cos(alpha)
+    cos_sin[:, order:] = np.sin(alpha)
+
+    # sum coefficients - equivalent to np.sum(cos_sin * coeffs[0::2], axis=1)
+    coeff_a = cos_sin @ coeffs[0::2]
+    coeff_b = cos_sin @ coeffs[1::2]
+
+    seasonal_cycle = coeff_a * yearly_predictor + coeff_b
+
+    return seasonal_cycle.flatten()
 
 
 def predict_harmonic_model(yearly_predictor, coeffs, time, time_dim="time"):
@@ -171,6 +182,10 @@ def _calculate_bic(n_samples, order, mse):
     """
 
     n_params = order * 4
+
+    # assume mse smaller eps is 'perfect' - only relevant for noiseless test data
+    mse = mse if mse > np.finfo(float).eps else 0.0
+
     return n_samples * np.log(mse) + n_params * np.log(n_samples)
 
 

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -37,14 +37,15 @@ def _generate_fourier_series_np(yearly_predictor, coeffs):
     """
     order = int(coeffs.size / 4)
     n_years = yearly_predictor.size // 12
-    months = np.tile(np.arange(1, 13), n_years)
+    # NOTE: months from 0..11 for consistency with standard fourier series and fft
+    months = np.tile(np.arange(12), n_years)
 
     seasonal_cycle = np.nansum(
         [
             (coeffs[idx * 4] * yearly_predictor + coeffs[idx * 4 + 1])
-            * np.sin(np.pi * i * (months) / 6)
+            * np.cos(2 * np.pi * i * months / 12)
             + (coeffs[idx * 4 + 2] * yearly_predictor + coeffs[idx * 4 + 3])
-            * np.cos(np.pi * i * (months) / 6)
+            * np.sin(2 * np.pi * i * months / 12)
             for idx, i in enumerate(range(1, order + 1))
         ],
         axis=0,

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -20,21 +20,21 @@ def test_generate_fourier_series_np():
     n_months = n_years * 12
 
     yearly_predictor = np.ones(n_months)
-    months = np.tile(np.arange(1, 13), n_years)
+    months = np.tile(np.arange(12), n_years)
+    alpha = 2 * np.pi * months / 12
 
-    coeffs = np.array([0, -1, 0, -2])
+    coeffs = np.array([0, -2, 0, -1])
 
     # dummy yearly cycle
-    expected = coeffs[1] * np.sin(2 * np.pi * (months) / 12) + coeffs[3] * np.cos(
-        2 * np.pi * (months) / 12
-    )
+    expected = coeffs[1] * np.cos(alpha) + coeffs[3] * np.sin(alpha)
 
     result = _generate_fourier_series_np(yearly_predictor, coeffs)
 
     np.testing.assert_equal(result, expected)
 
-    result = _generate_fourier_series_np(yearly_predictor, np.array([3.14, -1, 1, -2]))
-    expected += 3.14 * np.sin(np.pi * months / 6) + 1 * np.cos(np.pi * months / 6)
+    coeffs = np.array([1, -2, 3.14, -1])
+    result = _generate_fourier_series_np(yearly_predictor, coeffs)
+    expected += 1 * np.cos(alpha) + 3.14 * np.sin(alpha)
     np.testing.assert_allclose(result, expected, atol=1e-10)
 
 
@@ -171,18 +171,18 @@ def test_fit_harmonic_model():
     # compare numerically one cell of one year
     expected = np.array(
         [
-            9.970548,
+            7.324277,
             9.966644,
-            7.325875,
-            2.755833,
-            -2.518943,
-            -7.085081,
-            -9.719088,
+            9.972146,
+            7.33931,
+            2.7736,
+            -2.501604,
+            -7.072816,
             -9.715184,
-            -7.074415,
-            -2.504373,
-            2.770403,
-            7.336541,
+            -9.720686,
+            -7.087849,
+            -2.52214,
+            2.753065,
         ]
     )
 

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -30,7 +30,7 @@ def test_generate_fourier_series_np():
 
     result = _generate_fourier_series_np(yearly_predictor, coeffs)
 
-    np.testing.assert_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=1e-13)
 
     coeffs = np.array([1, -2, 3.14, -1])
     result = _generate_fourier_series_np(yearly_predictor, coeffs)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #410
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Performance optimization of `_generate_fourier_series_np`. Builds on #512 so the diff is actually smaller. This does two main things:

1. `cos(alpha)` is periodic - so we only need to compute it once for each month (instead of `n_years * 12` times). We then reshape the `yearly_predictor` to `n_years x 12` such that broadcasting ensures each element is multiplied with the coefficients
2. Change the order of operation: sum the coefficients before multiplying - this avoids a lot of multiplication and sum operations. So instead of
   $$\sum\left((a_i \cdot T + b_i) \cdot \cos(\alpha) + (c_i \cdot T + d_i) \cdot \sin(\alpha)\right)$$
   we do
   $$\sum\left(a_i \cdot \cos(\alpha) + c_i \cdot \sin(\alpha)\right) \cdot T + \sum\left(b_i \cdot \cos(\alpha) + d_i \cdot \sin(\alpha)\right)$$

This speeds up `_generate_fourier_series_np` about 9 times and `fit_harmonic_model` about 4 times (on my machine). We do pay this with a _small_ loss in precision (see changes in tests)

---

What we do additionally:
1. Combine the $\cos$ and $\sin$ array into one so we can directly multiply them with the coeffs
2. use `@` to compute the `product-sum`
3. optimize the creation of the `alpha` array for the cost of some readability

What else could we do:
1. Split the function into two to pre-allocate the `cos_sin` array similar #496
2. use `fft` to get better inital conditions (https://github.com/MESMER-group/mesmer/pull/512#issuecomment-2321208656)



