### PR TITLE
Raise error if first element returns `inf` in `_minimize_local_discrete`

### DIFF
--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -43,12 +43,13 @@ def _minimize_local_discrete(func: Callable, sequence: Iterable, **kwargs):
 
     Raises
     ------
-    ValueError : if `func` returns negative infinity for any input.
+    ValueError : if `func` returns negative infinity for any input or first element is `inf`.
 
     Notes
     -----
     - The function determines the local minimum, i.e., the loop is aborted if
       `func(sequence[i-1]) >= func(sequence[i])`.
+    - If func returns `inf` for any input, the function will return the previous element.
     """
 
     current_min = float("inf")
@@ -73,9 +74,14 @@ def _minimize_local_discrete(func: Callable, sequence: Iterable, **kwargs):
             sel = i - 1
             if sel == 0:
                 warnings.warn("First element is local minimum.", OptimizeWarning)
+            elif sel == -1:
+                raise ValueError("First element is `inf`, aborting.")
+
             return sequence[sel]
 
-    warnings.warn("No local minimum found, returning the last element", OptimizeWarning)
+        warnings.warn(
+            "No local minimum found, returning the last element", OptimizeWarning
+        )
 
     return element
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -150,12 +150,18 @@ def test_minimize_local_discrete_warning():
     assert result == 1
 
 
-def test_minimize_local_discrete_error():
-    def func(i):
+def test_minimize_local_discrete_errors():
+    def func_minf(i):
         return float("-inf")
 
     with pytest.raises(ValueError, match=r"`fun` returned `\-inf`"):
-        mesmer.core.utils._minimize_local_discrete(func, [0])
+        mesmer.core.utils._minimize_local_discrete(func_minf, [0])
+
+    def func_inf(i):
+        return float("inf")
+
+    with pytest.raises(ValueError, match=r"First element is `inf`, aborting."):
+        mesmer.core.utils._minimize_local_discrete(func_inf, [0])
 
 
 @pytest.mark.parametrize("obj", (None, xr.DataArray()))


### PR DESCRIPTION
This is to avoid if the first element returns `inf`, the last element is returned. 

Note that for the application in `find_localized_empirical_covariance()` the whole thing implicitly assumes that the localization radii are ordered and increasing. And that once a localization radius leads to a singular covariance matrix all higher ones do too (reasonably).

 - [ ] Closes #616
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`
