### PR TITLE
fit_yeo_johnson_transform: add month coords

### DIFF
--- a/mesmer/stats/_power_transformer.py
+++ b/mesmer/stats/_power_transformer.py
@@ -275,7 +275,8 @@ def fit_yeo_johnson_transform(monthly_residuals, yearly_pred, time_dim="time"):
 
         coeffs.append(xr.Dataset({"lambda_coeffs": res}))
 
-    return xr.concat(coeffs, dim="month")
+    month = xr.Variable("month", np.arange(1, 13))
+    return xr.concat(coeffs, dim=month)
 
 
 def yeo_johnson_transform(monthly_residuals, coeffs, yearly_pred):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Does what it says.

---

What is a bit inconsistent but also makes sense: the transformed residuals have dims `time, gridcell` while the and the `lambdas` have dims `month, gridcell, year`.

---

edit: only the `lambdas` do, the `lambda_coeffs` have dims `month, gridcell, coeff`