### PR TITLE
tests: run in parallel

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -71,6 +71,7 @@ jobs:
 
     - name: Run tests
       run: python -u -m pytest
+       -n 4
        -r a -v
        --all
        --cov=mesmer

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Run tests
       run: python -u -m pytest
-       -n 4
+       -n 2
        -r a -v
        --all
        --cov=mesmer

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -60,6 +60,7 @@ jobs:
         if: success()
         id: status
         run: python -m pytest
+          -n 4
           -rf
           --all
           --report-log output-${{ matrix.python-version }}-log.jsonl

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -60,7 +60,7 @@ jobs:
         if: success()
         id: status
         run: python -m pytest
-          -n 4
+          -n 2
           -rf
           --all
           --report-log output-${{ matrix.python-version }}-log.jsonl

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -26,3 +26,4 @@ dependencies:
 # for testing
  - pytest
  - pytest-cov
+ - pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -27,4 +27,5 @@ dependencies:
  - black!=23
  - pytest
  - pytest-cov
+ - pytest-xdist
  - ruff


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Runs the tests in parallel. Can be called as

```bash
pytest -n auto ... # auto select number of cores
pytest -n 4 ... # set number of cores

```

While in theory very nice it does actually not speed up the tests locally. This surprises me but is maybe because the individual tests take a bit longer due to multi-threading issues. Let's see what happens on GHA. For some reason pytest-xdist is already in setup.cfg.
