### PR TITLE
testing: assert_allclose with allowed failures

### DIFF
--- a/mesmer/testing.py
+++ b/mesmer/testing.py
@@ -2,6 +2,45 @@ import numpy as np
 import xarray as xr
 
 
+def assert_allclose_allowed_failures(
+    actual, desired, *, rtol=1e-07, atol=0, allowed_failures=0
+):
+    """check arrays are close but allow a number of failures
+
+        Parameters
+        ----------
+    actual : array_like
+        Array obtained.
+    desired : array_like
+        Array desired.
+    rtol : float, optional
+        Relative tolerance.
+    atol : float, optional
+        Absolute tolerance.
+    allowed_failures : int, default: 0
+        Number of points that may violate the tolerance criteria
+
+    Notes
+    -----
+    Only for numpy arrays at the moment.
+
+    """
+
+    __tracebackhide__ = True
+
+    def comparison(actual, desired):
+
+        __tracebackhide__ = True
+
+        isclose = np.isclose(actual, desired, rtol=rtol, atol=atol)
+        n_not_isclose = (~isclose).sum()
+        if n_not_isclose > allowed_failures:
+            return isclose
+        return True
+
+    np.testing.assert_array_compare(comparison, actual, desired)
+
+
 def assert_dict_allclose(first, second, first_name="left", second_name="right"):
 
     if not isinstance(first, dict) or not isinstance(second, dict):

--- a/mesmer/testing.py
+++ b/mesmer/testing.py
@@ -7,8 +7,8 @@ def assert_allclose_allowed_failures(
 ):
     """check arrays are close but allow a number of failures
 
-        Parameters
-        ----------
+    Parameters
+    ----------
     actual : array_like
         Array obtained.
     desired : array_like

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -4,11 +4,64 @@ import xarray as xr
 
 from mesmer.core.utils import _check_dataarray_form
 from mesmer.testing import (
+    assert_allclose_allowed_failures,
     assert_dict_allclose,
     trend_data_1D,
     trend_data_2D,
     trend_data_3D,
 )
+
+
+def test_assert_allclose_allowed_failures():
+
+    # test non-failure cases
+    arr1 = np.array([1, 2, 3])
+
+    arr2 = np.array([1, 2, 3])
+    assert_allclose_allowed_failures(arr1, arr2)
+
+    arr2 = np.array([1, 2, 4])
+    assert_allclose_allowed_failures(arr1, arr2, atol=1)
+
+    arr2 = np.array([1, 3, 3])
+    assert_allclose_allowed_failures(arr1, arr2, rtol=0.5)
+
+    arr2 = np.array([1, 2, 4])
+    assert_allclose_allowed_failures(arr1, arr2, allowed_failures=1)
+
+    arr1_nan = np.array([1, np.nan, 3])
+    arr2_nan = np.array([1, np.nan, 4])
+    assert_allclose_allowed_failures(arr1_nan, arr2_nan, allowed_failures=1)
+
+    arr2 = np.array([1, 2, 4])
+    with pytest.raises(AssertionError):
+        assert_allclose_allowed_failures(arr1, arr2)
+
+    arr2 = np.array([1, 2, np.inf])
+    with pytest.raises(AssertionError):
+        assert_allclose_allowed_failures(arr1, arr2)
+
+    arr2 = np.array([1, 2, np.nan])
+    with pytest.raises(AssertionError):
+        assert_allclose_allowed_failures(arr1, arr2)
+
+    arr2 = np.array([1, 3, 4])
+    with pytest.raises(AssertionError):
+        assert_allclose_allowed_failures(arr1, arr2, allowed_failures=1)
+
+    arr1_2d = np.random.uniform(0, 1, size=(5, 3))
+
+    arr2_2d = arr1_2d.copy()
+    assert_allclose_allowed_failures(arr1_2d, arr2_2d)
+
+    arr2_2d = arr1_2d.copy()
+    arr2_2d[0, 0] = -1
+    assert_allclose_allowed_failures(arr1_2d, arr2_2d, allowed_failures=1)
+
+    arr2_2d = arr1_2d.copy()
+    arr2_2d[:] = -1
+    with pytest.raises(AssertionError):
+        assert_allclose_allowed_failures(arr1_2d, arr2_2d, allowed_failures=1)
 
 
 def test_assert_dict_allclose_type_key_errors():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

A helper function to check if two arrays are close, but allows a number of failures. This could help with #501 where most of the array is close but some points are not & expect this could become more important? Uses the numpy machinery, thus does not work with xarray. However, there is no `isclose` function for `DataArray` and `Dataset` and `xr.testing.assert_allclose` is a mess.

See also `np.testing.assert_allclose??`