### PR TITLE
calc_anomaly: keep attrs

### DIFF
--- a/mesmer/core/anomaly.py
+++ b/mesmer/core/anomaly.py
@@ -54,7 +54,8 @@ def calc_anomaly(
 
     # https://github.com/pydata/xarray/issues/10013
     # anomalies = dt - ref.ds
-    anomalies = map_over_datasets(operator.sub, dt, ref.ds)
+    with xr.set_options(keep_attrs=True):
+        anomalies = map_over_datasets(operator.sub, dt, ref.ds)
 
     _assert_same_coords(dt, anomalies, ref_scenario)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Seen while working on #572, also uses `xr.testing.assert_equal` for `xr.DataTree` objects - forgotten in #627