### PR TITLE
`Expression`: disallow bare functions

### DIFF
--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -247,7 +247,7 @@ class Expression:
                 expr = expr.replace(x, "")
 
             # reading this condensed expression to find terms to replace
-            dico_replace, t = {}, ""  # initialization
+            t = ""  # initialization
 
             # adding one space at the end to treat the last term
             for ex in expr + " ":
@@ -260,7 +260,7 @@ class Expression:
                         if t.startswith("np."):
                             if t[len("np.") :] not in vars(np):
                                 raise ValueError(
-                                    f"Proposed a numpy function that does not exist: {t}"
+                                    f"Proposed a numpy function that does not exist: '{t}'"
                                 )
                             else:
                                 # nothing to replace, can go with that
@@ -268,21 +268,17 @@ class Expression:
                         elif t.startswith("math."):
                             if t[len("math.") :] not in vars(math):
                                 raise ValueError(
-                                    f"Proposed a math function that does not exist: {t}"
+                                    f"Proposed a math function that does not exist: '{t}'"
                                 )
                             else:
                                 # nothing to replace, can go with that
                                 pass
-                        elif t in vars(np):
-                            dico_replace[t] = "np." + t
-                        elif t in vars(math):
-                            dico_replace[t] = "math." + t
                         else:
                             raise ValueError(
-                                f"The term '{t}' appears in the expression"
-                                f" '{self.parameters_expressions[param]}' for"
-                                f" '{param}', but couldn't find an equivalent in numpy"
-                                " or math."
+                                f"Unknown function '{t}' in expression"
+                                f" '{self.parameters_expressions[param]}' for '{param}'."
+                                "Do you need to prepend it with 'np.' (or 'math.')?"
+                                " Currently only numpy and math functions are supported."
                             )
                     else:
                         # was a readable character, is still a readable character,
@@ -294,17 +290,7 @@ class Expression:
                 # TODO: would make sense to invert the logic here - move building 't'
                 # above the validity check
 
-            # list of replacements in correct order
-            tmp = list(dico_replace.keys())
-            tmp.sort(key=len, reverse=True)
-
-            # replacing
-            for t in tmp:
-                self.parameters_expressions[param] = self.parameters_expressions[
-                    param
-                ].replace(t, dico_replace[t])
-
-            # 2. replacing names of inputs in expressions
+            # replacing names of inputs in expressions
             for i in self.inputs_list:
                 self.parameters_expressions[param] = self.parameters_expressions[
                     param

--- a/tests/unit/test_mesmer_x_expression.py
+++ b/tests/unit/test_mesmer_x_expression.py
@@ -27,7 +27,7 @@ def test_expression_missing_param():
 def test_expression_wrong_np_function():
 
     with pytest.raises(
-        ValueError, match="Proposed a numpy function that does not exist: np.wrong"
+        ValueError, match="Proposed a numpy function that does not exist: 'np.wrong'"
     ):
         Expression("norm(scale=5, loc=np.wrong())", expr_name="name")
 
@@ -35,9 +35,17 @@ def test_expression_wrong_np_function():
 def test_expression_wrong_math_function():
 
     with pytest.raises(
-        ValueError, match="Proposed a math function that does not exist: math.wrong"
+        ValueError, match="Proposed a math function that does not exist: 'math.wrong'"
     ):
         Expression("norm(scale=5, loc=math.wrong())", expr_name="name")
+
+
+def test_expression_wrong_function():
+
+    with pytest.raises(
+        ValueError, match=r"Unknown function 'mean' in expression 'mean\(\)' for 'loc'"
+    ):
+        Expression("norm(scale=5, loc=mean())", expr_name="name")
 
 
 def test_expression_genextreme():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

As correctly guessed by @veni-vidi-vici-dormivi in https://github.com/MESMER-group/mesmer/pull/526#pullrequestreview-2317904070 I want to disallow passing bare functions to an expression, e.g. `loc=mean()`. This function would then be translated to `loc=np.mean()`.

@yquilcaille would like to keep this functionality (https://github.com/MESMER-group/mesmer/pull/526#issuecomment-2363569175).

I still want to remove it because it's **not difficult to fix** for the user, but difficult to explain and not obvious what happens. Removing also makes the code easier to understand.




