### PR TITLE
fix typing for mypy

### DIFF
--- a/mesmer/core/datatree.py
+++ b/mesmer/core/datatree.py
@@ -1,7 +1,9 @@
 import functools
-from typing import overload
+from collections.abc import Callable
+from typing import TypeVar, overload
 
 import xarray as xr
+from typing_extensions import ParamSpec
 
 from mesmer.core._datatreecompat import map_over_datasets
 
@@ -19,9 +21,9 @@ def _extract_single_dataarray_from_dt(
     ds = dt.to_dataset()
     var_name, *others = ds.keys()
     if others:
-        others = ", ".join(map(str, others))
+        o = ", ".join(map(str, others))
         raise ValueError(
-            f"Node must only contain one data variable, {name} has {others} and {var_name}."
+            f"Node must only contain one data variable, {name} has {o} and {var_name}."
         )
 
     da = ds[var_name]
@@ -199,24 +201,31 @@ def stack_datatrees_for_linear_regression(
     return predictors_stacked, target_stacked, weights_stacked
 
 
-def _datatree_wrapper(func):
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def _datatree_wrapper(func: Callable[P, T]) -> Callable[P, T]:
     """wrapper to extend functions so DataTree can be passed
 
     NOTE: DataTree arguments __must__ be passed as args (positional) and not as
     kwargs
+
+    see https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
+    for the typing
     """
 
     @functools.wraps(func)
-    def inner(*args, **kwargs):
+    def inner(*args: P.args, **kwargs: P.kwargs) -> T:
 
         # check to ensure there are no DataTree in kwargs. Altough this is not very
         # efficient, it has bitten me before.
         dt_kwargs = [key for key, val in kwargs.items() if isinstance(val, xr.DataTree)]
         if dt_kwargs:
-            dt_kwargs = "', '".join(dt_kwargs)
+            dt_kwargs_names = "', '".join(dt_kwargs)
             msg = (
                 "Passed a `DataTree` as keyword argument which is not allowed."
-                f" Passed `DataTree` kwargs: '{dt_kwargs}'"
+                f" Passed `DataTree` kwargs: '{dt_kwargs_names}'"
             )
             raise TypeError(msg)
 

--- a/mesmer/core/datatree.py
+++ b/mesmer/core/datatree.py
@@ -1,11 +1,13 @@
 import functools
 from collections.abc import Callable
-from typing import TypeVar, overload
+from typing import ParamSpec, TypeVar, overload
 
 import xarray as xr
-from typing_extensions import ParamSpec
 
 from mesmer.core._datatreecompat import map_over_datasets
+
+P = ParamSpec("P")
+T = TypeVar("T")
 
 
 def _extract_single_dataarray_from_dt(
@@ -199,10 +201,6 @@ def stack_datatrees_for_linear_regression(
         weights_stacked = None
 
     return predictors_stacked, target_stacked, weights_stacked
-
-
-P = ParamSpec("P")
-T = TypeVar("T")
 
 
 def _datatree_wrapper(func: Callable[P, T]) -> Callable[P, T]:

--- a/mesmer/core/grid.py
+++ b/mesmer/core/grid.py
@@ -2,6 +2,7 @@ import pandas as pd
 import xarray as xr
 
 from mesmer.core.datatree import _datatree_wrapper
+from mesmer.core.types import T_DataArraySetTree
 
 
 def _lon_to_180(lon):
@@ -27,9 +28,7 @@ def _lon_to_360(lon):
 
 
 @_datatree_wrapper
-def wrap_to_180(
-    obj: xr.Dataset | xr.DataArray, lon_name: str = "lon"
-) -> xr.Dataset | xr.DataArray:
+def wrap_to_180(obj: T_DataArraySetTree, lon_name: str = "lon") -> T_DataArraySetTree:
     """
     wrap array with longitude to [-180..180)
 
@@ -48,16 +47,14 @@ def wrap_to_180(
 
     new_lon = _lon_to_180(obj[lon_name])
 
-    obj = obj.assign_coords(**{lon_name: new_lon})  # type: ignore[arg-type] xarray doesn't type
+    obj = obj.assign_coords(coords={lon_name: new_lon})
     obj = obj.sortby(lon_name)
 
     return obj
 
 
 @_datatree_wrapper
-def wrap_to_360(
-    obj: xr.Dataset | xr.DataArray, lon_name: str = "lon"
-) -> xr.Dataset | xr.DataArray:
+def wrap_to_360(obj: T_DataArraySetTree, lon_name: str = "lon") -> T_DataArraySetTree:
     """
     wrap array with longitude to [0..360)
 
@@ -76,7 +73,7 @@ def wrap_to_360(
 
     new_lon = _lon_to_360(obj[lon_name])
 
-    obj = obj.assign_coords(**{lon_name: new_lon})  # type: ignore[arg-type]
+    obj = obj.assign_coords(coords={lon_name: new_lon})
     obj = obj.sortby(lon_name)
 
     return obj

--- a/mesmer/core/mask.py
+++ b/mesmer/core/mask.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 import mesmer
 from mesmer.core.datatree import _datatree_wrapper
+from mesmer.core.types import T_DataArraySetTree
 
 
 def _where_if_coords(obj, cond, coords):
@@ -23,7 +24,13 @@ def _where_if_coords(obj, cond, coords):
 
 
 @_datatree_wrapper
-def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
+def mask_ocean_fraction(
+    data: T_DataArraySetTree,
+    threshold: float,
+    *,
+    x_coords: str = "lon",
+    y_coords: str = "lat"
+) -> T_DataArraySetTree:
     """mask out ocean using fractional overlap
 
     Parameters
@@ -58,10 +65,10 @@ def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
     land_110 = regionmask.defined_regions.natural_earth_v5_0_0.land_110
 
     try:
-        mask_fraction = mesmer.core.regionmaskcompat._mask_3D_frac_approx(  # type: ignore[attr-defined]
+        mask_fraction = mesmer.core.regionmaskcompat._mask_3D_frac_approx(
             land_110, data[x_coords], data[y_coords]
         )
-    except mesmer.core.regionmaskcompat.InvalidCoordsError as e:  # type: ignore[attr-defined]
+    except mesmer.core.regionmaskcompat.InvalidCoordsError as e:
         raise ValueError(
             "Cannot calculate fractional mask for irregularly-spaced coords - use "
             "``mask_land`` instead."
@@ -77,7 +84,9 @@ def mask_ocean_fraction(data, threshold, *, x_coords="lon", y_coords="lat"):
 
 
 @_datatree_wrapper
-def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
+def mask_ocean(
+    data: T_DataArraySetTree, *, x_coords: str = "lon", y_coords: str = "lat"
+) -> T_DataArraySetTree:
     """mask out ocean
 
     Parameters
@@ -113,7 +122,9 @@ def mask_ocean(data, *, x_coords="lon", y_coords="lat"):
 
 
 @_datatree_wrapper
-def mask_antarctica(data, *, y_coords="lat"):
+def mask_antarctica(
+    data: T_DataArraySetTree, *, y_coords: str = "lat"
+) -> T_DataArraySetTree:
     """mask out ocean
 
     Parameters

--- a/mesmer/core/types.py
+++ b/mesmer/core/types.py
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+import xarray as xr
+
+T_DataArraySetTree = TypeVar(
+    "T_DataArraySetTree", xr.DataArray, xr.Dataset, xr.DataTree
+)

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -1,5 +1,6 @@
 import warnings
 from collections.abc import Callable, Iterable
+from typing import cast
 
 import numpy as np
 import xarray as xr
@@ -78,7 +79,7 @@ def _minimize_local_discrete(func: Callable, sequence: Iterable, **kwargs):
     return element
 
 
-def _to_set(arg):
+def _to_set(arg) -> set:
 
     if arg is None:
         arg = set()
@@ -191,8 +192,8 @@ def _check_dataset_form(
 
     missing_vars = required_vars - data_vars
     if missing_vars:
-        missing_vars = ",".join(missing_vars)
-        raise ValueError(f"{name} is missing the required data_vars: {missing_vars}")
+        missing = ",".join(missing_vars)
+        raise ValueError(f"{name} is missing the required data_vars: {missing}")
 
     n_vars_except = len(data_vars - (required_vars | optional_vars))
     if requires_other_vars and n_vars_except == 0:
@@ -235,11 +236,11 @@ def _check_dataarray_form(
     if not isinstance(obj, xr.DataArray):
         raise TypeError(f"Expected {name} to be an xr.DataArray, got {type(obj)}")
 
-    ndim = (ndim,) if np.isscalar(ndim) else ndim
+    ndim = cast(tuple[int], (ndim,) if np.isscalar(ndim) else ndim)
     if ndim is not None and obj.ndim not in ndim:
         *a, b = map(lambda x: f"{x}D", ndim)
-        ndim = (a and ", ".join(a) + " or " or "") + b
-        raise ValueError(f"{name} should be {ndim}, but is {obj.ndim}D")
+        ndim_options = (a and ", ".join(a) + " or " or "") + b
+        raise ValueError(f"{name} should be {ndim_options}, but is {obj.ndim}D")
 
     if required_dims - set(obj.dims):
         missing_dims = " ,".join(required_dims - set(obj.dims))

--- a/mesmer/core/volc.py
+++ b/mesmer/core/volc.py
@@ -9,7 +9,7 @@ from mesmer.stats import LinearRegression
 
 
 def _load_and_align_strat_aod_obs(
-    time: xr.DataArray, hist_period: slice[str, str], version="2022"
+    time: xr.DataArray, hist_period: slice, version="2022"
 ):
     """
     load stratospheric aerosol optical depth observations and align them to the to

--- a/mesmer/core/volc.py
+++ b/mesmer/core/volc.py
@@ -8,7 +8,9 @@ from mesmer.core.utils import _assert_annual_data, _check_dataarray_form
 from mesmer.stats import LinearRegression
 
 
-def _load_and_align_strat_aod_obs(time, hist_period, version="2022"):
+def _load_and_align_strat_aod_obs(
+    time: xr.DataArray, hist_period: slice[str, str], version="2022"
+):
     """
     load stratospheric aerosol optical depth observations and align them to the to
     calendar and time of `time`.
@@ -40,7 +42,7 @@ def _load_and_align_strat_aod_obs(time, hist_period, version="2022"):
     aod = aod.assign_coords({dim: time_hist})
 
     # expand aod to the full time period
-    __, aod = xr.align(time, aod, fill_value=0.0, join="outer")  # type: ignore[assignment]
+    __, aod = xr.align(time, aod, fill_value=0.0, join="outer")
 
     return aod
 

--- a/mesmer/core/weighted.py
+++ b/mesmer/core/weighted.py
@@ -167,10 +167,10 @@ def equal_scenario_weights_from_datatree(
         raise ValueError(f"DataTree must have a depth of 1, not {dt.depth}.")
 
     def _create_weights(ds: xr.Dataset) -> xr.Dataset:
-        dims = set(ds.dims)
-        if ens_dim not in dims:
+        ds_dims = set(ds.dims)
+        if ens_dim not in ds_dims:
             raise ValueError(f"Member dimension '{ens_dim}' not found in dataset.")
-        if time_dim not in dims:
+        if time_dim not in ds_dims:
             raise ValueError(f"Time dimension '{time_dim}' not found in dataset.")
 
         name, *others = ds.data_vars

--- a/mesmer/stats/_linear_regression.py
+++ b/mesmer/stats/_linear_regression.py
@@ -92,15 +92,14 @@ class LinearRegression:
 
         if required_predictors - available_predictors:
             missing = sorted(required_predictors - available_predictors)
-            missing = "', '".join(missing)
-            raise ValueError(f"Missing predictors: '{missing}'")
+            missing_preds = "', '".join(missing)
+            raise ValueError(f"Missing predictors: '{missing_preds}'")
 
         if available_predictors - required_predictors:
-            superfluous = map(str, available_predictors - required_predictors)
-            superfluous = sorted(superfluous)
-            superfluous = "', '".join(superfluous)
+            superfluous = sorted(map(str, available_predictors - required_predictors))
+            superfluous_preds = "', '".join(superfluous)
             raise ValueError(
-                f"Superfluous predictors: '{superfluous}', either params",
+                f"Superfluous predictors: '{superfluous_preds}', either params",
                 "for this predictor are missing or you forgot to add it to 'exclude'.",
             )
 
@@ -293,10 +292,10 @@ def _fit_linear_regression_xr(
             return ds.rename({var: "pred"})
 
         predictors = map_over_datasets(_rename_vars, predictors)
-        predictors_concat = collapse_datatree_into_dataset(
+        predictors_concat_ds = collapse_datatree_into_dataset(
             predictors, dim="predictor", join="exact", coords="minimal"  # type: ignore[arg-type]
         )
-        predictors_concat = predictors_concat["pred"]
+        predictors_concat = predictors_concat_ds["pred"]
 
     _check_dataarray_form(target, required_dims=dim, name="target")
 

--- a/mesmer/stats/_power_transformer.py
+++ b/mesmer/stats/_power_transformer.py
@@ -281,8 +281,8 @@ def fit_yeo_johnson_transform(
         res = res.assign_coords({"coeff": np.arange(len(res.coeff))})
         lambda_coeffs.append(res.rename("lambda_coeffs"))
 
-    month = xr.DataArray(np.arange(1, 13), dims="month")
-    return xr.concat(lambda_coeffs, dim=month)
+    month_dim = xr.DataArray(np.arange(1, 13), dims="month")
+    return xr.concat(lambda_coeffs, dim=month_dim)
 
 
 def yeo_johnson_transform(

--- a/mesmer/testing.py
+++ b/mesmer/testing.py
@@ -91,7 +91,7 @@ def trend_data_1D(n_timesteps=30, intercept=0.0, slope=1.0, scale=1.0):
 
 def trend_data_2D(
     n_timesteps=30, n_lat=3, n_lon=2, intercept=0.0, slope=1.0, scale=1.0
-):
+) -> xr.DataArray:
 
     n_cells = n_lat * n_lon
     time = np.arange(n_timesteps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ warn_unused_ignores = true
 ignore_missing_imports = true
 module = [
   "cftime.*",
+  "filefisher.*",
   "joblib.*",
   "pooch.*",
   "properscoring.*",

--- a/tests/integration/test_calibrate_mesmer_newcodepath.py
+++ b/tests/integration/test_calibrate_mesmer_newcodepath.py
@@ -78,7 +78,7 @@ def test_calibrate_mesmer(
     outname,
     test_data_root_dir,
     update_expected_files=False,
-):
+) -> None:
 
     # define config values
     THRESHOLD_LAND = 1 / 3
@@ -106,7 +106,7 @@ def test_calibrate_mesmer(
     )
 
     CMIP_FILEFINDER = FileFinder(
-        path_pattern=cmip_data_path / "{variable}/{time_res}/{resolution}",  # type: ignore
+        path_pattern=str(cmip_data_path / "{variable}/{time_res}/{resolution}"),
         file_pattern="{variable}_{time_res}_{model}_{scenario}_{member}_{resolution}.nc",
     )
 

--- a/tests/integration/test_draw_realisations_mesmer_newcodepath.py
+++ b/tests/integration/test_draw_realisations_mesmer_newcodepath.py
@@ -23,7 +23,7 @@ def create_forcing_data(test_data_root_dir, scenarios, use_hfds, use_tas2):
     )
 
     CMIP_FILEFINDER = FileFinder(
-        path_pattern=cmip_data_path / "{variable}/{time_res}/{resolution}",  # type: ignore
+        path_pattern=str(cmip_data_path / "{variable}/{time_res}/{resolution}"),
         file_pattern="{variable}_{time_res}_{model}_{scenario}_{member}_{resolution}.nc",
     )
 

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -735,7 +735,7 @@ def test_fit_autoregression_monthly_np_with_noise(slope, intercept, std):
     np.testing.assert_allclose(np.std(residuals), std, atol=1e-1)
 
 
-def test_fit_auto_regression_monthly():
+def test_fit_auto_regression_monthly() -> None:
     freq = "ME"
     n_years = 20
     n_gridcells = 10

--- a/tests/unit/test_auto_regression_scen_ens.py
+++ b/tests/unit/test_auto_regression_scen_ens.py
@@ -12,8 +12,9 @@ import mesmer.stats._auto_regression
 def generate_ar_samples(ar, std=1, n_timesteps=100, n_ens=4):
 
     np.random.seed(0)
-
-    data = ArmaProcess(ar, 1).generate_sample([n_timesteps, n_ens], scale=std)  # type: ignore[attr-defined] not typed in statsmodels
+    data = ArmaProcess(ar, 1).generate_sample(
+        [n_timesteps, n_ens], scale=std
+    )  # pyright: ignore[ reportArgumentType ]
 
     ens = np.arange(n_ens)
 
@@ -34,7 +35,7 @@ def _prepare_data(*dataarrays, data_format):
         data = {
             f"scen{i}": xr.Dataset({"tas": da}) for i, da in enumerate(dataarrays, 1)
         }
-        return xr.DataTree.from_dict(data)  # type: ignore[attr-defined] not typed in datatree
+        return xr.DataTree.from_dict(data)
     else:
         raise ValueError(f"Unknown format_type: {data_format}")
 
@@ -181,12 +182,12 @@ def test_fit_auto_regression_scen_ens_no_ens_dim(data_format):
     xr.testing.assert_allclose(result, expected)
 
 
-def test_fit_auto_regression_scen_ens_errors():
+def test_fit_auto_regression_scen_ens_errors() -> None:
     da = generate_ar_samples([1, 0.5, 0.3, 0.4], n_timesteps=100, n_ens=4)
 
     # data tree
     data = {"scen1": xr.Dataset({"tas": da})}
-    dt1 = xr.DataTree.from_dict(data)  # type: ignore[attr-defined] not typed in datatree
+    dt1 = xr.DataTree.from_dict(data)
     dt2 = dt1.copy()
 
     with pytest.raises(ValueError, match="Only one DataTree can be passed."):
@@ -195,7 +196,7 @@ def test_fit_auto_regression_scen_ens_errors():
         )
 
     data = {"scen1": xr.Dataset({"tas": da, "tas2": da})}
-    dt = xr.DataTree.from_dict(data)  # type: ignore[attr-defined]
+    dt = xr.DataTree.from_dict(data)
 
     with pytest.raises(ValueError, match="Dataset must have only one data variable."):
         mesmer.stats.fit_auto_regression_scen_ens(dt, dim="time", ens_dim="ens", lags=3)
@@ -204,12 +205,12 @@ def test_fit_auto_regression_scen_ens_errors():
     data = {"scen1": da, "scen2": da}
     with pytest.raises(ValueError, match="Only one dictionary can be passed."):
         mesmer.stats.fit_auto_regression_scen_ens(
-            data, data, dim="time", ens_dim="ens", lags=3
+            data, data, dim="time", ens_dim="ens", lags=3  # type: ignore[arg-type]
         )
 
     # wrong datatype
-    data = xr.Dataset({"tas": da})
+    dataset = xr.Dataset({"tas": da})
     with pytest.raises(ValueError, match="Expected either"):
         mesmer.stats.fit_auto_regression_scen_ens(
-            data, dim="time", ens_dim="ens", lags=3  # type: ignore[arg-type]
+            dataset, dim="time", ens_dim="ens", lags=3  # type: ignore[arg-type]
         )

--- a/tests/unit/test_computation.py
+++ b/tests/unit/test_computation.py
@@ -12,7 +12,7 @@ def test_gaspari_cohn_error():
     ds = xr.Dataset()
 
     with pytest.raises(TypeError, match="Dataset is not supported"):
-        gaspari_cohn(ds)  # type: ignore
+        gaspari_cohn(ds)
 
 
 def test_gaspari_cohn():
@@ -55,19 +55,19 @@ def test_gaspari_cohn_np():
     assert gaspari_cohn(values).shape == (3, 3)
 
 
-def test_calc_geodist_dataset_error():
+def test_calc_geodist_dataset_error() -> None:
 
     ds = xr.Dataset()
     da = xr.DataArray()
 
     with pytest.raises(TypeError, match="Dataset is not supported"):
-        geodist_exact(ds, ds)  # type: ignore
+        geodist_exact(ds, ds)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError, match="Dataset is not supported"):
-        geodist_exact(ds, da)  # type: ignore
+        geodist_exact(ds, da)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError, match="Dataset is not supported"):
-        geodist_exact(da, ds)  # type: ignore
+        geodist_exact(da, ds)  # type: ignore[arg-type]
 
 
 def test_calc_geodist_dataarray_equal_dims_required():

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -198,7 +198,7 @@ def test_fit_harmonic_model():
     xr.testing.assert_equal(expected, result.residuals)
 
 
-def test_fit_harmonic_model_checks():
+def test_fit_harmonic_model_checks() -> None:
     yearly_predictor = trend_data_2D(n_timesteps=10, n_lat=3, n_lon=2)
     monthly_target = trend_data_2D(n_timesteps=10 * 12, n_lat=3, n_lon=2)
 

--- a/tests/unit/test_smoothing.py
+++ b/tests/unit/test_smoothing.py
@@ -9,7 +9,7 @@ from mesmer.core.utils import _check_dataarray_form
 from mesmer.testing import trend_data_1D, trend_data_2D
 
 
-def test_lowess_errors():
+def test_lowess_errors() -> None:
     data = trend_data_2D()
 
     with pytest.raises(ValueError, match="Can only pass a single dimension."):

--- a/tests/unit/test_weighted.py
+++ b/tests/unit/test_weighted.py
@@ -1,3 +1,5 @@
+from typing import Literal, overload
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -7,7 +9,25 @@ import mesmer
 from mesmer.core._datatreecompat import map_over_datasets
 
 
-def data_lon_lat(datatype, x_dim="lon", y_dim="lat"):
+@overload
+def data_lon_lat(
+    datatype: Literal["DataArray"], x_dim="lon", y_dim="lat"
+) -> xr.DataArray: ...
+
+
+@overload
+def data_lon_lat(
+    datatype: Literal["Dataset"], x_dim="lon", y_dim="lat"
+) -> xr.Dataset: ...
+@overload
+def data_lon_lat(
+    datatype: Literal["DataTree"], x_dim="lon", y_dim="lat"
+) -> xr.DataTree: ...
+
+
+def data_lon_lat(
+    datatype: Literal["DataArray", "Dataset", "DataTree"], x_dim="lon", y_dim="lat"
+) -> xr.DataArray | xr.Dataset | xr.DataTree:
 
     lon = np.arange(0.5, 360, 2)
     lat = np.arange(90, -91, -2)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Fix typing such that `mypy .` passes. This does not make pyright/ pylance happy _at all_ (it makes it a bit worse `pyright .` goes from 207 errors to 224. Not that mypy passes everything - it only checks the functions that are typed (e.g. functions that do not have type annotations are not checked). In contrast pyright seem to check everything. I tried to fix some of the pyright errors but I only added more problems... (and 200 are somehow too much to sanely handle, I already spent too much time with this...). In addition I realized that my approach in #639 is wrong - I 'll comment there.
