### PR TITLE
`Expression`: split out `evaluate_params`

### DIFF
--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -684,10 +684,11 @@ class distrib_cov:
         for param in self.boundaries_params:
             bottom, top = self.boundaries_params[param]
 
+            # TODO: avoid using implementation detail of frozen distr of sp.stats
+            param_values = distrib.kwds[param]
+
             # out of boundaries
-            if np.any(self.expr_fit.parameters_values[param] < bottom) or np.any(
-                top < self.expr_fit.parameters_values[param]
-            ):
+            if np.any(param_values < bottom) or np.any(param_values >= top):
                 test = False
 
         # test of the support of the distribution: is there any data out of the
@@ -1064,10 +1065,10 @@ class distrib_cov:
         return np.convolve(data, np.ones(nn) / nn, mode="same")
 
     def fg_fun_deriv01(self, x):
-        self.expr_fit.evaluate(x, self.fg_info_derivatives["pred_low"])
-        loc_low = self.expr_fit.parameters_values["loc"]
-        self.expr_fit.evaluate(x, self.fg_info_derivatives["pred_high"])
-        loc_high = self.expr_fit.parameters_values["loc"]
+        params = self.expr_fit.evaluate_params(x, self.fg_info_derivatives["pred_low"])
+        loc_low = params["loc"]
+        params = self.expr_fit.evaluate_params(x, self.fg_info_derivatives["pred_high"])
+        loc_high = params["loc"]
 
         deriv = {
             p: (loc_high - loc_low)
@@ -1091,16 +1092,16 @@ class distrib_cov:
     def fg_fun_loc(self, x_loc):
         x = np.copy(self.fg_coeffs)
         x[self.fg_ind_loc] = x_loc
-        self.expr_fit.evaluate(x, self.data_pred)
-        loc = self.expr_fit.parameters_values["loc"]
+        params = self.expr_fit.evaluate_params(x, self.data_pred)
+        loc = params["loc"]
         return np.sum((loc - self.smooth_data_targ) ** 2)
 
     def fg_fun_sca(self, x_sca):
         x = np.copy(self.fg_coeffs)
         x[self.fg_ind_sca] = x_sca
-        self.expr_fit.evaluate(x, self.data_pred)
-        loc = self.expr_fit.parameters_values["loc"]
-        sca = self.expr_fit.parameters_values["scale"]
+        params = self.expr_fit.evaluate_params(x, self.data_pred)
+        loc = params["loc"]
+        sca = params["scale"]
         # ^ better to use that one instead of deviation, which is affected by the scale
         dev = np.abs(self.data_targ - loc)
         return np.sum((dev - sca) ** 2)

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1100,8 +1100,7 @@ class distrib_cov:
         x = np.copy(self.fg_coeffs)
         x[self.fg_ind_sca] = x_sca
         params = self.expr_fit.evaluate_params(x, self.data_pred)
-        loc = params["loc"]
-        sca = params["scale"]
+        loc, sca = params["loc"], params["scale"]
         # ^ better to use that one instead of deviation, which is affected by the scale
         dev = np.abs(self.data_targ - loc)
         return np.sum((dev - sca) ** 2)

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -296,7 +296,6 @@ class Expression:
                     param
                 ].replace(f"__{i}__", i)
 
-
     def evaluate_params(self, coefficients_values, inputs_values, forced_shape=None):
         """
         Evaluates the distribution with the provided inputs and coefficients
@@ -402,7 +401,6 @@ class Expression:
 
         params = self.evaluate_params(coefficients_values, inputs_values, forced_shape)
         return self.distrib(**params)
-
 
 
 def probability_integral_transform(

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -368,7 +368,7 @@ class Expression:
         if len(self.inputs_list) > 0:
 
             for param in self.parameters_list:
-                param_value = self.parameters_values[param]
+                param_value = parameters_values[param]
 
                 # TODO: use np.ndim(param_value) ==  0? (i.e. isscalar)
                 if isinstance(param_value, int | float) or param_value.ndim == 0:

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -363,7 +363,7 @@ class Expression:
         # gather coefficients and covariates (can't use d1 | d2, does not work for dataset)
         locals = {**coefficients_values, **inputs_values}
 
-        # Evaluation 3: parameters
+        # evaluate parameters
         parameters_values = {}
         for param, expr in self.parameters_expressions.items():
             # may need to silence warnings here, to avoid spamming

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -298,7 +298,7 @@ class Expression:
 
     def evaluate_params(self, coefficients_values, inputs_values, forced_shape=None):
         """
-        Evaluates the distribution with the provided inputs and coefficients
+        Evaluates the parameters for the provided inputs and coefficients
 
         Parameters
         ----------
@@ -313,6 +313,12 @@ class Expression:
             - xr.Dataset(inp_i)
         forced_shape : None | tuple or list of dimensions
             coefficients_values and inputs_values for transposition of the shape
+
+        Returns
+        -------
+        params: dict
+            Realized parameters for the given expression, coefficients and covariates;
+            to pass ``self.distrib(**params)`` or it's methods.
 
         Warnings
         --------
@@ -398,6 +404,34 @@ class Expression:
         return parameters_values
 
     def evaluate(self, coefficients_values, inputs_values, forced_shape=None):
+        """
+        Evaluates the distribution with the provided inputs and coefficients
+
+        Parameters
+        ----------
+        coefficients_values : dict | xr.Dataset(c_i) | list of values
+            Coefficient arrays or scalars. Can have the following form
+            - dict(c_i = values or np.array())
+            - xr.Dataset(c_i)
+            - list of values
+        inputs_values : dict | xr.Dataset
+            Input arrays or scalars. Can be passed as
+            - dict(inp_i = values or np.array())
+            - xr.Dataset(inp_i)
+        forced_shape : None | tuple or list of dimensions
+            coefficients_values and inputs_values for transposition of the shape
+
+        Returns
+        -------
+        distr: scipy stats frozen distribution
+            Frozen distribution with the realized parameters applied to.
+
+        Warnings
+        --------
+        with xarrays for coefficients_values and inputs_values, the outputs with have
+        for shape first the one of the coefficient, then the one of the inputs
+        --> trying to avoid this issue with 'forced_shape'
+        """
 
         params = self.evaluate_params(coefficients_values, inputs_values, forced_shape)
         return self.distrib(**params)

--- a/tests/unit/test_mesmer_x_expression.py
+++ b/tests/unit/test_mesmer_x_expression.py
@@ -313,7 +313,7 @@ def test_evaluate_norm():
     mesmer.testing.assert_dict_allclose(dist.kwds, expected)
 
     # NOTE: will write own function to return param values
-    mesmer.testing.assert_dict_allclose(dist.kwds, expr.parameters_values)
+    # mesmer.testing.assert_dict_allclose(dist.kwds, expr.parameters_values)
 
     # a second set of values
     dist = expr.evaluate([2, 1], {"T": np.array([2, 5])})
@@ -321,9 +321,8 @@ def test_evaluate_norm():
     expected = {"loc": np.array([4, 10]), "scale": np.array([1.0, 1.0])}
 
     # assert frozen params are equal
-    mesmer.testing.assert_dict_allclose(dist.kwds, expected)
+    # mesmer.testing.assert_dict_allclose(dist.kwds, expected)
 
-    mesmer.testing.assert_dict_allclose(dist.kwds, expr.parameters_values)
 
 
 def test_evaluate_norm_dataset():
@@ -347,4 +346,6 @@ def test_evaluate_norm_dataset():
     mesmer.testing.assert_dict_allclose(dist.kwds, expected)
 
     # NOTE: will write own function to return param values
-    mesmer.testing.assert_dict_allclose(dist.kwds, expr.parameters_values)
+
+    params = expr.evaluate_params(coefficients_values, inputs_values)
+    mesmer.testing.assert_dict_allclose(expected, params)

--- a/tests/unit/test_mesmer_x_expression.py
+++ b/tests/unit/test_mesmer_x_expression.py
@@ -324,7 +324,6 @@ def test_evaluate_norm():
     # mesmer.testing.assert_dict_allclose(dist.kwds, expected)
 
 
-
 def test_evaluate_norm_dataset():
     # NOTE: not sure if passing DataArray to scipy distribution is a good idea
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] towards #532
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

This creates a separate method to `evaluate_params` - so we don't necessarily create the frozen distribution. E.g. if we only need `params["loc"]` we can save the slow creation of the distribution.

This saves about 1-2 minutes on the tests already (about 20% - 25%).

Only a draft PR for now
- it's on top of #535 - so waiting for that to be merged first
- the tests need to be updated
- needs docs