### PR TITLE
distrib_cov._fg_fun_LL_n(): add logpmf for discrete distributions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,9 +111,10 @@ In the release the MESMER-X functionality is integrated into the MESMER Codebase
 - Add integration tests (`#524 <https://github.com/MESMER-group/mesmer/pull/524>`_,
                          `#550 <https://github.com/MESMER-group/mesmer/pull/550>`_
                          `#553 <https://github.com/MESMER-group/mesmer/pull/553>`_)
-- Enable to pass set values for loc and scale (only integers) and make scale parameter optional (`#597 <https://github.com/MESMER-group/mesmer/pull/597>`_)
-- Enable `threshold_min_proba` to be `None` in `distrib_cov` (`#598 <https://github.com/MESMER-group/mesmer/pull/598>`_)
+- Enable to pass set values for loc and scale (only integers) and make scale parameter optional (`#597 <https://github.com/MESMER-group/mesmer/pull/597>`_).
+- Enable `threshold_min_proba` to be `None` in `distrib_cov` (`#598 <https://github.com/MESMER-group/mesmer/pull/598>`_).
 - Also use Nelder-Mead fit in `distrib_cov._minimize` for `option_NelderMead == "best_run"` when Powell fit was not successful (`#600 <https://github.com/MESMER-group/mesmer/pull/600>`_).
+- Return `logpmf` for discrete distributions in `distrib_cov._fg_fun_LL_n()` (`#602 <https://github.com/MESMER-group/mesmer/pull/602>`_)
 
 Integration of MESMER-M
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/mesmer/mesmer_x/train_l_distrib_mesmerx.py
+++ b/mesmer/mesmer_x/train_l_distrib_mesmerx.py
@@ -1388,7 +1388,11 @@ class distrib_cov:
 
     def _fg_fun_LL_n(self, x, n=4):
         distrib = self.expr_fit.evaluate(x, self.data_pred)
-        LL = np.sum(distrib.logpdf(self.data_targ) ** n)
+
+        if self.expr_fit.is_distrib_discrete:
+            LL = np.sum(distrib.logpmf(self.data_targ) ** n)
+        else:
+            LL = np.sum(distrib.logpdf(self.data_targ) ** n)
         return LL
 
     def find_bound(self, i_c, x0, fact_coeff):

--- a/tests/unit/test_mesmer_x_first_guess.py
+++ b/tests/unit/test_mesmer_x_first_guess.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from scipy.stats import beta, binom, gamma, hypergeom, genextreme, laplace, truncnorm
+from scipy.stats import beta, binom, gamma, genextreme, hypergeom, laplace, truncnorm
 
 from mesmer.mesmer_x import Expression, distrib_cov
 from mesmer.mesmer_x.train_l_distrib_mesmerx import _smooth_data

--- a/tests/unit/test_mesmer_x_first_guess.py
+++ b/tests/unit/test_mesmer_x_first_guess.py
@@ -187,10 +187,29 @@ def test_fg_hypergeom():
     first_guess = [99, 9, 1]
     dist = distrib_cov(targ, {"tas": pred}, expression, first_guess=first_guess)
     dist.find_fg()
-    result = dist.fg_coeffs
+    result = dist.fg_coeffs  # 99, 11, 2
     expected = [M, n_draws, n_success]
 
     np.testing.assert_allclose(result, expected, rtol=0.1)
+
+    # test with bounds
+    # NOTE: here we add a bound on c2 that is smaller than the negative loglikelihood fit (step 5)
+    # this leads to `test_coeff` being False and another fit with NLL*4 is being done (step 6)
+    # this leads to coverage of _fg_fun_LL_n() also for the discrete case
+    # NOTE: sadly this does not improve the fit
+
+    boundaries_coeffs = {"c1": (80, 110), "c2": (5, 10), "c3": (1, 3)}
+    dist = distrib_cov(
+        targ,
+        {"tas": pred},
+        expression,
+        first_guess=first_guess,
+        boundaries_coeffs=boundaries_coeffs,
+    )
+    dist.find_fg()
+    result_with_bounds = dist.fg_coeffs
+
+    np.testing.assert_equal(result, result_with_bounds)
 
 
 def test_first_guess_beta():

--- a/tests/unit/test_mesmer_x_first_guess.py
+++ b/tests/unit/test_mesmer_x_first_guess.py
@@ -173,7 +173,7 @@ def test_fg_binom():
 def test_fg_hypergeom():
     rng = np.random.default_rng(0)
     n = 251
-    pred = np.ones(n, dtype=int) * 2
+    pred = np.full(n, fill_value=2, dtype=int)
 
     M = 100
     n_draws = 10


### PR DESCRIPTION
Discrete distributions don't have logpdf but instead a logpmf. We already use the logpmf in `distrib_cov.loglike()` but  we do not reuse this function here because we need an exponent. Thus I added the logpmf for discrete distribution which enables us to also test some of these.

 - [x] Tests added
 - [x] Fully documented, including `CHANGELOG.rst`
