### PR TITLE
Enable that location and scale parameters might be set or not used.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,10 +92,12 @@ In the release the MESMER-X functionality is integrated into the MESMER Codebase
 - Add unit tests (`#526 <https://github.com/MESMER-group/mesmer/pull/526>`_,
                   `#533 <https://github.com/MESMER-group/mesmer/pull/533>`_,
                   `#534 <https://github.com/MESMER-group/mesmer/pull/534>`_,
-                  `#540 <https://github.com/MESMER-group/mesmer/pull/540>`_)
+                  `#540 <https://github.com/MESMER-group/mesmer/pull/540>`_,
+                  `#577 <https://github.com/MESMER-group/mesmer/pull/577>`_)
 - Add integration tests (`#524 <https://github.com/MESMER-group/mesmer/pull/524>`_,
                          `#550 <https://github.com/MESMER-group/mesmer/pull/550>`_
                          `#553 <https://github.com/MESMER-group/mesmer/pull/553>`_)
+- Enable to pass set values for loc and scale (only integers) and make scale parameter optional (`#597 <https://github.com/MESMER-group/mesmer/pull/597>`_)
 
 Integration of MESMER-M
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1042,14 +1042,17 @@ class distrib_cov:
             [self.expr_fit.coefficients_list.index(c) for c in loc_coeffs]
         )
 
-        localfit_loc = self._minimize(
-            func=self._fg_fun_loc,
-            x0=self.fg_coeffs[self.fg_ind_loc],
-            args=(smooth_targ,),
-            fact_maxfev_iter=len(self.fg_ind_loc) / self.n_coeffs,
-            option_NelderMead="best_run",
-        )
-        self.fg_coeffs[self.fg_ind_loc] = localfit_loc.x
+        # location might not be used (beta distribution) or set in the expression
+        if len(self.fg_ind_loc) > 0:
+
+            localfit_loc = self._minimize(
+                func=self._fg_fun_loc,
+                x0=self.fg_coeffs[self.fg_ind_loc],
+                args=(smooth_targ,),
+                fact_maxfev_iter=len(self.fg_ind_loc) / self.n_coeffs,
+                option_NelderMead="best_run",
+            )
+            self.fg_coeffs[self.fg_ind_loc] = localfit_loc.x
 
         # Step 3: fit coefficients of scale (objective: improving the subset of
         # scale coefficients)
@@ -1058,7 +1061,7 @@ class distrib_cov:
             scale_coeffs = self.expr_fit.coefficients_dict["scale"]
         except KeyError: 
             scale_coeffs = []
-        
+        # scale might not be used or set in the expression
         if len(scale_coeffs) > 0:
             self.fg_ind_sca = np.array(
                 [self.expr_fit.coefficients_list.index(c) for c in scale_coeffs]

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1061,9 +1061,10 @@ class distrib_cov:
             scale_coeffs = self.expr_fit.coefficients_dict["scale"]
         except KeyError:
             scale_coeffs = []
-            self.fg_ind_sca = np.array(
-                [self.expr_fit.coefficients_list.index(c) for c in scale_coeffs]
-            )
+        
+        self.fg_ind_sca = np.array(
+            [self.expr_fit.coefficients_list.index(c) for c in scale_coeffs]
+        )
         # scale might not be used or set in the expression
         if len(self.fg_ind_sca) > 0:
             if self.first_guess is None:

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1061,11 +1061,11 @@ class distrib_cov:
             scale_coeffs = self.expr_fit.coefficients_dict["scale"]
         except KeyError:
             scale_coeffs = []
-        # scale might not be used or set in the expression
-        if len(scale_coeffs) > 0:
             self.fg_ind_sca = np.array(
                 [self.expr_fit.coefficients_list.index(c) for c in scale_coeffs]
             )
+        # scale might not be used or set in the expression
+        if len(self.fg_ind_sca) > 0:
             if self.first_guess is None:
                 # compared to all 0, better for ref level but worse for trend
                 x0 = np.full(len(scale_coeffs), fill_value=np.std(self.data_targ))

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1061,7 +1061,7 @@ class distrib_cov:
             scale_coeffs = self.expr_fit.coefficients_dict["scale"]
         except KeyError:
             scale_coeffs = []
-        
+
         self.fg_ind_sca = np.array(
             [self.expr_fit.coefficients_list.index(c) for c in scale_coeffs]
         )

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -564,8 +564,8 @@ class distrib_cov:
             "method_fit": "Powell",
             "xtol_req": 1e-6,
             "ftol_req": 1.0e-6,
-            "maxiter": 1000 * self.n_coeffs * np.log(self.n_coeffs),
-            "maxfev": 1000 * self.n_coeffs * np.log(self.n_coeffs),
+            "maxiter": 1000 * self.n_coeffs * (np.log(self.n_coeffs) + 1),
+            "maxfev": 1000 * self.n_coeffs * (np.log(self.n_coeffs) + 1),
             "error_failedfit": False,
             "fg_with_global_opti": False,
         }
@@ -1057,9 +1057,9 @@ class distrib_cov:
         # Step 3: fit coefficients of scale (objective: improving the subset of
         # scale coefficients)
         # TODO: move to `Expression`
-        try: 
+        try:
             scale_coeffs = self.expr_fit.coefficients_dict["scale"]
-        except KeyError: 
+        except KeyError:
             scale_coeffs = []
         # scale might not be used or set in the expression
         if len(scale_coeffs) > 0:

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1036,7 +1036,7 @@ class distrib_cov:
 
         # Step 2: fit coefficients of location (objective: improving the subset of
         # location coefficients)
-        loc_coeffs = self.expr_fit.coefficients_dict["loc"]
+        loc_coeffs = self.expr_fit.coefficients_dict.get("loc", [])
         # TODO: move to `Expression`
         self.fg_ind_loc = np.array(
             [self.expr_fit.coefficients_list.index(c) for c in loc_coeffs]
@@ -1057,10 +1057,7 @@ class distrib_cov:
         # Step 3: fit coefficients of scale (objective: improving the subset of
         # scale coefficients)
         # TODO: move to `Expression`
-        try:
-            scale_coeffs = self.expr_fit.coefficients_dict["scale"]
-        except KeyError:
-            scale_coeffs = []
+        scale_coeffs = self.expr_fit.coefficients_dict.get("scale", [])
 
         self.fg_ind_sca = np.array(
             [self.expr_fit.coefficients_list.index(c) for c in scale_coeffs]

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1080,6 +1080,7 @@ class distrib_cov:
 
         # Step 4: fit other coefficients (objective: improving the subset of
         # other coefficients. May use multiple coefficients, eg beta distribution)
+        # TODO: move to `Expression`
         other_params = [
             p for p in self.expr_fit.parameters_list if p not in ["loc", "scale"]
         ]

--- a/tests/unit/test_mesmer_x_distrib_cov.py
+++ b/tests/unit/test_mesmer_x_distrib_cov.py
@@ -31,8 +31,8 @@ def test_distrib_cov_init_all_default():
     assert dist.scores_fit == ["func_optim", "NLL", "BIC"]
     assert dist.xtol_req == 1e-06
     assert dist.ftol_req == 1e-06
-    assert dist.maxiter == 1000 * dist.n_coeffs * np.log(dist.n_coeffs)
-    assert dist.maxfev == 1000 * dist.n_coeffs * np.log(dist.n_coeffs)
+    assert dist.maxiter == 1000 * dist.n_coeffs * (np.log(dist.n_coeffs) + 1)
+    assert dist.maxfev == 1000 * dist.n_coeffs * (np.log(dist.n_coeffs) + 1)
     assert dist.method_fit == "Powell"
     assert dist.name_ftol == "ftol"
     assert dist.name_xtol == "xtol"

--- a/tests/unit/test_mesmer_x_first_guess.py
+++ b/tests/unit/test_mesmer_x_first_guess.py
@@ -171,7 +171,7 @@ def test_first_guess_beta():
     dist.find_fg()
 
     # NOTE: for the beta distribution the support does not change for loc = 0 and scale = 1
-    # it is always (0,1), thus the optimization with _fg_fun_others does not do anything
+    # it is always (0, 1), thus the optimization with _fg_fun_others does not do anything
     # NOTE: Step 7 (fg_with_global_opti) leads to a impovement of the first guess at the 6th digit after the comma, i.e. very small
     result = dist.fg_coeffs
     expected = [a, b]

--- a/tests/unit/test_mesmer_x_first_guess.py
+++ b/tests/unit/test_mesmer_x_first_guess.py
@@ -38,7 +38,7 @@ def test_first_guess_standard_normal_including_pred():
     dist.find_fg()
     result = dist.fg_coeffs
 
-    np.testing.assert_allclose(result, [c1, c2, c3], rtol=0.1)
+    np.testing.assert_allclose(result, [c1, c2, c3], rtol=0.03)
 
 
 @pytest.mark.parametrize("first_guess", [[1.0, 1.0], [1.0, 2.0], [-1, 0.5], [10, 7]])
@@ -79,7 +79,7 @@ def test_first_guess_GEV(shape):
     expected = [loc, scale, shape]
 
     # test right order of magnitude
-    np.testing.assert_allclose(result, expected, rtol=0.5)
+    np.testing.assert_allclose(result, expected, rtol=0.4)
 
     # any difference if we provide a first guess?
     dist2 = distrib_cov(
@@ -112,7 +112,7 @@ def test_first_guess_GEV_including_pred():
     expected = [c1, scale, shape]
 
     # test right order of magnitude
-    np.testing.assert_allclose(result, expected, atol=0.2)
+    np.testing.assert_allclose(result, expected, rtol=0.2)
 
 
 def test_first_guess_truncnorm():
@@ -211,7 +211,7 @@ def test_first_guess_gamma():
     result = dist.fg_coeffs
     expected = [a]
 
-    np.testing.assert_allclose(result, expected, atol=0.03)
+    np.testing.assert_allclose(result, expected, rtol=0.02)
 
 
 def test_fg_fun_scale_laplace():
@@ -229,7 +229,7 @@ def test_fg_fun_scale_laplace():
     result = dist.fg_coeffs
     expected = [loc, scale]
 
-    np.testing.assert_allclose(result, expected, rtol=0.52)
+    np.testing.assert_allclose(result, expected, rtol=0.1)
 
 
 def test_first_guess_with_bounds():
@@ -270,7 +270,7 @@ def test_first_guess_with_bounds():
     dist.find_fg()
     result = dist.fg_coeffs
     expected = np.array([-0.016552528, 1.520612114])
-    np.testing.assert_allclose(result, expected, rtol=1e-5)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
     # ^ still finds a fg because we do not enforce the bounds on the fg
     # however the fg is significantly worse on the param with the wrong bounds
     # in contrast to the above the test below also runs step 6: fit on CDF or LL^n -> implications?
@@ -302,7 +302,7 @@ def test_first_guess_with_bounds():
     dist.find_fg()
     result = dist.fg_coeffs
     expected = np.array([-0.005093817, 1.015267298])
-    np.testing.assert_allclose(result, expected, rtol=1e-5)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
 
 
 @pytest.mark.xfail(reason="https://github.com/MESMER-group/mesmer/issues/581")

--- a/tests/unit/test_mesmer_x_first_guess.py
+++ b/tests/unit/test_mesmer_x_first_guess.py
@@ -302,7 +302,7 @@ def test_first_guess_with_bounds():
     dist.find_fg()
     result = dist.fg_coeffs
     expected = np.array([-0.005093817, 1.015267298])
-    np.testing.assert_allclose(result, expected, rtol=1e-6)
+    np.testing.assert_allclose(result, expected, rtol=1e-5)
 
 
 @pytest.mark.xfail(reason="https://github.com/MESMER-group/mesmer/issues/581")


### PR DESCRIPTION
Some distributions do not use `loc` and `scale`. While all distributions have `loc` as parameter, for some it might make sense to set it to 0 like the beta distribution or even just if one has calculated residuals for their data and knows the loc is 0. Thus, I implemented an option to set the location in the expression to a certain value (note because of #525 it can only be ints atm). Moreover, the discrete distributions tend to not have a scale parameter so I made it optional.

 - [x] Tests added
 - [x] Fully documented, including `CHANGELOG.rst`
