### PR TITLE
enable functions for xr.DataTree

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,6 +92,7 @@ This was originally done with the prototype `xarray-datatree` package. After the
 - Add weighting function for several scenarios (`#567 <https://github.com/MESMER-group/mesmer/pull/567>`_).
 - Add function to compute anomalies over several scenarios stored in a :py:class:`DataTree` (`#625 <https://github.com/MESMER-group/mesmer/pull/625>`_).
 - Add utility functions for :py:class:`DataTree` (`#556 <https://github.com/MESMER-group/mesmer/pull/556>`_).
+- Add a wrapper to allow :py:class:`DataTree` in many data handling functions (`#632 <https://github.com/MESMER-group/mesmer/issues/632>`_).
 - Add calibration integration tests for multiple scenarios and change parameter files to netcdfs with new naming structure (`#537 <https://github.com/MESMER-group/mesmer/pull/537>`_)
 - Add new integration tests for drawing realisations (`#599 <https://github.com/MESMER-group/mesmer/pull/599>`_)
 - PRs related to xarray and xarray-datatree:

--- a/mesmer/core/datatree.py
+++ b/mesmer/core/datatree.py
@@ -1,3 +1,4 @@
+import functools
 from typing import overload
 
 import xarray as xr
@@ -196,3 +197,17 @@ def stack_datatrees_for_linear_regression(
         weights_stacked = None
 
     return predictors_stacked, target_stacked, weights_stacked
+
+
+def _datatree_wrapper(func):
+    """wrapper to extend functions written for DataTree"""
+
+    @functools.wraps(func)
+    def inner(*args, **kwargs):
+
+        if any(isinstance(arg, xr.DataTree) for arg in args):
+            return map_over_datasets(func, *args, kwargs=kwargs)
+
+        return func(*args, **kwargs)
+
+    return inner

--- a/mesmer/core/datatree.py
+++ b/mesmer/core/datatree.py
@@ -200,7 +200,11 @@ def stack_datatrees_for_linear_regression(
 
 
 def _datatree_wrapper(func):
-    """wrapper to extend functions written for DataTree"""
+    """wrapper to extend functions so DataTree can be passed
+
+    NOTE: DataTree arguments __must__ be passed as args (positional) and not as
+    kwargs
+    """
 
     @functools.wraps(func)
     def inner(*args, **kwargs):

--- a/mesmer/core/grid.py
+++ b/mesmer/core/grid.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import xarray as xr
 
+from mesmer.core.datatree import _datatree_wrapper
+
 
 def _lon_to_180(lon):
 
@@ -24,6 +26,7 @@ def _lon_to_360(lon):
     return lon
 
 
+@_datatree_wrapper
 def wrap_to_180(
     obj: xr.Dataset | xr.DataArray, lon_name: str = "lon"
 ) -> xr.Dataset | xr.DataArray:
@@ -32,14 +35,14 @@ def wrap_to_180(
 
     Parameters
     ----------
-    obj : xr.Dataset or xr.DataArray
+    obj : xr.DataTree | xr.Dataset | xr.DataArray
         object with longitude coordinates
     lon_name : str, default: "lon"
         name of the longitude ('lon', 'longitude', ...)
 
     Returns
     -------
-    wrapped : xr.Dataset or xr.DataArray
+    wrapped : xr.DataTree | xr.Dataset | xr.DataArray
         Another dataset or array wrapped around.
     """
 
@@ -51,6 +54,7 @@ def wrap_to_180(
     return obj
 
 
+@_datatree_wrapper
 def wrap_to_360(
     obj: xr.Dataset | xr.DataArray, lon_name: str = "lon"
 ) -> xr.Dataset | xr.DataArray:
@@ -59,14 +63,14 @@ def wrap_to_360(
 
     Parameters
     ----------
-    obj : xr.Dataset or xr.DataArray
+    obj : xr.DataTree | xr.Dataset | xr.DataArray
         object with longitude coordinates
     lon_name : str, default: "lon"
         name of the longitude ('lon', 'longitude', ...)
 
     Returns
     -------
-    wrapped : xr.Dataset or xr.DataArray
+    wrapped : xr.DataTree | xr.Dataset | xr.DataArray
         Another dataset or array wrapped around.
     """
 
@@ -78,6 +82,7 @@ def wrap_to_360(
     return obj
 
 
+@_datatree_wrapper
 def stack_lat_lon(
     data,
     *,
@@ -91,7 +96,7 @@ def stack_lat_lon(
 
     Parameters
     ----------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array to convert to an 1D grid.
     x_dim : str, default: "lon"
         Name of the x-dimension.
@@ -106,7 +111,7 @@ def stack_lat_lon(
 
     Returns
     -------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array converted to an 1D grid.
     """
 
@@ -123,6 +128,7 @@ def stack_lat_lon(
     return data
 
 
+@_datatree_wrapper
 def unstack_lat_lon_and_align(
     data, coords_orig, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"
 ):
@@ -130,7 +136,7 @@ def unstack_lat_lon_and_align(
 
     Parameters
     ----------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array with 1D grid to unstack and align.
     coords_orig : xr.Dataset | xr.DataArray
         xarray object containing the original coordinates before it was converted to the
@@ -144,7 +150,7 @@ def unstack_lat_lon_and_align(
 
     Returns
     -------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array converted to a regular lat-lon grid.
     """
 
@@ -155,12 +161,13 @@ def unstack_lat_lon_and_align(
     return data
 
 
+@_datatree_wrapper
 def unstack_lat_lon(data, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
     """unstack an 1D grid to a regular lat-lon grid but do not align
 
     Parameters
     ----------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array with 1D grid to unstack and align.
     x_dim : str, default: "lon"
         Name of the x-dimension.
@@ -171,7 +178,7 @@ def unstack_lat_lon(data, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
 
     Returns
     -------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array converted to a regular lat-lon grid (unaligned).
     """
 
@@ -182,12 +189,13 @@ def unstack_lat_lon(data, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
     return data.unstack(stack_dim)
 
 
+@_datatree_wrapper
 def align_to_coords(data, coords_orig):
     """align an unstacked lat-lon grid with its original coords
 
     Parameters
     ----------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Unstacked array with lat-lon to align.
     coords_orig : xr.Dataset | xr.DataArray
         xarray object containing the original coordinates before it was converted to the
@@ -195,7 +203,7 @@ def align_to_coords(data, coords_orig):
 
     Returns
     -------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array aligned with original grid.
     """
 

--- a/mesmer/core/grid.py
+++ b/mesmer/core/grid.py
@@ -35,14 +35,14 @@ def wrap_to_180(
 
     Parameters
     ----------
-    obj : xr.DataTree | xr.Dataset | xr.DataArray
+    obj : xr.DataArray | xr.Dataset | xr.DataTree
         object with longitude coordinates
     lon_name : str, default: "lon"
         name of the longitude ('lon', 'longitude', ...)
 
     Returns
     -------
-    wrapped : xr.DataTree | xr.Dataset | xr.DataArray
+    wrapped : xr.DataArray | xr.Dataset | xr.DataTree
         Another dataset or array wrapped around.
     """
 
@@ -63,14 +63,14 @@ def wrap_to_360(
 
     Parameters
     ----------
-    obj : xr.DataTree | xr.Dataset | xr.DataArray
+    obj : xr.DataArray | xr.Dataset | xr.DataTree
         object with longitude coordinates
     lon_name : str, default: "lon"
         name of the longitude ('lon', 'longitude', ...)
 
     Returns
     -------
-    wrapped : xr.DataTree | xr.Dataset | xr.DataArray
+    wrapped : xr.DataArray | xr.Dataset | xr.DataTree
         Another dataset or array wrapped around.
     """
 
@@ -96,7 +96,7 @@ def stack_lat_lon(
 
     Parameters
     ----------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array to convert to an 1D grid.
     x_dim : str, default: "lon"
         Name of the x-dimension.
@@ -111,7 +111,7 @@ def stack_lat_lon(
 
     Returns
     -------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array converted to an 1D grid.
     """
 
@@ -136,7 +136,7 @@ def unstack_lat_lon_and_align(
 
     Parameters
     ----------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array with 1D grid to unstack and align.
     coords_orig : xr.Dataset | xr.DataArray
         xarray object containing the original coordinates before it was converted to the
@@ -150,7 +150,7 @@ def unstack_lat_lon_and_align(
 
     Returns
     -------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array converted to a regular lat-lon grid.
     """
 
@@ -167,7 +167,7 @@ def unstack_lat_lon(data, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
 
     Parameters
     ----------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array with 1D grid to unstack and align.
     x_dim : str, default: "lon"
         Name of the x-dimension.
@@ -178,7 +178,7 @@ def unstack_lat_lon(data, *, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
 
     Returns
     -------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array converted to a regular lat-lon grid (unaligned).
     """
 
@@ -195,7 +195,7 @@ def align_to_coords(data, coords_orig):
 
     Parameters
     ----------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Unstacked array with lat-lon to align.
     coords_orig : xr.Dataset | xr.DataArray
         xarray object containing the original coordinates before it was converted to the
@@ -203,7 +203,7 @@ def align_to_coords(data, coords_orig):
 
     Returns
     -------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array aligned with original grid.
     """
 

--- a/mesmer/core/mask.py
+++ b/mesmer/core/mask.py
@@ -28,7 +28,7 @@ def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
 
     Parameters
     ----------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array to mask.
     threshold : float
         Threshold above which land fraction to consider a grid point as a land grid
@@ -40,7 +40,7 @@ def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
 
     Returns
     -------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array with ocean grid points masked out.
 
     Notes
@@ -82,7 +82,7 @@ def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
 
     Parameters
     ----------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array to mask.
     x_coords : str, default: "lon"
         Name of the x-coordinates.
@@ -91,7 +91,7 @@ def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
 
     Returns
     -------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array with ocean grid points masked out.
 
     Notes
@@ -118,14 +118,14 @@ def mask_antarctica(data, *, y_coords="lat"):
 
     Parameters
     ----------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array to mask.
     y_coords : str, default: "lat"
         Name of the y-coordinates.
 
     Returns
     -------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array with Antarctic grid points masked out.
 
     Notes

--- a/mesmer/core/mask.py
+++ b/mesmer/core/mask.py
@@ -3,6 +3,7 @@ import regionmask
 import xarray as xr
 
 import mesmer
+from mesmer.core.datatree import _datatree_wrapper
 
 
 def _where_if_coords(obj, cond, coords):
@@ -21,12 +22,13 @@ def _where_if_coords(obj, cond, coords):
     return obj.where(cond)
 
 
+@_datatree_wrapper
 def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
     """mask out ocean using fractional overlap
 
     Parameters
     ----------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array to mask.
     threshold : float
         Threshold above which land fraction to consider a grid point as a land grid
@@ -38,7 +40,7 @@ def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
 
     Returns
     -------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array with ocean grid points masked out.
 
     Notes
@@ -74,12 +76,13 @@ def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
     return _where_if_coords(data, mask_bool, [y_coords, x_coords])
 
 
+@_datatree_wrapper
 def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
     """mask out ocean
 
     Parameters
     ----------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array to mask.
     x_coords : str, default: "lon"
         Name of the x-coordinates.
@@ -88,7 +91,7 @@ def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
 
     Returns
     -------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array with ocean grid points masked out.
 
     Notes
@@ -109,19 +112,20 @@ def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
     return _where_if_coords(data, mask_bool, [y_coords, x_coords])
 
 
+@_datatree_wrapper
 def mask_antarctica(data, *, y_coords="lat"):
     """mask out ocean
 
     Parameters
     ----------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array to mask.
     y_coords : str, default: "lat"
         Name of the y-coordinates.
 
     Returns
     -------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array with Antarctic grid points masked out.
 
     Notes

--- a/mesmer/core/weighted.py
+++ b/mesmer/core/weighted.py
@@ -88,7 +88,7 @@ def global_mean(data, weights=None, x_dim="lon", y_dim="lat"):
 
     Parameters
     ----------
-    data : xr.DataTree | xr.Dataset | xr.DataArray
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Array reduce to the global mean.
     weights : xr.DataArray, optional
         DataArray containing the area of each grid cell (or a measure proportional to

--- a/mesmer/core/weighted.py
+++ b/mesmer/core/weighted.py
@@ -4,6 +4,7 @@ import numpy as np
 import xarray as xr
 
 from mesmer.core._datatreecompat import map_over_datasets
+from mesmer.core.datatree import _datatree_wrapper
 
 
 def _weighted_if_dim(obj, weights, dims):
@@ -81,12 +82,13 @@ def weighted_mean(data, weights, dims=None):
     return _weighted_if_dim(data, weights, dims)
 
 
+@_datatree_wrapper
 def global_mean(data, weights=None, x_dim="lon", y_dim="lat"):
     """calculate global weighted mean
 
     Parameters
     ----------
-    data : xr.Dataset | xr.DataArray
+    data : xr.DataTree | xr.Dataset | xr.DataArray
         Array reduce to the global mean.
     weights : xr.DataArray, optional
         DataArray containing the area of each grid cell (or a measure proportional to
@@ -99,7 +101,7 @@ def global_mean(data, weights=None, x_dim="lon", y_dim="lat"):
 
     Returns
     -------
-    obj : xr.Dataset | xr.DataArray
+    obj : xr.DataTree |  xr.Dataset | xr.DataArray
         Array converted to an unstructured grid.
 
     """

--- a/mesmer/stats/_smoothing.py
+++ b/mesmer/stats/_smoothing.py
@@ -3,11 +3,13 @@ from typing import TypeVar
 import numpy as np
 import xarray as xr
 
+from mesmer.core.datatree import _datatree_wrapper
 from mesmer.core.utils import _check_dataarray_form
 
 T_Xarray = TypeVar("T_Xarray", "xr.DataArray", "xr.Dataset")
 
 
+@_datatree_wrapper
 def lowess(
     data: T_Xarray,
     dim: str,
@@ -22,7 +24,7 @@ def lowess(
 
     Parameters
     ----------
-    data : xr.DataArray | xr.Dataset
+    data : xr.DataArray | xr.Dataset | xr.DataTree
         Data to smooth (y-values).
     dim : str
         Dimension along which to smooth (x-dimension)
@@ -44,8 +46,8 @@ def lowess(
 
     Returns
     -------
-    out : xr.DataArray | xr.Dataset same as `data`
-        LOWESS smoothed array
+    out : xr.DataArray | xr.Dataset | xr.DataTree
+        LOWESS smoothed array. Same type as `data`.
 
     See Also
     --------

--- a/mesmer/testing.py
+++ b/mesmer/testing.py
@@ -126,3 +126,15 @@ def trend_data_3D(
 
     # reshape to 3D (time x lat x lon)
     return data.set_index(cells=("lat", "lon")).unstack("cells")
+
+
+def _convert(da: xr.DataArray, datatype):
+
+    if datatype == "DataArray":
+        return da
+
+    if datatype == "Dataset":
+        return da.to_dataset()
+
+    if datatype == "DataTree":
+        return xr.DataTree.from_dict({"node": da.to_dataset()})

--- a/mesmer/testing.py
+++ b/mesmer/testing.py
@@ -138,3 +138,5 @@ def _convert(da: xr.DataArray, datatype):
 
     if datatype == "DataTree":
         return xr.DataTree.from_dict({"node": da.to_dataset()})
+
+    raise ValueError(f"Unkown datatype: {datatype}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,11 @@ def update_expected_files(request):
     return request.config.getoption("--update-expected-files")
 
 
+@pytest.fixture(params=["DataArray", "Dataset", "DataTree"])
+def datatype(request):
+    return request.param
+
+
 # add markers and options
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def update_expected_files(request):
     return request.config.getoption("--update-expected-files")
 
 
-@pytest.fixture(params=["DataArray", "Dataset", "DataTree"])
+@pytest.fixture(params=("DataArray", "Dataset", "DataTree"))
 def datatype(request):
     return request.param
 

--- a/tests/integration/test_draw_realisations_mesmer_newcodepath.py
+++ b/tests/integration/test_draw_realisations_mesmer_newcodepath.py
@@ -105,13 +105,11 @@ def create_forcing_data(test_data_root_dir, scenarios, use_hfds, use_tas2):
     tas = load_hist_scen_continuous(fc_hist, fc_scens)
     ref = tas.sel(time=REFERENCE_PERIOD).mean("time")
     tas_anoms = tas - ref
-    tas_globmean = map_over_datasets(mesmer.weighted.global_mean, tas_anoms)
+    tas_globmean = mesmer.weighted.global_mean(tas_anoms)
 
     tas_globmean_ensmean = tas_globmean.mean(dim="member")
-    tas_globmean_forcing = map_over_datasets(
-        mesmer.stats.lowess,
-        tas_globmean_ensmean,
-        kwargs={"dim": "time", "n_steps": 30, "use_coords": False},
+    tas_globmean_forcing = mesmer.stats.lowess(
+        tas_globmean_ensmean, dim="time", n_steps=30, use_coords=False
     )
 
     def _get_hfds():
@@ -136,13 +134,10 @@ def create_forcing_data(test_data_root_dir, scenarios, use_hfds, use_tas2):
         hfds = load_hist_scen_continuous(fc_hfds_hist, fc_hfds)
         hfds_ref = hfds.sel(time=REFERENCE_PERIOD).mean("time")
         hfds_anoms = hfds - hfds_ref
-        hfds_globmean = map_over_datasets(mesmer.weighted.global_mean, hfds_anoms)
+        hfds_globmean = mesmer.weighted.global_mean(hfds_anoms)
         hfds_globmean_ensmean = hfds_globmean.mean(dim="member")
-        hfds_globmean_smoothed = map_over_datasets(
-            mesmer.stats.lowess,
-            hfds_globmean_ensmean,
-            "time",
-            kwargs={"n_steps": 50, "use_coords": False},
+        hfds_globmean_smoothed = mesmer.stats.lowess(
+            hfds_globmean_ensmean, "time", n_steps=50, use_coords=False
         )
         return hfds_globmean_smoothed
 
@@ -287,6 +282,7 @@ def test_make_realisations(
 
     # 1.) superimpose volcanic influence
     volcanic_params = xr.open_dataset(volcanic_file)
+    # TODO: check superimpose_volcanic_influence
     tas_forcing = map_over_datasets(
         mesmer.volc.superimpose_volcanic_influence,
         tas_forcing,

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -3,9 +3,10 @@ import pytest
 import xarray as xr
 
 import mesmer
+from mesmer.testing import _convert
 
 
-def data_1D_coords(as_dataset, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
+def data_1D_coords(datatype, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
 
     data = np.arange(2 * 3 * 4, dtype=float)
     time = [0, 1]
@@ -35,13 +36,10 @@ def data_1D_coords(as_dataset, x_dim="lon", y_dim="lat", stack_dim="gridcell"):
         attrs=attrs,
     )
 
-    if as_dataset:
-        return da_structured.to_dataset(), da_unstructured.to_dataset()
-
-    return da_structured, da_unstructured
+    return _convert(da_structured, datatype), _convert(da_unstructured, datatype)
 
 
-def data_2D_coords(as_dataset):
+def data_2D_coords(datatype):
 
     data = np.arange(2 * 3 * 4, dtype=float)
     time = [0, 1]
@@ -73,28 +71,31 @@ def data_2D_coords(as_dataset):
         attrs=attrs,
     )
 
-    if as_dataset:
-        return da_structured.to_dataset(), da_unstructured.to_dataset()
-
-    return da_structured, da_unstructured
+    return _convert(da_structured, datatype), _convert(da_unstructured, datatype)
 
 
-@pytest.mark.parametrize("as_dataset", [True, False])
-def test_to_unstructured_defaults(as_dataset):
-    da, expected = data_1D_coords(as_dataset)
+def test_to_unstructured_defaults(datatype):
+    da, expected = data_1D_coords(datatype)
 
     result = mesmer.grid.stack_lat_lon(da)
 
     xr.testing.assert_identical(result, expected)
 
 
-@pytest.mark.parametrize("as_dataset", [True, False])
-def test_to_unstructured_multiindex(as_dataset):
-    da, expected = data_1D_coords(as_dataset)
+def test_to_unstructured_multiindex(datatype):
+    da, expected = data_1D_coords(datatype)
 
     result = mesmer.grid.stack_lat_lon(da, multiindex=True)
 
-    expected = expected.set_index({"gridcell": ("lat", "lon")})
+    # TODO: simplify once DataTree has set_index
+    if datatype == "DataTree":
+
+        expected = xr.DataTree.from_dict(
+            {"node": expected["node"].dataset.set_index({"gridcell": ("lat", "lon")})}
+        )
+
+    else:
+        expected = expected.set_index({"gridcell": ("lat", "lon")})
 
     xr.testing.assert_identical(result, expected)
 
@@ -102,10 +103,9 @@ def test_to_unstructured_multiindex(as_dataset):
 @pytest.mark.parametrize("x_dim", ["lon", "x"])
 @pytest.mark.parametrize("y_dim", ["lat", "y"])
 @pytest.mark.parametrize("cell_dim", ["cell", "gridpoint"])
-@pytest.mark.parametrize("as_dataset", [True, False])
-def test_to_unstructured(x_dim, y_dim, cell_dim, as_dataset):
+def test_to_unstructured(x_dim, y_dim, cell_dim, datatype):
     da, expected = data_1D_coords(
-        as_dataset, x_dim=x_dim, y_dim=y_dim, stack_dim=cell_dim
+        datatype, x_dim=x_dim, y_dim=y_dim, stack_dim=cell_dim
     )
 
     result = mesmer.grid.stack_lat_lon(da, x_dim=x_dim, y_dim=y_dim, stack_dim=cell_dim)
@@ -113,9 +113,8 @@ def test_to_unstructured(x_dim, y_dim, cell_dim, as_dataset):
     xr.testing.assert_identical(result, expected)
 
 
-@pytest.mark.parametrize("as_dataset", [True, False])
-def test_to_unstructured_2D_coords(as_dataset):
-    da, expected = data_2D_coords(as_dataset)
+def test_to_unstructured_2D_coords(datatype):
+    da, expected = data_2D_coords(datatype)
 
     result = mesmer.grid.stack_lat_lon(da, x_dim="x", y_dim="y")
 
@@ -128,10 +127,10 @@ def test_to_unstructured_2D_coords(as_dataset):
 def test_to_unstructured_dropna(dropna, coords, time_pos):
 
     if coords == "1D":
-        da, expected = data_1D_coords(as_dataset=False)
+        da, expected = data_1D_coords("DataArray")
         kwargs = {}
     else:
-        da, expected = data_2D_coords(as_dataset=False)
+        da, expected = data_2D_coords("DataArray")
         kwargs = {"x_dim": "x", "y_dim": "y"}
 
     da[slice(time_pos), 0, 0] = np.nan
@@ -151,10 +150,10 @@ def test_to_unstructured_dropna(dropna, coords, time_pos):
 def test_unstructured_roundtrip_dropna_row(coords):
 
     if coords == "1D":
-        da_structured, __ = data_1D_coords(as_dataset=False)
+        da_structured, __ = data_1D_coords("DataArray")
         kwargs = {"x_dim": "lon", "y_dim": "lat"}
     else:
-        da_structured, __ = data_2D_coords(as_dataset=False)
+        da_structured, __ = data_2D_coords("DataArray")
         kwargs = {"x_dim": "x", "y_dim": "y"}
 
     coords_orig = da_structured.coords.to_dataset()[list(kwargs.values())]
@@ -174,11 +173,18 @@ def test_unstructured_roundtrip_dropna_row(coords):
     xr.testing.assert_identical(result, expected)
 
 
-@pytest.mark.parametrize("as_dataset", [True, False])
-def test_from_unstructured_defaults(as_dataset):
-    expected, da = data_1D_coords(as_dataset)
+def _get_coords(data, datatype, x_dim, y_dim):
 
-    coords_orig = expected.coords.to_dataset()[["lon", "lat"]]
+    if datatype == "DataTree":
+        data = data["node"]
+
+    return data.coords.to_dataset()[[x_dim, y_dim]]
+
+
+def test_from_unstructured_defaults(datatype):
+    expected, da = data_1D_coords(datatype)
+
+    coords_orig = _get_coords(expected, datatype, "lon", "lat")
 
     result = mesmer.grid.unstack_lat_lon_and_align(da, coords_orig)
 
@@ -188,13 +194,12 @@ def test_from_unstructured_defaults(as_dataset):
 @pytest.mark.parametrize("x_dim", ["lon", "x"])
 @pytest.mark.parametrize("y_dim", ["lat", "y"])
 @pytest.mark.parametrize("stack_dim", ["cell", "gridpoint"])
-@pytest.mark.parametrize("as_dataset", [True, False])
-def test_from_unstructured(x_dim, y_dim, stack_dim, as_dataset):
+def test_from_unstructured(x_dim, y_dim, stack_dim, datatype):
     expected, da = data_1D_coords(
-        as_dataset, x_dim=x_dim, y_dim=y_dim, stack_dim=stack_dim
+        datatype, x_dim=x_dim, y_dim=y_dim, stack_dim=stack_dim
     )
 
-    coords_orig = expected.coords.to_dataset()[[x_dim, y_dim]]
+    coords_orig = _get_coords(expected, datatype, x_dim, y_dim)
     result = mesmer.grid.unstack_lat_lon_and_align(
         da, coords_orig, x_dim=x_dim, y_dim=y_dim, stack_dim=stack_dim
     )
@@ -202,12 +207,11 @@ def test_from_unstructured(x_dim, y_dim, stack_dim, as_dataset):
     xr.testing.assert_identical(result, expected)
 
 
-@pytest.mark.parametrize("as_dataset", [True, False])
-def test_unstructured_roundtrip_1D_coords(as_dataset):
+def test_unstructured_roundtrip_1D_coords(datatype):
 
-    da_structured, da_unstructured = data_1D_coords(as_dataset)
+    da_structured, da_unstructured = data_1D_coords(datatype)
 
-    coords_orig = da_structured.coords.to_dataset()[["lon", "lat"]]
+    coords_orig = _get_coords(da_structured, datatype, "lon", "lat")
 
     result = mesmer.grid.unstack_lat_lon_and_align(
         mesmer.grid.stack_lat_lon(da_structured), coords_orig
@@ -220,14 +224,13 @@ def test_unstructured_roundtrip_1D_coords(as_dataset):
     xr.testing.assert_identical(result, da_unstructured)
 
 
-@pytest.mark.parametrize("as_dataset", [True, False])
-def test_unstructured_roundtrip_2D_coords(as_dataset):
+def test_unstructured_roundtrip_2D_coords(datatype):
 
-    da_structured, da_unstructured = data_2D_coords(as_dataset)
+    da_structured, da_unstructured = data_2D_coords(datatype)
 
     dims = {"x_dim": "x", "y_dim": "y"}
 
-    coords_orig = da_structured.coords.to_dataset()[["x", "y"]]
+    coords_orig = _get_coords(da_structured, datatype, "x", "y")
 
     result = mesmer.grid.stack_lat_lon(
         mesmer.grid.unstack_lat_lon_and_align(da_unstructured, coords_orig, **dims),

--- a/tests/unit/test_mask.py
+++ b/tests/unit/test_mask.py
@@ -5,7 +5,7 @@ import xarray as xr
 import mesmer
 
 
-def data_lon_lat(as_dataset, x_coords="lon", y_coords="lat"):
+def data_lon_lat(datatype, x_coords="lon", y_coords="lat"):
 
     lon = np.arange(0.5, 360, 2)
     lat = np.arange(90, -91, -2)
@@ -21,15 +21,17 @@ def data_lon_lat(as_dataset, x_coords="lon", y_coords="lat"):
 
     ds = xr.Dataset(data_vars={"data": da, "scalar": 1}, attrs={"key": "ds_attrs"})
 
-    if as_dataset:
+    if datatype == "Dataset":
         return ds
+    elif datatype == "DataTree":
+        return xr.DataTree.from_dict({"node": ds})
     return ds.data
 
 
 @pytest.mark.parametrize("threshold", ([0, 1], -0.1, 1.1))
 def test_ocean_land_fraction_errors(threshold):
 
-    data = data_lon_lat(as_dataset=True)
+    data = data_lon_lat("Dataset")
 
     with pytest.raises(
         ValueError, match="`threshold` must be a scalar between 0 and 1"
@@ -53,7 +55,7 @@ def test_ocean_land_fraction_irregular():
 
 def test_ocean_land_fraction_threshold():
     # check that the threshold has an influence
-    data = data_lon_lat(as_dataset=True)
+    data = data_lon_lat("Dataset")
 
     result_033 = mesmer.mask.mask_ocean_fraction(data, threshold=0.33)
     result_066 = mesmer.mask.mask_ocean_fraction(data, threshold=0.66)
@@ -61,18 +63,29 @@ def test_ocean_land_fraction_threshold():
     assert not (result_033.data == result_066.data).all()
 
 
-def _test_mask(func, as_dataset, threshold=None, **kwargs):
+def _test_mask(func, datatype, threshold=None, **kwargs):
     # not checking the actual mask
 
-    data = data_lon_lat(as_dataset=as_dataset, **kwargs)
+    data = data_lon_lat(datatype, **kwargs)
+
+    print(data)
 
     kwargs = kwargs if threshold is None else {"threshold": threshold, **kwargs}
     result = func(data, **kwargs)
 
-    if as_dataset:
+    print(result)
+
+    if datatype == "DataTree":
+        assert isinstance(result, xr.DataTree)
+        result = result["node"].to_dataset()
+
+    if datatype in ("DataTree", "Dataset"):
         # ensure scalar is not broadcast
         assert result.scalar.ndim == 0
-        assert result.attrs == {"key": "ds_attrs"}
+
+        # TODO: enable again after https://github.com/pydata/xarray/pull/10219
+        if datatype != "DataTree":
+            assert result.attrs == {"key": "ds_attrs"}
 
         result_da = result.data
     else:
@@ -84,55 +97,45 @@ def _test_mask(func, as_dataset, threshold=None, **kwargs):
     assert result_da.attrs == {"key": "da_attrs"}
 
 
-@pytest.mark.parametrize("as_dataset", (True, False))
-def test_ocean_land_fraction_default(as_dataset):
+def test_ocean_land_fraction_default(datatype):
 
-    _test_mask(mesmer.mask.mask_ocean_fraction, as_dataset, threshold=0.5)
+    _test_mask(mesmer.mask.mask_ocean_fraction, datatype, threshold=0.5)
 
 
-@pytest.mark.parametrize("as_dataset", (True, False))
 @pytest.mark.parametrize("x_coords", ("x", "lon"))
 @pytest.mark.parametrize("y_coords", ("y", "lat"))
-def test_ocean_land_fraction(as_dataset, x_coords, y_coords):
+def test_ocean_land_fraction(datatype, x_coords, y_coords):
 
     _test_mask(
         mesmer.mask.mask_ocean_fraction,
-        as_dataset,
+        datatype,
         threshold=0.5,
         x_coords=x_coords,
         y_coords=y_coords,
     )
 
 
-@pytest.mark.parametrize("as_dataset", (True, False))
-def test_ocean_land_default(
-    as_dataset,
-):
+def test_ocean_land_default(datatype):
 
-    _test_mask(mesmer.mask.mask_ocean, as_dataset)
+    _test_mask(mesmer.mask.mask_ocean, datatype)
 
 
-@pytest.mark.parametrize("as_dataset", (True, False))
 @pytest.mark.parametrize("x_coords", ("x", "lon"))
 @pytest.mark.parametrize("y_coords", ("y", "lat"))
-def test_mask_land(as_dataset, x_coords, y_coords):
+def test_mask_land(datatype, x_coords, y_coords):
 
-    _test_mask(mesmer.mask.mask_ocean, as_dataset, x_coords=x_coords, y_coords=y_coords)
-
-
-@pytest.mark.parametrize("as_dataset", (True, False))
-def test_mask_antarctiva_default(
-    as_dataset,
-):
-
-    _test_mask(mesmer.mask.mask_antarctica, as_dataset)
+    _test_mask(mesmer.mask.mask_ocean, datatype, x_coords=x_coords, y_coords=y_coords)
 
 
-@pytest.mark.parametrize("as_dataset", (True, False))
+def test_mask_antarctiva_default(datatype):
+
+    _test_mask(mesmer.mask.mask_antarctica, datatype)
+
+
 @pytest.mark.parametrize("y_coords", ("y", "lat"))
-def test_mask_antarctiva(as_dataset, y_coords):
+def test_mask_antarctiva(datatype, y_coords):
 
-    _test_mask(mesmer.mask.mask_antarctica, as_dataset, y_coords=y_coords)
+    _test_mask(mesmer.mask.mask_antarctica, datatype, y_coords=y_coords)
 
 
 def test_mask_ocean_2D_grid():

--- a/tests/unit/test_mask.py
+++ b/tests/unit/test_mask.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+from packaging.version import Version
 
 import mesmer
 
@@ -81,8 +82,8 @@ def _test_mask(func, datatype, threshold=None, **kwargs):
         # ensure scalar is not broadcast
         assert result.scalar.ndim == 0
 
-        # TODO: enable again after https://github.com/pydata/xarray/pull/10219
-        if datatype != "DataTree":
+        # NOTE: DataTree attrs fixed in https://github.com/pydata/xarray/pull/10219
+        if datatype != "DataTree" or Version(xr.__version__) > Version("2025.3.1"):
             assert result.attrs == {"key": "ds_attrs"}
 
         result_da = result.data

--- a/tests/unit/test_mask.py
+++ b/tests/unit/test_mask.py
@@ -73,8 +73,6 @@ def _test_mask(func, datatype, threshold=None, **kwargs):
     kwargs = kwargs if threshold is None else {"threshold": threshold, **kwargs}
     result = func(data, **kwargs)
 
-    print(result)
-
     if datatype == "DataTree":
         assert isinstance(result, xr.DataTree)
         result = result["node"].to_dataset()

--- a/tests/unit/test_smoothing.py
+++ b/tests/unit/test_smoothing.py
@@ -191,3 +191,15 @@ def test_lowess_2D_combine_dim_it():
 
     xr.testing.assert_allclose(r1, r2)
     xr.testing.assert_allclose(r1, r3)
+
+
+def test_lowess_datatree():
+
+    ds = trend_data_1D().to_dataset()
+    dt = xr.DataTree.from_dict({"node": ds})
+
+    result = mesmer.stats.lowess(dt, "time", frac=0.33, it=1)
+    expected = mesmer.stats.lowess(ds, "time", frac=0.33, it=1)
+    expected = xr.DataTree.from_dict({"node": expected})
+
+    xr.testing.assert_equal(result, expected)

--- a/tests/unit/test_weighted.py
+++ b/tests/unit/test_weighted.py
@@ -109,9 +109,9 @@ def _test_weighted_mean(datatype, **kwargs):
         # ensure scalar is not broadcast
         assert result.scalar.ndim == 0
 
-    # NOTE: DataTree attrs fixed in https://github.com/pydata/xarray/pull/10219
-    if datatype != "DataTree" or Version(xr.__version__) > Version("2025.3.1"):
-        assert result.attrs == {"key": "ds_attrs"}
+        # NOTE: DataTree attrs fixed in https://github.com/pydata/xarray/pull/10219
+        if datatype != "DataTree" or Version(xr.__version__) > Version("2025.3.1"):
+            assert result.attrs == {"key": "ds_attrs"}
 
         result_da = result.data
     else:

--- a/tests/unit/test_weighted.py
+++ b/tests/unit/test_weighted.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+from packaging.version import Version
 
 import mesmer
 from mesmer.core._datatreecompat import map_over_datasets
@@ -108,8 +109,8 @@ def _test_weighted_mean(datatype, **kwargs):
         # ensure scalar is not broadcast
         assert result.scalar.ndim == 0
 
-        # TODO: enable again after https://github.com/pydata/xarray/pull/10219
-        # if datatype != "DataTree":
+    # NOTE: DataTree attrs fixed in https://github.com/pydata/xarray/pull/10219
+    if datatype != "DataTree" or Version(xr.__version__) > Version("2025.3.1"):
         assert result.attrs == {"key": "ds_attrs"}
 
         result_da = result.data

--- a/tests/unit/test_weighted.py
+++ b/tests/unit/test_weighted.py
@@ -3,9 +3,10 @@ import pytest
 import xarray as xr
 
 import mesmer
+from mesmer.core._datatreecompat import map_over_datasets
 
 
-def data_lon_lat(as_dataset, x_dim="lon", y_dim="lat"):
+def data_lon_lat(datatype, x_dim="lon", y_dim="lat"):
 
     lon = np.arange(0.5, 360, 2)
     lat = np.arange(90, -91, -2)
@@ -22,8 +23,10 @@ def data_lon_lat(as_dataset, x_dim="lon", y_dim="lat"):
 
     ds = xr.Dataset(data_vars={"data": da, "scalar": 1}, attrs={"key": "ds_attrs"})
 
-    if as_dataset:
+    if datatype == "Dataset":
         return ds
+    elif datatype == "DataTree":
+        return xr.DataTree.from_dict({"node": ds})
     return ds.data
 
 
@@ -141,35 +144,42 @@ def test_weighted_no_scalar_expand(as_dataset):
     xr.testing.assert_allclose(result, expected)
 
 
-@pytest.mark.parametrize("as_dataset", (True, False))
 @pytest.mark.parametrize("x_dim", ("x", "lon"))
 @pytest.mark.parametrize("y_dim", ("y", "lat"))
-def test_global_mean_no_weights_passed(as_dataset, x_dim, y_dim):
+def test_global_mean_no_weights_passed(datatype, x_dim, y_dim):
 
-    data = data_lon_lat(as_dataset, y_dim=y_dim, x_dim=x_dim)
+    data = data_lon_lat(datatype, y_dim=y_dim, x_dim=x_dim)
 
-    weights = mesmer.weighted.lat_weights(data[y_dim])
+    lat = data["node"].to_dataset()[y_dim] if datatype == "DataTree" else data[y_dim]
+
+    weights = mesmer.weighted.lat_weights(lat)
 
     result = mesmer.weighted.global_mean(data, x_dim=x_dim, y_dim=y_dim)
 
     dims = (x_dim, y_dim)
-    expected = mesmer.weighted.weighted_mean(data, weights=weights, dims=dims)
+    if datatype == "DataTree":
+        expected = map_over_datasets(mesmer.weighted.weighted_mean, data, weights, dims)
+    else:
+        expected = mesmer.weighted.weighted_mean(data, weights=weights, dims=dims)
 
     xr.testing.assert_equal(result, expected)
 
 
-@pytest.mark.parametrize("as_dataset", (True, False))
-def test_global_mean_weights_passed(as_dataset):
+def test_global_mean_weights_passed(datatype):
 
-    data = data_lon_lat(as_dataset)
+    data = data_lon_lat(datatype)
 
-    weights = xr.ones_like(data["lat"])
+    lat = (data["node"].to_dataset() if datatype == "DataTree" else data)["lat"]
+    weights = xr.ones_like(lat)
 
     result = mesmer.weighted.global_mean(data, weights=weights)
 
     expected = data.mean(("lat", "lon"))
 
-    xr.testing.assert_allclose(result, expected)
+    if datatype == "DataTree":
+        map_over_datasets(xr.testing.assert_allclose, result, expected)
+    else:
+        xr.testing.assert_allclose(result, expected)
 
 
 def test_equal_scenario_weights_from_datatree():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #632
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Make many functions work with `xr.DataTree`. This will make #521 and #572 a bit simpler. Pretty cool because it's quite trivial. I still need to go over the statistical functions. Unfortunately this does not work for the auto regression functions because the `DataTree` argument (`seed`) is passed as a keyword-only - should we re-order them?

Oh yes, will be annoying to write the tests because it's so many functions. Will probably do minimal test only. The typing will come later (see #639).


https://github.com/MESMER-group/mesmer/blob/19a03beba5d3a45895834f943b9c2d58cfd498dd/mesmer/stats/_auto_regression.py#L377
