### PR TITLE
CI: fix upstream-dev issue-from-pytest-log

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -69,7 +69,7 @@ jobs:
           failure()
           && steps.status.outcome == 'failure'
           && github.event_name == 'schedule'
-          && github.repository_owner == 'mesmer'
+          && github.repository_owner == 'MESMER-group'
         uses: xarray-contrib/issue-from-pytest-log@v1
         with:
           log-path: output-${{ matrix.python-version }}-log.jsonl


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

upstream dev CI failed but no issue was created because there was the wrong repo owner... (I copied that from regionmask where the organization is also called regionmask)

---

As for why it failed - no idea. I had hoped this was fixed for good with https://github.com/MESMER-group/mesmer/pull/516/files#r1742290021 That optimization seems to still be brittle :-( let's see if it turns up again tonight