### PR TITLE
fit_harmonic_model: allow more dims

### DIFF
--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -305,32 +305,29 @@ def fit_harmonic_model(
     """
 
     _check_dataarray_form(
-        yearly_predictor, "yearly_predictor", ndim=2, required_dims={time_dim}
+        yearly_predictor, "yearly_predictor", required_dims={time_dim}
     )
 
-    _check_dataarray_form(
-        monthly_target, "monthly_target", ndim=2, required_dims={time_dim}
-    )
+    _check_dataarray_form(monthly_target, "monthly_target", required_dims={time_dim})
 
-    (gridcell_dim,) = set(monthly_target.dims) - {time_dim}
-
-    if gridcell_dim not in yearly_predictor.dims:
-        (gridcell_dim_yp,) = set(yearly_predictor.dims) - {time_dim}
+    if set(yearly_predictor.dims) != set(monthly_target.dims):
 
         msg = (
-            "Differently named `gridcell_dim`:\n"
-            f"- `{gridcell_dim_yp}` in `yearly_predictor`\n"
-            f"- `{gridcell_dim}` in `monthly_target`"
+            "DataArray objects have different dimensions:\n"
+            f"- `{yearly_predictor.dims}` in `yearly_predictor`\n"
+            f"- `{monthly_target.dims}` in `monthly_target`"
         )
         raise ValueError(msg)
 
-    if yearly_predictor[gridcell_dim].size != monthly_target[gridcell_dim].size:
-        msg = (
-            "yearly_predictor` and `monthly_target` don't have the same number of "
-            f"gridcells ({yearly_predictor[gridcell_dim].size} vs. "
-            f"{monthly_target[gridcell_dim].size})"
-        )
-        raise ValueError(msg)
+    for dim in set(yearly_predictor.dims) - {time_dim}:
+
+        if yearly_predictor[dim].size != monthly_target[dim].size:
+            msg = (
+                f"The '{dim}' coords of `yearly_predictor` and `monthly_target` have a "
+                f"different size: {yearly_predictor[dim].size} vs. "
+                f"{monthly_target[dim].size}"
+            )
+            raise ValueError(msg)
 
     if not monthly_target[time_dim].isel({time_dim: 0}).dt.month == 1:
         raise ValueError("Monthly target data must start with January.")

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -216,22 +216,22 @@ def test_fit_harmonic_model_checks():
 
     monthly_target["time"] = pd.date_range("2000-01-01", periods=10 * 12, freq="ME")
 
-    with pytest.raises(ValueError, match="yearly_predictor should be 2D, but is 1D"):
+    with pytest.raises(ValueError, match="DataArray objects have different dimensions"):
         mesmer.stats.fit_harmonic_model(yearly_predictor.isel(cells=0), monthly_target)
 
-    with pytest.raises(ValueError, match="Differently named `gridcell_dim`:"):
+    with pytest.raises(ValueError, match="DataArray objects have different dimensions"):
         mesmer.stats.fit_harmonic_model(
             yearly_predictor.rename(cells="gp"), monthly_target
         )
 
-    with pytest.raises(ValueError, match="Differently named `gridcell_dim`:"):
+    with pytest.raises(ValueError, match="DataArray objects have different dimensions"):
         mesmer.stats.fit_harmonic_model(
             yearly_predictor, monthly_target.rename(cells="gp")
         )
 
     with pytest.raises(
         ValueError,
-        match=r"yearly_predictor` and `monthly_target` don't have the same number of gridcells \(6 vs\. 4\)",
+        match=r"The 'cells' coords of `yearly_predictor` and `monthly_target` have a different size: 6 vs. 4",
     ):
         mesmer.stats.fit_harmonic_model(
             yearly_predictor, monthly_target.isel(cells=slice(None, 4))
@@ -239,7 +239,7 @@ def test_fit_harmonic_model_checks():
 
     with pytest.raises(
         ValueError,
-        match=r"yearly_predictor` and `monthly_target` don't have the same number of gridcells \(5 vs\. 6\)",
+        match=r"The 'cells' coords of `yearly_predictor` and `monthly_target` have a different size: 5 vs. 6",
     ):
         mesmer.stats.fit_harmonic_model(
             yearly_predictor.isel(cells=slice(None, 5)), monthly_target


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Working on #572 I realized that I was too zealous in #624 - and we should allow more than 1 extra dimension (i.e. gridpoint and member, but let's generalize and allow any number).