### PR TITLE
skip calibration tests on windos

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -53,6 +53,7 @@ jobs:
         else
           echo "CONDA_ENV_FILE=ci/requirements/${{ matrix.env }}.yml" >> $GITHUB_ENV
         fi
+        echo "date=$(date +'%Y-%m-%d')"  >> $GITHUB_ENV
 
     - name: Create conda environment
       uses: mamba-org/setup-micromamba@v2
@@ -60,6 +61,9 @@ jobs:
         environment-name: mesmer-tests
         cache-downloads: true
         cache-downloads-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{ env.CONDA_ENV_FILE }}"
+        cache-environment: true
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{ env.CONDA_ENV_FILE }}-${{ env.date }}"
+
         micromamba-version: 'latest'
         environment-file: ${{ env.CONDA_ENV_FILE }}
         create-args: >-

--- a/tests/integration/test_calibrate_mesmer.py
+++ b/tests/integration/test_calibrate_mesmer.py
@@ -1,11 +1,16 @@
 import os.path
 import shutil
+import sys
 
 import joblib
 import pytest
 
 from mesmer.calibrate_mesmer import _calibrate_tas
 from mesmer.testing import assert_dict_allclose
+
+# skip tests on windows (because it's slow & this is the legacy code path)
+if sys.platform.startswith("win"):
+    pytest.skip("skipping windows-only tests", allow_module_level=True)
 
 
 @pytest.mark.filterwarnings("ignore:No local minimum found")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Skip tests in test_calibrate_mesmer.py on windows. Win is much slower than linux & mac and these tests check the legacy code base which should be removed soon anyway.