### PR TITLE
add anomaly function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,6 +92,7 @@ This release implements using :py:class:`DataTree` from `xarray-datatree` to han
 - Add calibration integration tests for multiple scenarios and change parameter files to netcdfs with new naming structure (`#537 <https://github.com/MESMER-group/mesmer/pull/537>`_)
 - Add new integration tests for drawing realisations (`#599 <https://github.com/MESMER-group/mesmer/pull/599>`_)
 - Port the functionality to xarray's :py:class:`DataTree` implementation (`#607 <https://github.com/MESMER-group/mesmer/pull/607>`_).
+- Add function to compute anomalies over several scenarios stored in a DataTree (`#625 <https://github.com/MESMER-group/mesmer/pull/625>`_).
 
 By `Victoria Bauer`_ and `Mathias Hauser`_.
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -133,6 +133,15 @@ Geospatial
    ~core.geospatial.geodist_exact
 
 
+Anomalies
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   ~core.anomaly.calc_anomaly
+
+
 Emulator functions
 ==================
 

--- a/mesmer/__init__.py
+++ b/mesmer/__init__.py
@@ -11,7 +11,7 @@ from importlib.metadata import version as _get_version
 
 from mesmer import calibrate_mesmer, core, create_emulations, io, stats, testing, utils
 from mesmer.core import _data as data
-from mesmer.core import datatree, geospatial, grid, mask, volc, weighted
+from mesmer.core import anomaly, datatree, geospatial, grid, mask, volc, weighted
 
 # "legacy" modules
 __all__ = [
@@ -23,6 +23,7 @@ __all__ = [
 
 # "new" "modules"
 __all__ += [
+    "anomaly",
     "core",
     "data",
     "datatree",

--- a/mesmer/core/anomaly.py
+++ b/mesmer/core/anomaly.py
@@ -1,0 +1,75 @@
+import operator
+
+from mesmer.core._datatreecompat import DataTree, map_over_datasets
+
+
+def calc_anomaly(
+    dt: DataTree, reference_period: slice, *, time_dim="time", ref_scenario="historical"
+) -> DataTree:
+    """subtract mean over the reference period
+
+    Parameters
+    ----------
+    dt : DataTree
+        Data to to calculate anomalies from. Must be a DataTree object which contains
+        the historical scenario as node and may contain several projections. Individual
+        ensmble members must be on the scenario nodes and
+    reference_period : slice(str, str)
+        Reference period, e.g. ``slice("1850", "1900")``.
+    time_dim : str, default: "time"
+        Name of the time dimension.
+    ref_scenario : str, default: "historical"
+        Name of the node containing the reference scenario.
+
+
+    Returns
+    -------
+    anomalies: DataTree
+        ``dt`` with the reference period subtracted.
+
+    Notes
+    -----
+    - subtracts the reference of each individual ensmble member""
+
+    """
+
+    # NOTE: this corresponds to `ref["type"] == "individ"`
+
+    if ref_scenario not in dt.children:
+        raise ValueError(f"The ref_scenario ({ref_scenario}) is missing from `dt`")
+
+    # calculate anomalies w.r.t. the reference period
+    ref = dt[ref_scenario].sel({time_dim: reference_period})
+
+    if ref[time_dim].size == 0:
+        raise ValueError("No data selected for reference period")
+
+    ref = ref.mean(time_dim)
+
+    # https://github.com/pydata/xarray/issues/10013
+    # anomalies = dt - ref.ds
+    anomalies = map_over_datasets(operator.sub, dt, ref.ds)
+
+    map_over_datasets(_assert_same_coords, dt, anomalies, ref_scenario)
+
+    return anomalies
+
+
+def _assert_same_coords(ref, anom, ref_scenario):
+
+    # TODO: use xr.group_subtrees?
+
+    # import xarray as xr
+
+    # for path, (l, r) in xr.group_subtrees(dt, dt_anom):
+    if not ref.coords.equals(anom.coords):
+
+        msg = (
+            f"Subtracting the reference changed the coordinates. "
+            f"Most likely because the ref_scenario ({ref_scenario}) is missing "
+            "some ensemble members.\n"
+        )
+
+        raise ValueError(msg)
+
+    return ref

--- a/tests/integration/test_calibrate_mesmer_newcodepath.py
+++ b/tests/integration/test_calibrate_mesmer_newcodepath.py
@@ -1,4 +1,3 @@
-import operator
 import pathlib
 
 import pytest
@@ -188,11 +187,7 @@ def test_calibrate_mesmer(
     # convert the 0..360 grid to a -180..180 grid to be consistent with legacy code
 
     # calculate anomalies w.r.t. the reference period
-    ref = dt["historical"].sel(time=REFERENCE_PERIOD).mean("time")
-
-    # https://github.com/pydata/xarray/issues/10013
-    # tas_anoms = dt - ref.ds
-    tas_anoms = map_over_datasets(operator.sub, dt, ref.ds)
+    tas_anoms = mesmer.anomaly.calc_anomaly(dt, REFERENCE_PERIOD)
 
     tas_globmean = map_over_datasets(mesmer.weighted.global_mean, tas_anoms)
 
@@ -241,12 +236,8 @@ def test_calibrate_mesmer(
     )
 
     if dt_hfds is not None:
-        hfds_ref = dt_hfds["historical"].sel(time=REFERENCE_PERIOD).mean("time")
 
-        # TODO: use again, https://github.com/pydata/xarray/issues/10013
-        # hfds_anoms = dt_hfds - hfds_ref.ds
-
-        hfds_anoms = map_over_datasets(operator.sub, dt_hfds, hfds_ref.ds)
+        hfds_anoms = mesmer.anomaly.calc_anomaly(dt_hfds, REFERENCE_PERIOD)
 
         hfds_globmean = map_over_datasets(mesmer.weighted.global_mean, hfds_anoms)
 

--- a/tests/unit/test_anomaly.py
+++ b/tests/unit/test_anomaly.py
@@ -1,0 +1,93 @@
+import re
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import mesmer
+from mesmer.core._datatreecompat import DataTree, map_over_datasets
+
+
+@pytest.fixture
+def example_tas():
+
+    data_hist = np.arange(12).reshape(3, 4)
+
+    time_hist = xr.date_range("1850-01-01", "2000-01-01", freq="50YS")
+
+    ens_hist = ["0", "1", "2"]
+
+    dta = xr.DataArray(
+        data_hist,
+        dims=("ens", "time"),
+        coords={"ens": ens_hist, "time": time_hist},
+        name="tas",
+    )
+    hist = xr.Dataset(data_vars={"tas": dta})
+
+    data_proj = np.arange(4).reshape(2, 2) * 10
+    time_proj = xr.date_range("2050-01-01", "2100-01-01", freq="50YS")
+
+    ens_proj = ["0", "2"]
+    dta = xr.DataArray(
+        data_proj,
+        dims=("ens", "time"),
+        coords={"ens": ens_proj, "time": time_proj},
+        name="tas",
+    )
+    proj = xr.Dataset(data_vars={"tas": dta})
+
+    tas = DataTree.from_dict({"historical": hist, "proj": proj})
+
+    return tas
+
+
+def test_calc_anomaly_errors(example_tas):
+    # TODO: uncomment tests once requiring new xarray version
+
+    with pytest.raises(
+        ValueError, match=re.escape("The ref_scenario (wrong) is missing from `dt`")
+    ):
+        mesmer.anomaly.calc_anomaly(
+            example_tas, slice("1850", "1900"), ref_scenario="wrong"
+        )
+
+    # different error is raised in datatree than xarray
+    # with pytest.raises(ValueError, match="Dimensions {'wrong'} do not exist"):
+    #     mesmer.anomaly.calc_anomaly(
+    #         example_tas, slice("1850", "1900"), time_dim="wrong"
+    #     )
+
+    with pytest.raises(ValueError, match="No data selected for reference period"):
+        mesmer.anomaly.calc_anomaly(example_tas, slice("1750", "1800"))
+
+    # add scenario containing a ensemble that is missing from historical
+    # example_tas["proj1"] = example_tas["proj"].dataset.assign_coords(ens=["0", "3"])
+
+    ds = example_tas["proj"].to_dataset().assign_coords(ens=["0", "3"])
+    example_tas["proj1"] = DataTree(ds)
+
+    with pytest.raises(
+        ValueError, match="Subtracting the reference changed the coordinates."
+    ):
+        mesmer.anomaly.calc_anomaly(example_tas, slice("1850", "1900"))
+
+
+def test_calc_anomaly(example_tas):
+
+    result = mesmer.anomaly.calc_anomaly(example_tas, slice("1850", "1900"))
+
+    ref = example_tas["historical"].sel(time=slice("1850", "1900")).mean("time")
+
+    expected = example_tas.copy(deep=True)
+
+    expected["historical"] = expected["historical"] - ref
+    expected["proj"] = expected["proj"] - ref
+
+    def _assert(a, b):
+        xr.testing.assert_equal(a, b)
+        return a
+
+    map_over_datasets(_assert, result, expected)
+
+    # xr.testing.assert_equal(result, expected)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Adds a helper function to calculate anomalies, which hides not-nice `xr.DataTree` workaround. Turns out this is all nice and dandy until you think about all the ways this could fail. So if an member is missing from the historical simulation it silently removes it from the scenario (inner join). Testing that up-front is annoying (because we don't know the name of the ensemble dimension) so we compare the coords of the anomaly with the original ones.

Also here we see some stuff that is nicer on the new datatree implementation, e.g. a way to iterate over two or more trees (`group_subtrees`). There is some incompatibility in the tests which I don't bother to fix.


