### PR TITLE
upstream-dev: install xarray only once

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -30,8 +30,8 @@ python -m pip install \
     pandas \
     scikit-learn \
     scipy \
-    statsmodels \
-    xarray
+    statsmodels
+
 python -m pip install \
     --no-deps \
     --upgrade \


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Follow up for #559: looks like I installed xarray twice. I remove it from the nightly-wheels and keep the installation from pip (commented at the moment). While the former is a bit faster, it is only updated once a week (I think) and because xarray does not have any compiled code it's only marginally faster to install...

FYI @veni-vidi-vici-dormivi (I'll merge right away)