### PR TITLE
explicitely cast to datetime64[ns] (non-ns-compat)

### DIFF
--- a/mesmer/core/_data.py
+++ b/mesmer/core/_data.py
@@ -43,7 +43,7 @@ def _load_aod_obs(*, version, resample):
         dtype={"year": str, "month": str},
     )
 
-    time = pd.to_datetime(df.year + df.month, format="%Y%m")
+    time = pd.to_datetime(df.year + df.month, format="%Y%m").astype("datetime64[ns]")
 
     aod = xr.DataArray(df.aod.values, coords={"time": time}, name="aod")
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #601
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

pandas and xarray relax the condition that datetime has to be in nano second resolution. Explicitly cast to `datetime64[ns]` so our tests don't fail. (Could be better to use seconds instead but for backwards compatibility we can make our live easier.) Mostly done so I can remove it from #607. 
