### PR TITLE
MESMER-X: keep scalars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -117,7 +117,10 @@ In the release the MESMER-X functionality is integrated into the MESMER Codebase
 - Enable `threshold_min_proba` to be `None` in `distrib_cov` (`#598 <https://github.com/MESMER-group/mesmer/pull/598>`_).
 - Also use Nelder-Mead fit in `distrib_cov._minimize` for `option_NelderMead == "best_run"` when Powell fit was not successful (`#600 <https://github.com/MESMER-group/mesmer/pull/600>`_).
 - Return `logpmf` for discrete distributions in `distrib_cov._fg_fun_LL_n()` (`#602 <https://github.com/MESMER-group/mesmer/pull/602>`_).
-- Speed-up MESMER-X by avoiding frozen distributions (`#532 <https://github.com/MESMER-group/mesmer/issues/532>`_).
+- Speed-up MESMER-X by
+  - add method to calculate params of a distribution (`#539 <https://github.com/MESMER-group/mesmer/pull/539>`_)
+  - avoiding frozen distributions (`#532 <https://github.com/MESMER-group/mesmer/issues/532>`_)
+  - not broadcasting scalars (`#613 <https://github.com/MESMER-group/mesmer/pull/613>`_)
 
 
 Integration of MESMER-M

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -369,28 +369,7 @@ class Expression:
             # may need to silence warnings here, to avoid spamming
             parameters_values[param] = eval(expr, None, locals)
 
-        # Correcting shapes 1: scalar parameters must have the shape of the inputs
-        # if len(self.inputs_list) > 0:
-
-        #     for param in self.parameters_list:
-        #         param_value = parameters_values[param]
-
-        #         # TODO: use np.ndim(param_value) ==  0? (i.e. isscalar)
-        #         if isinstance(param_value, int | float) or param_value.ndim == 0:
-        #             if isinstance(coefficients_values, xr.Dataset) and (
-        #                 isinstance(inputs_values, xr.Dataset)
-        #             ):
-        #                 param_value = param_value * xr.ones_like(
-        #                     inputs_values[self.inputs_list[0]]
-        #                 )
-        #             else:
-        #                 param_value = param_value * np.ones(
-        #                     inputs_values[self.inputs_list[0]].shape
-        #                 )
-
-        #         parameters_values[param] = param_value
-
-        # Correcting shapes 2: possibly forcing shape
+        # possibly forcing shape
         if forced_shape is not None and len(self.inputs_list) > 0:
 
             for param in self.parameters_list:

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -370,28 +370,28 @@ class Expression:
             parameters_values[param] = eval(expr, None, locals)
 
         # Correcting shapes 1: scalar parameters must have the shape of the inputs
-        if len(self.inputs_list) > 0:
+        # if len(self.inputs_list) > 0:
 
-            for param in self.parameters_list:
-                param_value = parameters_values[param]
+        #     for param in self.parameters_list:
+        #         param_value = parameters_values[param]
 
-                # TODO: use np.ndim(param_value) ==  0? (i.e. isscalar)
-                if isinstance(param_value, int | float) or param_value.ndim == 0:
-                    if isinstance(coefficients_values, xr.Dataset) and (
-                        isinstance(inputs_values, xr.Dataset)
-                    ):
-                        param_value = param_value * xr.ones_like(
-                            inputs_values[self.inputs_list[0]]
-                        )
-                    else:
-                        param_value = param_value * np.ones(
-                            inputs_values[self.inputs_list[0]].shape
-                        )
+        #         # TODO: use np.ndim(param_value) ==  0? (i.e. isscalar)
+        #         if isinstance(param_value, int | float) or param_value.ndim == 0:
+        #             if isinstance(coefficients_values, xr.Dataset) and (
+        #                 isinstance(inputs_values, xr.Dataset)
+        #             ):
+        #                 param_value = param_value * xr.ones_like(
+        #                     inputs_values[self.inputs_list[0]]
+        #                 )
+        #             else:
+        #                 param_value = param_value * np.ones(
+        #                     inputs_values[self.inputs_list[0]].shape
+        #                 )
 
-                parameters_values[param] = param_value
+        #         parameters_values[param] = param_value
 
         # Correcting shapes 2: possibly forcing shape
-        if len(self.inputs_list) > 0 and forced_shape is not None:
+        if forced_shape is not None and len(self.inputs_list) > 0:
 
             for param in self.parameters_list:
                 dims_param = [

--- a/tests/unit/test_mesmer_x_expression.py
+++ b/tests/unit/test_mesmer_x_expression.py
@@ -382,7 +382,7 @@ def test_evaluate_params_norm_dataset():
     params = expr.evaluate_params(coefficients_values, inputs_values)
 
     loc = xr.DataArray([1, 2], dims="x")
-    scale = xr.DataArray([2, 2], dims="x")
+    scale = xr.DataArray(2)
 
     expected = {"loc": loc, "scale": scale}
 
@@ -422,7 +422,7 @@ def test_evaluate_norm_dataset():
     assert isinstance(dist.dist, type(sp.stats.norm))
 
     loc = xr.DataArray([1, 2], dims="x")
-    scale = xr.DataArray([2, 2], dims="x")
+    scale = xr.DataArray(2)
 
     expected = {"loc": loc, "scale": scale}
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

I am very confident that the scalars don't need to be broadcast, which will save some more seconds.
