### PR TITLE
CI: test upstream dev

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -1,0 +1,73 @@
+name: CI Upstream
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize, labeled]
+  schedule:
+    - cron: "0 0 * * *" # Daily “At 00:00” UTC
+    # TODO: switch to weekly once I know this works
+    # - cron: "0 17 * * 1" # “At 17:00 on Monday” UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  upstream-dev:
+    name: upstream-dev
+    runs-on: ubuntu-latest
+    if: |
+        always()
+        && (
+            github.event_name == 'schedule'
+            || contains( github.event.pull_request.labels.*.name, 'run-upstream')
+        )
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags.
+      - name: Set up conda environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: environment.yml
+          environment-name: mesmer-tests
+          create-args: >-
+            python=${{ matrix.python-version }}
+            pytest-reportlog
+      - name: Install upstream versions
+        run: |
+          bash ci/install-upstream-wheels.sh
+      - name: Install mesmer
+        run: |
+          python -m pip install --no-deps -e .
+
+      - name: Import mesmer
+        run: |
+          python -c 'import mesmer'
+      - name: Run Tests
+        if: success()
+        id: status
+        run: |
+          python -m pytest -rf \
+            --report-log output-${{ matrix.python-version }}-log.jsonl
+      - name: Generate and publish the report
+        if: |
+          failure()
+          && steps.status.outcome == 'failure'
+          && github.event_name == 'schedule'
+          && github.repository_owner == 'mesmer'
+        uses: xarray-contrib/issue-from-pytest-log@v1
+        with:
+          log-path: output-${{ matrix.python-version }}-log.jsonl

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -59,9 +59,10 @@ jobs:
       - name: Run Tests
         if: success()
         id: status
-        run: |
-          python -m pytest -rf \
-            --report-log output-${{ matrix.python-version }}-log.jsonl
+        run: python -m pytest
+          -rf
+          --all
+          --report-log output-${{ matrix.python-version }}-log.jsonl
       - name: Generate and publish the report
         if: |
           failure()

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -45,5 +45,3 @@ python -m pip install \
     git+https://github.com/pyproj4/pyproj \
     git+https://github.com/regionmask/regionmask \
     git+https://github.com/SciTools/nc-time-axis
-
-

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -9,7 +9,6 @@ conda uninstall -y --force \
   pandas \
   pooch \
   properscoring \
-  pyogrio \
   regionmask \
   scikit-learn \
   scipy \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# forcibly remove packages to avoid artifacts
+conda uninstall -y --force \
+  dask \
+  nc-time-axis \
+  numpy \
+  packaging \
+  pandas \
+  pooch \
+  properscoring \
+  pyogrio \
+  regionmask \
+  scikit-learn \
+  scipy \
+  statsmodels \
+  xarray
+
+# keep cartopy & matplotlib as we don't have tests that use them
+#   cartopy \
+#   matplotlib-base \
+# keep joblib as we want to move away from pickle files
+# keep netcdf4: difficult to build
+
+# to limit the runtime of Upstream CI
+python -m pip install \
+    -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+    --no-deps \
+    --pre \
+    --upgrade \
+    matplotlib \
+    numpy \
+    pandas \
+    scikit-learn \
+    scipy \
+    statsmodels \
+    xarray
+python -m pip install \
+    --no-deps \
+    --upgrade \
+    git+https://github.com/dask/dask \
+    git+https://github.com/fatiando/pooch \
+    git+https://github.com/geopandas/geopandas \
+    git+https://github.com/pydata/xarray \
+    git+https://github.com/pypa/packaging \
+    git+https://github.com/pyproj4/pyproj \
+    git+https://github.com/regionmask/regionmask \
+    git+https://github.com/SciTools/nc-time-axis
+
+

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -39,6 +39,7 @@ python -m pip install \
     git+https://github.com/dask/dask \
     git+https://github.com/fatiando/pooch \
     git+https://github.com/geopandas/geopandas \
+    git+https://github.com/properscoring/properscoring \
     git+https://github.com/pydata/xarray \
     git+https://github.com/pypa/packaging \
     git+https://github.com/pyproj4/pyproj \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -16,10 +16,8 @@ conda uninstall -y --force \
   statsmodels \
   xarray
 
-# keep cartopy & matplotlib as we don't have tests that use them
-#   cartopy \
-#   matplotlib-base \
-# keep joblib as we want to move away from pickle files
+# keep cartopy & matplotlib: we don't have tests that use them
+# keep joblib: we want to move away from pickle files
 # keep netcdf4: difficult to build
 
 # to limit the runtime of Upstream CI

--- a/tests/unit/test_smoothing.py
+++ b/tests/unit/test_smoothing.py
@@ -74,7 +74,8 @@ def test_lowess_n_steps(n_steps):
 def test_lowess_use_coords():
 
     data = trend_data_1D()
-    time = data.time.values
+    # make copy as it's read only
+    time = np.array(data.time.values)
     time[-1] = time[-1] + 10
     data = data.assign_coords(time=time)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

This PR tests the development versions of our dependencies. This gives us more time if they introduce a breaking change and also helps to catch bugs in upstream dependencies. We don't update all the (indirect) dependencies (e.g. regionmask would depend on geopandas). The approach here is to install the current version, then remove it and install it with pip. The first step is done so we have all dependencies present.

That usually goes wrong the first time...
