### PR TITLE
MESMER-X: compile expression

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -117,10 +117,12 @@ In the release the MESMER-X functionality is integrated into the MESMER Codebase
 - Enable `threshold_min_proba` to be `None` in `distrib_cov` (`#598 <https://github.com/MESMER-group/mesmer/pull/598>`_).
 - Also use Nelder-Mead fit in `distrib_cov._minimize` for `option_NelderMead == "best_run"` when Powell fit was not successful (`#600 <https://github.com/MESMER-group/mesmer/pull/600>`_).
 - Return `logpmf` for discrete distributions in `distrib_cov._fg_fun_LL_n()` (`#602 <https://github.com/MESMER-group/mesmer/pull/602>`_).
-- Speed-up MESMER-X by
+- Speed-up MESMER-X
+
   - add method to calculate params of a distribution (`#539 <https://github.com/MESMER-group/mesmer/pull/539>`_)
   - avoiding frozen distributions (`#532 <https://github.com/MESMER-group/mesmer/issues/532>`_)
   - not broadcasting scalars (`#613 <https://github.com/MESMER-group/mesmer/pull/613>`_)
+  - compiling the expression (`#614 <https://github.com/MESMER-group/mesmer/pull/614>`_).
 
 
 Integration of MESMER-M

--- a/mesmer/mesmer_x/train_utils_mesmerx.py
+++ b/mesmer/mesmer_x/train_utils_mesmerx.py
@@ -102,6 +102,9 @@ class Expression:
         # correct expressions of parameters
         self._correct_expr_parameters()
 
+        # compile expression for faster eval
+        self._compile_expression()
+
     def _interpret_distrib(self):
         """interpreting the expression"""
 
@@ -296,6 +299,14 @@ class Expression:
                     param
                 ].replace(f"__{i}__", i)
 
+    def _compile_expression(self):
+        """compile expression for faster eval"""
+
+        self._compiled_param_expr = {
+            param: compile(expr, param, "eval")
+            for param, expr in self.parameters_expressions.items()
+        }
+
     def evaluate_params(self, coefficients_values, inputs_values, forced_shape=None):
         """
         Evaluates the parameters for the provided inputs and coefficients
@@ -365,8 +376,7 @@ class Expression:
 
         # evaluate parameters
         parameters_values = {}
-        for param, expr in self.parameters_expressions.items():
-            # may need to silence warnings here, to avoid spamming
+        for param, expr in self._compiled_param_expr.items():
             parameters_values[param] = eval(expr, None, locals)
 
         # possibly forcing shape


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Another way to speed up MESMER-X. 


```python
import numpy as np

c1 = 2.558745
tas = np.array([1.3, 4])

a = "c1"
a_compiled = compile(a, "", "eval")

b = "c1 * tas"
b_compiled = compile(b, "", "eval")

%timeit eval(a)
%timeit eval(a_compiled)
%timeit eval(b)
%timeit eval(b_compiled)
```


```
5.23 μs ± 70.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
411 ns ± 8.39 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
9.53 μs ± 615 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
1.42 μs ± 41.7 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```


