### PR TITLE
harmonic model: relax 'perfect' mse

### DIFF
--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -185,8 +185,9 @@ def _calculate_bic(n_samples, order, mse):
 
     n_params = order * 4
 
-    # assume mse smaller eps is 'perfect' - only relevant for noiseless test data
-    mse = mse if mse > np.finfo(float).eps else 0.0
+    # assume mse smaller 10 eps is 'perfect' - only relevant for noiseless test data
+    if mse < np.finfo(float).eps * 10:
+        return -np.inf
 
     return n_samples * np.log(mse) + n_params * np.log(n_samples)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #575
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Relax the condition for a perfect `mse` in the selection of the harmonic model order. This is necessary because (1) there are some numerical inaccuracies when calculating a product-sum using `@` (2) the upcoming scipy release, which seems to add a bit of inaccuracy as well...

Note: the abort condition uses `<` (and not `<=`) thus the second `-np.inf` stops the search, which is the correct choice.

https://github.com/MESMER-group/mesmer/blob/598e2673c644a84a632e5387b0090ee1411d352c/mesmer/stats/_harmonic_model.py#L232 
