### PR TITLE
mesmer-x integration test: mark both as slow

### DIFF
--- a/tests/integration/test_calibrate_mesmer_x.py
+++ b/tests/integration/test_calibrate_mesmer_x.py
@@ -11,7 +11,13 @@ import mesmer.mesmer_x
 @pytest.mark.parametrize(
     ("expr", "option_2ndfit", "outname", "update_expected_files"),
     [
-        pytest.param("norm(loc=c1 + c2 * __tas__, scale=c3)", False, "exp1", False),
+        pytest.param(
+            "norm(loc=c1 + c2 * __tas__, scale=c3)",
+            False,
+            "exp1",
+            False,
+            marks=pytest.mark.slow,
+        ),
         pytest.param(
             "norm(loc=c1 + c2 * __tas__, scale=c3)",
             True,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I am regularly running `pytest .` and want to be able to keep doing that. A runtime of ~2 min is too long for that, so I have to mark this test as slow as well. Optimally would speed this up considerably, but that is for another time ;-)

This test still runs on GHA
