### PR TITLE
volc: make `hist_period` optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ New Features
   By `Victoria Bauer`_.
 - Add python 3.13 to list of supported versions (`#547 <https://github.com/MESMER-group/mesmer/pull/547>`_).
   By `Mathias Hauser`_.
+- Passing ``hist_period`` to the volcaninc helper functions is no longer needed (\
+  `#649 <https://github.com/MESMER-group/mesmer/pull/649>`_). By `Mathias Hauser`_.
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/mesmer/core/volc.py
+++ b/mesmer/core/volc.py
@@ -40,9 +40,9 @@ def _load_and_align_strat_aod_obs(
         aod_beg, aod_end = aod.time[0].dt.year.item(), aod.time[-1].dt.year.item()
         if beg < aod_beg or end > aod_end:
             raise ValueError(
-                "Passed array exeeds time of stratospheric aerosol optical depth "
-                f"observations {beg}-{end} vs. {aod_beg}-{aod_end}. Do you need "
-                "to pass ``hist_period``?"
+                f"Time period of passed array ({beg}-{end}) exeeds time of stratospheric"
+                " aerosol optical depth observations ({aod_beg}-{aod_end}). Do you need"
+                " to pass ``hist_period``?"
             )
 
         hist_period = slice(str(beg), str(end))

--- a/mesmer/core/volc.py
+++ b/mesmer/core/volc.py
@@ -9,7 +9,7 @@ from mesmer.stats import LinearRegression
 
 
 def _load_and_align_strat_aod_obs(
-    time: xr.DataArray, hist_period: slice, version="2022"
+    time: xr.DataArray, hist_period: slice | None, version="2022"
 ):
     """
     load stratospheric aerosol optical depth observations and align them to the to
@@ -20,9 +20,9 @@ def _load_and_align_strat_aod_obs(
     time: xr.DataArray
         DataArray containing the time coords to align the aerosol optical depth
         observations to.
-    hist_period : slice
+    hist_period : slice | None
         Slice object indicating the years of the historical period. E.g.
-        ``slice("1850", "2014")``.
+        ``slice("1850", "2014")``. If None uses the entire period in ``time``.
     version : str, default: "2022"
         Which version of the dataset to load. Currently only "2022" is available
 
@@ -34,6 +34,19 @@ def _load_and_align_strat_aod_obs(
     """
 
     aod = load_stratospheric_aerosol_optical_depth_obs(version=version, resample=True)
+
+    if hist_period is None:
+        beg, end = time[0].dt.year.item(), time[-1].dt.year.item()
+        aod_beg, aod_end = aod.time[0].dt.year.item(), aod.time[-1].dt.year.item()
+        if beg < aod_beg or end > aod_end:
+            raise ValueError(
+                "Passed array exeeds time of stratospheric aerosol optical depth "
+                f"observations {beg}-{end} vs. {aod_beg}-{aod_end}. Do you need "
+                "to pass ``hist_period``?"
+            )
+
+        hist_period = slice(str(beg), str(end))
+
     aod = aod.sel(time=hist_period)
 
     # replace time axis of aod -> so they have the same calendar
@@ -47,7 +60,9 @@ def _load_and_align_strat_aod_obs(
     return aod
 
 
-def fit_volcanic_influence(tas_residuals, hist_period, *, dim="time", version="2022"):
+def fit_volcanic_influence(
+    tas_residuals, hist_period=None, *, dim="time", version="2022"
+):
     """
     estimate volcanic influence on temperature residuals using aerosol optical depth
     observations as proxy
@@ -57,9 +72,9 @@ def fit_volcanic_influence(tas_residuals, hist_period, *, dim="time", version="2
     tas_residuals : xr.DataArray
         DataArray containing global mean temperature residual to estimate the volcanic
         influence from.
-    hist_period : slice
+    hist_period : slice | None
         Slice object indicating the years of the historical period. E.g.
-        ``slice("1850", "2014")``.
+        ``slice("1850", "2014")``.  If None uses the entire time period of ``tas_residuals``.
     dim : str, default: "time"
         Dimension along which to estimate the volcanic influence.
     version : str, default: "2022"
@@ -156,7 +171,7 @@ def _predict_volcanic_contribution(time, hist_period, params, version="2022"):
 
 @_datatree_wrapper
 def superimpose_volcanic_influence(
-    tas_globmean_lowess, params, hist_period, *, dim="time", version="2022"
+    tas_globmean_lowess, params, hist_period=None, *, dim="time", version="2022"
 ):
     """
     superimpose volcanic influence on smooth temperature anomalies using aerosol optical
@@ -170,9 +185,10 @@ def superimpose_volcanic_influence(
     params : xr.Dataset
         Parameters of the linear regression fit, obtained from
         ``fit_volcanic_influence``.
-    hist_period : slice
+    hist_period : slice | None
         Slice object indicating the years of the historical period. E.g.
-        ``slice("1850", "2014")``.
+        ``slice("1850", "2014")``. If None uses the entire time period in
+        ``tas_globmean_lowess``.
     dim : str, default: "time"
         Dimension along which to estimate the volcanic influence.
     version : str, default: "2022"

--- a/tests/integration/test_calibrate_mesmer_newcodepath.py
+++ b/tests/integration/test_calibrate_mesmer_newcodepath.py
@@ -85,8 +85,6 @@ def test_calibrate_mesmer(
 
     REFERENCE_PERIOD = slice("1850", "1900")
 
-    HIST_PERIOD = slice("1850", "2014")
-
     LOCALISATION_RADII = range(1750, 2001, 250)
 
     esm = "IPSL-CM6A-LR"
@@ -208,15 +206,11 @@ def test_calibrate_mesmer(
         tas_globmean["historical"] - tas_globmean_smoothed["historical"]
     )
 
-    volcanic_params = mesmer.volc.fit_volcanic_influence(
-        hist_lowess_residuals.tas, hist_period=HIST_PERIOD, dim="time"
-    )
+    volcanic_params = mesmer.volc.fit_volcanic_influence(hist_lowess_residuals.tas)
 
     tas_globmean_smoothed["historical"] = mesmer.volc.superimpose_volcanic_influence(
         tas_globmean_smoothed["historical"],
         volcanic_params,
-        hist_period=HIST_PERIOD,
-        dim="time",
     )
 
     # train global variability module

--- a/tests/integration/test_volc.py
+++ b/tests/integration/test_volc.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import xarray as xr
 
@@ -76,7 +78,7 @@ def test_fit_volcanic_influence_self_longer():
     aod, _ = xr.align(aod, time, join="right", fill_value=0.0)
 
     with pytest.raises(
-        ValueError, match="Time period of passed array (1900-2039) exeeds"
+        ValueError, match=re.escape("Time period of passed array (1900-2039) exeeds")
     ):
         mesmer.volc.fit_volcanic_influence(-aod, None)
 
@@ -85,7 +87,7 @@ def test_fit_volcanic_influence_self_longer():
     aod, _ = xr.align(aod, time, join="right", fill_value=0.0)
 
     with pytest.raises(
-        ValueError, match="Time period of passed array (1800-2000) exeeds"
+        ValueError, match=re.escape("Time period of passed array (1800-1999) exeeds")
     ):
         mesmer.volc.fit_volcanic_influence(-aod, None)
 
@@ -177,7 +179,7 @@ def test_superimpose_volcanic_influence_loner_errors():
     data, _ = xr.align(data, time, join="right", fill_value=0.0)
 
     with pytest.raises(
-        ValueError, match="Time period of passed array (1900-2039) exeeds"
+        ValueError, match=re.escape("Time period of passed array (1900-2039) exeeds")
     ):
         mesmer.volc.superimpose_volcanic_influence(data, params)
 
@@ -186,7 +188,7 @@ def test_superimpose_volcanic_influence_loner_errors():
     data, _ = xr.align(data, time, join="right", fill_value=0.0)
 
     with pytest.raises(
-        ValueError, match="Time period of passed array (1800-2000) exeeds"
+        ValueError, match=re.escape("Time period of passed array (1800-1999) exeeds")
     ):
         mesmer.volc.superimpose_volcanic_influence(data, params)
 

--- a/tests/integration/test_volc.py
+++ b/tests/integration/test_volc.py
@@ -75,14 +75,18 @@ def test_fit_volcanic_influence_self_longer():
     time = xr.Dataset(coords={"time": xr.date_range("1900", "2040", freq="YE")})
     aod, _ = xr.align(aod, time, join="right", fill_value=0.0)
 
-    with pytest.raises(ValueError, match="Passed array exeeds time of stratospheric"):
+    with pytest.raises(
+        ValueError, match="Time period of passed array (1900-2039) exeeds"
+    ):
         mesmer.volc.fit_volcanic_influence(-aod, None)
 
     # starts before
     time = xr.Dataset(coords={"time": xr.date_range("1800", "2000", freq="YE")})
     aod, _ = xr.align(aod, time, join="right", fill_value=0.0)
 
-    with pytest.raises(ValueError, match="Passed array exeeds time of stratospheric"):
+    with pytest.raises(
+        ValueError, match="Time period of passed array (1800-2000) exeeds"
+    ):
         mesmer.volc.fit_volcanic_influence(-aod, None)
 
 
@@ -172,14 +176,18 @@ def test_superimpose_volcanic_influence_loner_errors():
     time = xr.Dataset(coords={"time": xr.date_range("1900", "2040", freq="YE")})
     data, _ = xr.align(data, time, join="right", fill_value=0.0)
 
-    with pytest.raises(ValueError, match="Passed array exeeds time of stratospheric"):
+    with pytest.raises(
+        ValueError, match="Time period of passed array (1900-2039) exeeds"
+    ):
         mesmer.volc.superimpose_volcanic_influence(data, params)
 
     # starts before
     time = xr.Dataset(coords={"time": xr.date_range("1800", "2000", freq="YE")})
     data, _ = xr.align(data, time, join="right", fill_value=0.0)
 
-    with pytest.raises(ValueError, match="Passed array exeeds time of stratospheric"):
+    with pytest.raises(
+        ValueError, match="Time period of passed array (1800-2000) exeeds"
+    ):
         mesmer.volc.superimpose_volcanic_influence(data, params)
 
 

--- a/tests/integration/test_volc.py
+++ b/tests/integration/test_volc.py
@@ -19,31 +19,71 @@ def _get_volcanic_params(slope):
 
 def test_fit_volcanic_influence_errors():
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Expected tas_residuals to be an xr.DataArray"):
         mesmer.volc.fit_volcanic_influence(xr.Dataset(), slice("1850", "2014"))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="tas_residuals should be 1D or 2D, but is 0D"):
         mesmer.volc.fit_volcanic_influence(xr.DataArray(), slice("1850", "2014"))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="tas_residuals should be 1D or 2D, but is 3D"):
         data = mesmer.testing.trend_data_3D()
         mesmer.volc.fit_volcanic_influence(data, slice("1850", "2014"))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="tas_residuals is missing the required dims: sample"
+    ):
         data = mesmer.testing.trend_data_1D()
         mesmer.volc.fit_volcanic_influence(data, slice("1850", "2014"), dim="sample")
 
 
-def test_fit_volcanic_influence_self():
+@pytest.mark.parametrize(
+    "hist_period", (None, slice("1850", "2014"), slice("1900", "2000"))
+)
+def test_fit_volcanic_influence_self(hist_period):
 
     aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
-    result = mesmer.volc.fit_volcanic_influence(-aod, slice("1850", "2014"))
+    result = mesmer.volc.fit_volcanic_influence(-aod, hist_period)
     expected = _get_volcanic_params(-1.0)
 
     xr.testing.assert_allclose(result, expected)
+
+
+def test_fit_volcanic_influence_self_shorter():
+    # test it works when passing data shorter than aod obs
+    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+        version="2022", resample=True
+    )
+
+    result = mesmer.volc.fit_volcanic_influence(
+        -aod.sel(time=slice("1900", "2000")), None
+    )
+    expected = _get_volcanic_params(-1.0)
+
+    xr.testing.assert_allclose(result, expected)
+
+
+def test_fit_volcanic_influence_self_longer():
+    # test it works when passing data longer than aod obs
+    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+        version="2022", resample=True
+    )
+
+    # ends later
+    time = xr.Dataset(coords={"time": xr.date_range("1900", "2040", freq="YE")})
+    aod, _ = xr.align(aod, time, join="right", fill_value=0.0)
+
+    with pytest.raises(ValueError, match="Passed array exeeds time of stratospheric"):
+        mesmer.volc.fit_volcanic_influence(-aod, None)
+
+    # starts before
+    time = xr.Dataset(coords={"time": xr.date_range("1800", "2000", freq="YE")})
+    aod, _ = xr.align(aod, time, join="right", fill_value=0.0)
+
+    with pytest.raises(ValueError, match="Passed array exeeds time of stratospheric"):
+        mesmer.volc.fit_volcanic_influence(-aod, None)
 
 
 def test_fit_volcanic_warns_positive():
@@ -67,9 +107,9 @@ def test_fit_volcanic_influence_2D():
         version="2022", resample=True
     )
 
-    aod = xr.concat([aod, -aod], dim="ens")
+    aod_ens = xr.concat([aod, -aod], dim="ens")
 
-    result = mesmer.volc.fit_volcanic_influence(-aod, slice("1850", "2014"))
+    result = mesmer.volc.fit_volcanic_influence(-aod_ens, slice("1850", "2014"))
     expected = _get_volcanic_params(0)
 
     xr.testing.assert_allclose(result, expected)
@@ -100,7 +140,8 @@ def test_fit_volcanic_influence_hist_period():
 
 
 @pytest.mark.parametrize("slope", [0, -1, -2])
-def test_superimpose_volcanic_influence(slope):
+@pytest.mark.parametrize("hist_period", (None, slice("1850", "2014")))
+def test_superimpose_volcanic_influence(slope, hist_period):
 
     aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
@@ -110,13 +151,36 @@ def test_superimpose_volcanic_influence(slope):
 
     params = _get_volcanic_params(slope)
 
-    result = mesmer.volc.superimpose_volcanic_influence(
-        data, params, slice("1850", "2014")
-    )
+    result = mesmer.volc.superimpose_volcanic_influence(data, params, hist_period)
 
     expected = slope * aod
 
     xr.testing.assert_allclose(result, expected)
+
+
+def test_superimpose_volcanic_influence_loner_errors():
+
+    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+        version="2022", resample=True
+    )
+
+    data = xr.zeros_like(aod)
+
+    params = _get_volcanic_params(1)
+
+    # ends later
+    time = xr.Dataset(coords={"time": xr.date_range("1900", "2040", freq="YE")})
+    data, _ = xr.align(data, time, join="right", fill_value=0.0)
+
+    with pytest.raises(ValueError, match="Passed array exeeds time of stratospheric"):
+        mesmer.volc.superimpose_volcanic_influence(data, params)
+
+    # starts before
+    time = xr.Dataset(coords={"time": xr.date_range("1800", "2000", freq="YE")})
+    data, _ = xr.align(data, time, join="right", fill_value=0.0)
+
+    with pytest.raises(ValueError, match="Passed array exeeds time of stratospheric"):
+        mesmer.volc.superimpose_volcanic_influence(data, params)
 
 
 def test_superimpose_volcanic_influence_hist_period():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #648
 - [x] Tests added
 - [x] Fully documented, including `CHANGELOG.rst`


Make `hist_period` optional in `fit_volcanic_influence` and `superimpose_volcanic_influence`. I decided that this closes #648 (even though the argument is not entirely removed but I am not sure it's possible to do so.)