### PR TITLE
bump dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,28 +23,29 @@ Breaking changes
   By `Mathias Hauser`_.
 - The supported versions of some dependencies were changed
   (`#399 <https://github.com/MESMER-group/mesmer/pull/399>`_,
-  `#405 <https://github.com/MESMER-group/mesmer/pull/405>`_, and
-  `#503 <https://github.com/MESMER-group/mesmer/pull/503>`_):
+  `#405 <https://github.com/MESMER-group/mesmer/pull/405>`_,
+  `#503 <https://github.com/MESMER-group/mesmer/pull/503>`_, and
+  `#621 <https://github.com/MESMER-group/mesmer/pull/621>`_):
 
   ================= ============= =========
   Package           Old           New
   ================= ============= =========
   **cartopy**       not specified 0.22
-  **dask**          not specified 2023.8
+  **dask**          not specified 2024.3
   **joblib**        not specified 1.3
   **netcdf4**       not specified 1.6
-  **numpy**         not specified 1.24
-  **packaging**     not specified 23.1
-  **pandas**        2.0           no change
-  **pooch**         not specified 1.7
+  **numpy**         not specified 1.25
+  **packaging**     not specified 24.0
+  **pandas**        2.0           2.2
+  **pooch**         not specified 1.8
   **properscoring** not specified 0.1
   **pyproj**        not specified 3.6
-  **regionmask**    0.8           0.10
-  **scikit-learn**  not specified 1.3
-  **scipy**         not specified 1.11
+  **regionmask**    0.8           0.11
+  **scikit-learn**  not specified 1.4
+  **scipy**         not specified 1.12
   **shapely**       not specified 2.0
   **statsmodels**   not specified 0.14
-  **xarray**        2023.04       2023.7
+  **xarray**        2023.04       2024.2
   ================= ============= =========
 
 Deprecations

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -7,23 +7,23 @@ channels:
 dependencies:
  - python=3.10
  - cartopy=0.22
- - dask=2023.8
+ - dask=2024.3
  - joblib=1.3
  - netcdf4=1.6
- - numpy=1.24
- - packaging=23.1
- - pandas=2.0
- - pooch=1.7
+ - numpy=1.25
+ - packaging=24.0
+ - pandas=2.2
+ - pooch=1.8
  - properscoring=0.1
  - pyproj=3.6
- - regionmask=0.10
- - scikit-learn=1.3
- - scipy=1.11
+ - regionmask=0.11
+ - scikit-learn=1.4
+ - scipy=1.12
  - shapely=2.0
  - statsmodels=0.14
- - xarray=2023.7
+ - xarray=2024.2
  - xarray-datatree=0.0.13
- - pip=23.1
+ - pip=24.0
  - pip:
     - filefisher==1.0.1
 # for testing

--- a/mesmer/core/_data.py
+++ b/mesmer/core/_data.py
@@ -3,7 +3,6 @@ from functools import cache
 import pandas as pd
 import pooch
 import xarray as xr
-from packaging.version import Version
 
 import mesmer
 
@@ -48,8 +47,7 @@ def _load_aod_obs(*, version, resample):
     aod = xr.DataArray(df.aod.values, coords={"time": time}, name="aod")
 
     if resample:
-        freq = "YE" if Version(xr.__version__) >= Version("2024.02") else "A"
-        aod = aod.resample(time=freq).mean()
+        aod = aod.resample(time="YE").mean()
 
     return aod
 

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -2,9 +2,7 @@ import warnings
 from collections.abc import Callable, Iterable
 
 import numpy as np
-import pandas as pd
 import xarray as xr
-from packaging.version import Version
 
 
 class OptimizeWarning(UserWarning):
@@ -139,9 +137,7 @@ def upsample_yearly_data(
         )
 
     # make sure monthly and yearly data both start at the beginning of the period
-    # pandas v2.2 changed the time freq string for year
-    freq = "AS" if Version(pd.__version__) < Version("2.2") else "YS"
-    year = yearly_data.resample({time_dim: freq}).bfill()
+    year = yearly_data.resample({time_dim: "YS"}).bfill()
     month = monthly_time.resample({time_dim: "MS"}).bfill()
 
     # forward fill yearly values to monthly resolution

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,21 +32,21 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.10
 install_requires =
-    dask[array,distributed] >=2023.8
+    dask[array,distributed] >=2024.3
     filefisher >=1.0.1
     joblib >=1.3
     netcdf4 >=1.6
-    numpy >=1.24
-    packaging >=23.1
-    pandas >=2.0
-    pooch >=1.7
+    numpy >=1.25
+    packaging >=24.0
+    pandas >=2.2
+    pooch >=1.8
     properscoring >=0.1
     pyproj >=3.6
-    regionmask >=0.9
-    scikit-learn >=1.3 # only for the tests
-    scipy >=1.11
+    regionmask >=0.11
+    scikit-learn >=1.4 # only for the tests
+    scipy >=1.12
     statsmodels >=0.14
-    xarray >=2023.07, < 2024.10 # upper pin for xarray-datatree
+    xarray >=2024.2, <2024.10 # upper pin for xarray-datatree
     xarray-datatree ==0.0.13
 
 [options.extras_require]

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 import xarray as xr
 from datatree import DataTree, map_over_subtree
-from packaging.version import Version
 
 import mesmer
 from mesmer.core.utils import LinAlgWarning, _check_dataarray_form, _check_dataset_form
@@ -738,7 +737,7 @@ def test_fit_autoregression_monthly_np_with_noise(slope, intercept, std):
 
 
 def test_fit_auto_regression_monthly():
-    freq = "ME" if Version(pd.__version__) >= Version("2.2") else "M"
+    freq = "ME"
     n_years = 20
     n_gridcells = 10
     rng = np.random.default_rng(seed=0)
@@ -835,7 +834,7 @@ def test_draw_autoregression_monthly_np_rng():
 
 @pytest.mark.parametrize("seed", [0, xr.Dataset({"seed": 0})])
 def test_draw_auto_regression_monthly(seed):
-    freq = "ME" if Version(pd.__version__) >= Version("2.2") else "M"
+    freq = "ME"
 
     n_gridcells = 10
     n_realisations = 5
@@ -895,7 +894,7 @@ def test_draw_auto_regression_monthly_dt():
         }
     )
 
-    freq = "ME" if Version(pd.__version__) >= Version("2.2") else "M"
+    freq = "ME"
 
     n_gridcells = 10
     n_realisation = 5

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
-from packaging.version import Version
 
 from mesmer.core._data import load_stratospheric_aerosol_optical_depth_obs
 
@@ -10,9 +9,7 @@ def test_load_stratospheric_aerosol_optical_depth_data():
 
     aod = load_stratospheric_aerosol_optical_depth_obs(version="2022", resample=True)
 
-    freq = "YE" if Version(pd.__version__) >= Version("2.2") else "A"
-
-    time = pd.date_range("1850", "2023", freq=freq)
+    time = pd.date_range("1850", "2023", freq="YE")
     time = xr.DataArray(time, dims="time", coords={"time": time})
 
     xr.testing.assert_equal(aod.time, time)

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from packaging.version import Version
 
 import mesmer
 from mesmer.core.utils import _check_dataarray_form
@@ -41,8 +40,7 @@ def test_generate_fourier_series_np():
 def test_predict_harmonic_model():
     n_years = 10
     n_lat, n_lon, n_gridcells = 2, 3, 2 * 3
-    freq = "AS" if Version(pd.__version__) < Version("2.2") else "YS"
-    time = xr.cftime_range(start="2000-01-01", periods=n_years, freq=freq)
+    time = xr.cftime_range(start="2000-01-01", periods=n_years, freq="YS")
     yearly_predictor = xr.DataArray(
         np.zeros((n_years, n_gridcells)), dims=["time", "cells"], coords={"time": time}
     )
@@ -143,9 +141,8 @@ def test_fit_harmonic_model():
         "time", "cells"
     )
 
-    freq = "AS" if Version(pd.__version__) < Version("2.2") else "YS"
     yearly_predictor["time"] = xr.cftime_range(
-        start="2000-01-01", periods=n_ts, freq=freq
+        start="2000-01-01", periods=n_ts, freq="YS"
     )
 
     time = xr.cftime_range(start="2000-01-01", periods=n_ts * 12, freq="MS")
@@ -211,11 +208,9 @@ def test_fit_harmonic_model_checks():
     with pytest.raises(TypeError):
         mesmer.stats.fit_harmonic_model(yearly_predictor, monthly_target.values)  # type: ignore[arg-type]
 
-    freq = "YE" if Version(pd.__version__) >= Version("2.2") else "Y"
-    yearly_predictor["time"] = pd.date_range("2000-01-01", periods=10, freq=freq)
+    yearly_predictor["time"] = pd.date_range("2000-01-01", periods=10, freq="YE")
 
-    freq = "ME" if Version(pd.__version__) >= Version("2.2") else "M"
-    monthly_target["time"] = pd.date_range("2000-02-01", periods=10 * 12, freq=freq)
+    monthly_target["time"] = pd.date_range("2000-02-01", periods=10 * 12, freq="ME")
     with pytest.raises(ValueError, match="Monthly target data must start with January"):
         mesmer.stats.fit_harmonic_model(yearly_predictor, monthly_target)
 
@@ -225,11 +220,9 @@ def test_fit_harmonic_model_time_dim():
     yearly_predictor = trend_data_2D(n_timesteps=10, n_lat=3, n_lon=2)
     monthly_target = trend_data_2D(n_timesteps=10 * 12, n_lat=3, n_lon=2)
 
-    freq = "YE" if Version(pd.__version__) >= Version("2.2") else "Y"
-    yearly_predictor["time"] = pd.date_range("2000-01-01", periods=10, freq=freq)
+    yearly_predictor["time"] = pd.date_range("2000-01-01", periods=10, freq="YE")
 
-    freq = "ME" if Version(pd.__version__) >= Version("2.2") else "M"
-    monthly_target["time"] = pd.date_range("2000-01-01", periods=10 * 12, freq=freq)
+    monthly_target["time"] = pd.date_range("2000-01-01", periods=10 * 12, freq="ME")
 
     time_dim = "dates"
     monthly_target = monthly_target.rename({"time": time_dim})

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,17 +2,16 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from packaging.version import Version
 
 import mesmer.core.utils
 
 
 def make_dummy_yearly_data(freq, calendar="standard"):
+
+    # NOTE: "YM" is a made-up "Year-Middle" freq string
     if freq == "YM":
-        freq = "AS-JUL" if Version(pd.__version__) < Version("2.2") else "YS-JUL"
-        time = xr.date_range(
-            start="2000", periods=5, freq=freq, calendar=calendar
-        ) + pd.Timedelta("14d")
+        time = xr.date_range(start="2000", periods=5, freq="YS-JUL", calendar=calendar)
+        time = time + pd.Timedelta("14d")
     else:
         time = xr.date_range(start="2000", periods=5, freq=freq, calendar=calendar)
 
@@ -21,16 +20,18 @@ def make_dummy_yearly_data(freq, calendar="standard"):
 
 
 def make_dummy_monthly_data(freq, calendar="standard"):
-    if freq == "MM":
-        time = time = xr.date_range(
-            start="2000", periods=5 * 12, freq="MS", calendar=calendar
-        ) + pd.Timedelta("14d")
-    else:
-        time = xr.date_range(
-            start="2000-01", periods=5 * 12, freq=freq, calendar=calendar
-        )
 
-    data = xr.DataArray(np.ones(5 * 12), dims=("time"), coords={"time": time})
+    start = "2000-01"
+    periods = 5 * 12
+
+    # NOTE: "MM" is a made-up "Month-Middle" freq string
+    if freq == "MM":
+        time = xr.date_range(start=start, periods=periods, freq="MS", calendar=calendar)
+        time = time + pd.Timedelta("14d")
+    else:
+        time = xr.date_range(start=start, periods=periods, freq=freq, calendar=calendar)
+
+    data = xr.DataArray(np.arange(periods), dims=("time"), coords={"time": time})
     return data
 
 
@@ -38,14 +39,6 @@ def make_dummy_monthly_data(freq, calendar="standard"):
 @pytest.mark.parametrize("freq_m", ["MM", "MS", "ME"])
 @pytest.mark.parametrize("calendar", ["standard", "gregorian", "365_day"])
 def test_upsample_yearly_data(freq_y, freq_m, calendar):
-    if Version(pd.__version__) < Version("2.2"):
-        if freq_y == "YE":
-            freq_y = freq_y.replace("YE", "A")
-        elif "YS" in freq_y:
-            freq_y = freq_y.replace("YS", "AS")
-
-        if freq_m == "ME":
-            freq_m = freq_m.replace("ME", "M")
 
     yearly_data = make_dummy_yearly_data(freq_y, calendar=calendar)
     monthly_data = make_dummy_monthly_data(freq_m, calendar=calendar)
@@ -294,10 +287,6 @@ def _get_time(*args, **kwargs):
 
     calendar = kwargs.pop("calendar", "standard")
     freq = kwargs.pop("freq", None)
-
-    # translate freq strings
-    if freq and Version(xr.__version__) < Version("2024.02"):
-        freq = freq.replace("YE", "A").replace("ME", "M")
 
     time = xr.date_range(*args, calendar=calendar, freq=freq, **kwargs)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [x] Fully documented, including `CHANGELOG.rst`


Especially requiring `xarray >=2024.2` and `pandas >= 2.2` allows to remove the frequency string adaptations.

#607 will also need the _newest_ xarray version (but that's not yet relevant).


@l-pierini @yquilcaille: FYI (but you should probably not need to update your environment).