### PR TITLE
`Expression.evaluate`: avoid `exec` by using `locals`

### DIFF
--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -353,19 +353,14 @@ class Expression:
         if len(shapes) > 1:
             raise ValueError("Different shapes of inputs detected.")
 
-        # Evaluation 1: coefficients
-        for c in coefficients_values:
-            exec(c + " = coefficients_values[c]")
-
-        # Evaluation 2: inputs
-        for i in inputs_values:
-            exec(i + " = inputs_values[i]")
+        # gather coefficients and covariates (can't use d1 | d2, does not work for dataset)
+        locals = {**coefficients_values, **inputs_values}
 
         # Evaluation 3: parameters
         self.parameters_values = {}
-        for param in self.parameters_list:
+        for param, expr in self.parameters_expressions.items():
             # may need to silence warnings here, to avoid spamming
-            self.parameters_values[param] = eval(self.parameters_expressions[param])
+            self.parameters_values[param] = eval(expr, None, locals)
 
         # Correcting shapes 1: scalar parameters must have the shape of the inputs
         if len(self.inputs_list) > 0:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

We can pass `locals` ("locally defined variables") as argument to `eval` - this avoids `exec` and "magically defined variables". I think this helps a lot with the readability of the code.

- `locals` is a positional-only argument, so the `None` is required
- as `coefficients_values` or `inputs_values` can be a `Dataset` we cannot use dict union (`d1 | d2`) and need to splat them
- I suggest to merge #534 first so to have the tests first (therefore only draft PR at the moment)