### PR TITLE
distrib_cov._minimize: also use `fit_NM` for "best_run" if fit.success is False

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,7 +111,7 @@ In the release the MESMER-X functionality is integrated into the MESMER Codebase
                          `#550 <https://github.com/MESMER-group/mesmer/pull/550>`_
                          `#553 <https://github.com/MESMER-group/mesmer/pull/553>`_)
 - Enable `threshold_min_proba` to be `None` in `distrib_cov` (`#598 <https://github.com/MESMER-group/mesmer/pull/598>`_)
-- Also use Nelder-Mead fit in `distrib_cov._minimize` for `option_NelderMead == "best_run"` when Powell fit was not successful. (`#600 <https://github.com/MESMER-group/mesmer/pull/600>`_)
+- Also use Nelder-Mead fit in `distrib_cov._minimize` for `option_NelderMead == "best_run"` when Powell fit was not successful (`#600 <https://github.com/MESMER-group/mesmer/pull/600>`_).
 
 Integration of MESMER-M
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,6 +111,7 @@ In the release the MESMER-X functionality is integrated into the MESMER Codebase
                          `#550 <https://github.com/MESMER-group/mesmer/pull/550>`_
                          `#553 <https://github.com/MESMER-group/mesmer/pull/553>`_)
 - Enable `threshold_min_proba` to be `None` in `distrib_cov` (`#598 <https://github.com/MESMER-group/mesmer/pull/598>`_)
+- Also use Nelder-Mead fit in `distrib_cov._minimize` for `option_NelderMead == "best_run"` when Powell fit was not successful. (`#600 <https://github.com/MESMER-group/mesmer/pull/600>`_)
 
 Integration of MESMER-M
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1206,7 +1206,8 @@ class distrib_cov:
                 },
             )
             if (option_NelderMead == "fail_run") or (
-                option_NelderMead == "best_run" and (fit_NM.fun < fit.fun or not fit.success)
+                option_NelderMead == "best_run"
+                and (fit_NM.fun < fit.fun or not fit.success)
             ):
                 fit = fit_NM
         return fit

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1199,7 +1199,7 @@ class distrib_cov:
                 },
             )
             if (option_NelderMead == "fail_run") or (
-                option_NelderMead == "best_run" and fit_NM.fun < fit.fun
+                option_NelderMead == "best_run" and (fit_NM.fun < fit.fun or not fit.success)
             ):
                 fit = fit_NM
         return fit


### PR DESCRIPTION
When we use `option_NelderMead == "best_run"` for `distrib_cov._minimize()` we want to select the parameters that yield the least loss between minimizing with Powell or with Nelder-Mead. Until now, if the fit using Powell (`fit`) failed, `fit.fun` would be `nan` and thus the test if the Nelder Mead fit (`fit_NM`) was better `fit_NM.fun < fit.fun` would yield ` False and `fit_NM` was discarded.

 - [x] Fully documented, including `CHANGELOG.rst`
