### PR TITLE
show timing of slowest tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ omit =
     */tests/*, */scripts/*, */examples/*, */configs/*, */mesmer/_version.py
 
 [tool:pytest]
-addopts = --strict-markers
+addopts = --strict-markers --durations=10
 python_files = test_*.py
 testpaths = tests/
 filterwarnings =


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Shows the timing of the 10 slowest tests each time the tests are run. I wasn't sure if I should only add this for the CI :man_shrugging: (i.e. add to the pytest call in ci-workflow.yml)
