### PR TITLE
power transformer: coeffs as array

### DIFF
--- a/mesmer/stats/_power_transformer.py
+++ b/mesmer/stats/_power_transformer.py
@@ -176,14 +176,14 @@ def _yeo_johnson_optimize_lambda_np(monthly_residuals, yearly_pred):
     bounds = np.array([[0, np.inf], [-0.1, 0.1]])
     first_guess = np.array([1, 0])
 
-    res = minimize(
+    coeffs = minimize(
         _neg_log_likelihood,
         x0=first_guess,
         bounds=bounds,
         method="Nelder-Mead",
     ).x
 
-    return res
+    return coeffs
 
 
 def get_lambdas_from_covariates(coeffs, yearly_pred):
@@ -193,11 +193,13 @@ def get_lambdas_from_covariates(coeffs, yearly_pred):
 
     Parameters
     ----------
-    coeffs : ``xr.Dataset`` containing xi_0 and xi_1 of shape (months, n_gridcells)
-        The parameters of the power transformation for each gridcell and month, calculated
-        using fit_yeo_johnson_transform.
-    yearly_pred : ``xr.DataArray`` of shape (n_years, n_gridcells)
-        yearly values used as predictors for the lambdas.
+    lambda_coeffs : ``xr.Dataset``
+        The parameters of the power transformation for each gridcell and month,
+        containing ``lambda_coeffs`` with dims (months, n_gridcells, coeff) calculated
+        using ``fit_yeo_johnson_transform``.
+    yearly_pred : ``xr.DataArray``
+        yearly values used as predictors for the lambdas. Must have shape shape
+        (n_years, n_gridcells).
 
     Returns
     -------
@@ -213,7 +215,7 @@ def get_lambdas_from_covariates(coeffs, yearly_pred):
 
     lambdas = xr.apply_ufunc(
         lambda_function,
-        coeffs.coeffs,
+        coeffs.lambda_coeffs,
         yearly_pred,
         input_core_dims=[("coeff",), []],
         output_core_dims=[[]],
@@ -278,7 +280,7 @@ def fit_yeo_johnson_transform(monthly_residuals, yearly_pred, time_dim="time"):
             vectorize=True,
         )
 
-        coeffs.append(xr.Dataset({"coeffs": res}))
+        coeffs.append(xr.Dataset({"lambda_coeffs": res}))
 
     return xr.concat(coeffs, dim="month")
 
@@ -293,8 +295,9 @@ def yeo_johnson_transform(monthly_residuals, coeffs, yearly_pred):
     monthly_residuals : ``xr.DataArray`` of shape (n_years*12, n_gridcells)
         Monthly residuals after removing harmonic model fits, used to fit for the
         optimal transformation parameters (lambdas).
-    coeffs : ``xr.Dataset`` containing xi_0 and xi_1 of shape (months, n_gridcells)
-        The parameters of the power transformation for each gridcell, calculated using
+    coeffs : ``xr.Dataset``
+        The parameters of the power transformation containing ``lambda_coeffs`` of shape
+        (months, n_gridcells, coeff) for each gridcell, calculated using
         :func:`lambda_function <mesmer.stats.lambda_function>`.
     yearly_pred : ``xr.DataArray`` of shape (n_years, n_gridcells)
         yearly values used as predictors for the lambdas.
@@ -353,8 +356,9 @@ def inverse_yeo_johnson_transform(monthly_residuals, coeffs, yearly_pred):
     ----------
     monthly_residuals : ``xr.DataArray`` of shape (n_years, n_gridcells)
         The data to be transformed back to the original scale.
-    coeffs : ``xr.Dataset`` containing xi_0 and xi_1 of shape (months, n_gridcells)
-        The parameters of the power transformation for each gridcell, calculated using
+    coeffs : ``xr.Dataset``
+        The parameters of the power transformation containing ``lambda_coeffs`` of shape
+        (months, n_gridcells, coeff) for each gridcell, calculated using
         :func:`lambda_function <mesmer.stats.lambda_function>`.
     yearly_pred : ``xr.DataArray`` of shape (n_years, n_gridcells)
         yearly values used as predictors for the lambdas.

--- a/tests/unit/test_power_transformer.py
+++ b/tests/unit/test_power_transformer.py
@@ -258,11 +258,11 @@ def test_power_transformer_xr():
         shape=(n_gridcells, n_years * 12),
     )
     _check_dataset_form(
-        pt_coefficients, name="pt_coefficients", required_vars=("coeffs")
+        pt_coefficients, name="pt_coefficients", required_vars=("lambda_coeffs")
     )
     _check_dataarray_form(
-        pt_coefficients.coeffs,
-        name="coeffs",
+        pt_coefficients.lambda_coeffs,
+        name="lambda_coeffs",
         ndim=3,
         required_dims=("cells", "coeff", "month"),
         shape=(12, n_gridcells, 2),

--- a/tests/unit/test_power_transformer.py
+++ b/tests/unit/test_power_transformer.py
@@ -30,7 +30,7 @@ from mesmer.testing import trend_data_2D
 )
 def test_lambda_function(coeffs, t, expected):
 
-    result = mesmer.stats.lambda_function(coeffs[0], coeffs[1], t)
+    result = mesmer.stats.lambda_function(coeffs, t)
     np.testing.assert_allclose(result, expected)
 
 
@@ -72,7 +72,7 @@ def test_yeo_johnson_optimize_lambda_np(skew, bounds):
     local_monthly_residuals = sp.stats.skewnorm.rvs(skew, size=n_years)
 
     coeffs = _yeo_johnson_optimize_lambda_np(local_monthly_residuals, yearly_T)
-    lmbda = mesmer.stats.lambda_function(coeffs[0], coeffs[1], yearly_T)
+    lmbda = mesmer.stats.lambda_function(coeffs, yearly_T)
     transformed = _yeo_johnson_transform_np(local_monthly_residuals, lmbda)
 
     assert (lmbda >= bounds[0]).all() & (lmbda <= bounds[1]).all()
@@ -182,7 +182,7 @@ def test_yeo_johnson_optimize_lambda_sklearn():
     local_monthly_residuals = sp.stats.skewnorm.rvs(2, size=n_ts)
 
     ourfit = _yeo_johnson_optimize_lambda_np(local_monthly_residuals, yearly_T)
-    result = mesmer.stats.lambda_function(ourfit[0], ourfit[1], yearly_T_value)
+    result = mesmer.stats.lambda_function(ourfit, yearly_T_value)
     sklearnfit = PowerTransformer(method="yeo-johnson", standardize=False).fit(
         local_monthly_residuals.reshape(-1, 1), yearly_T.reshape(-1, 1)
     )
@@ -258,12 +258,12 @@ def test_power_transformer_xr():
         shape=(n_gridcells, n_years * 12),
     )
     _check_dataset_form(
-        pt_coefficients, name="pt_coefficients", required_vars=("xi_0", "xi_1")
+        pt_coefficients, name="pt_coefficients", required_vars=("coeffs")
     )
     _check_dataarray_form(
-        pt_coefficients.xi_0,
-        name="xi_0",
-        ndim=2,
-        required_dims=("cells",),
-        shape=(12, n_gridcells),
+        pt_coefficients.coeffs,
+        name="coeffs",
+        ndim=3,
+        required_dims=("cells", "coeff", "month"),
+        shape=(12, n_gridcells, 2),
     )


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`


This would be a step towards #517 - gather the coeffs in an array instead of different variables. This should make it agnostic to the number of coeffs there are.

What I am not happy is the naming (as always) - the DataArray is now named `coeffs` and it has a dimension named `coeff` - that is not good but would be a good name? :face_in_clouds:  