### PR TITLE
fix pins in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,15 +13,15 @@ dependencies:
  - netcdf4
  - numpy
  - packaging
- - pandas>=2.0
+ - pandas>=2.2
  - pooch
  - properscoring
  - pyproj
- - regionmask>=0.9
+ - regionmask>=0.11
  - scikit-learn
  - scipy
- - statsmodels>=0.13
- - xarray>=2023.04, <2024.10 # upper pin for xarray-datatree
+ - statsmodels>=0.14
+ - xarray>=2024.02, <2024.10 # upper pin for xarray-datatree
  - xarray-datatree==0.0.13
 # for testing
  - black!=23


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

In #621 I forgot to bump the dependencies in `environment.yml`. Honestly, I am not sure why we even have lower pins (the upper pin of xarray, and the exact pins of regionmask, and datatree are required). No pin means "takes the newest possible version". 