### PR TITLE
RTD: sphinx fail on warning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,3 +14,4 @@ build:
     python: "3.12"
 sphinx:
   configuration: docs/source/conf.py
+  fail_on_warning: true

--- a/docs/source/api_legacy.rst
+++ b/docs/source/api_legacy.rst
@@ -101,6 +101,8 @@ Load observations
 .. autosummary::
    :toctree: generated/
 
+   ~io.load_obs.load_obs
+   ~io.load_obs.load_obs_tblend
    ~io.load_obs.load_strat_aod
 
 Save mesmer bundle

--- a/docs/source/api_legacy.rst
+++ b/docs/source/api_legacy.rst
@@ -101,8 +101,6 @@ Load observations
 .. autosummary::
    :toctree: generated/
 
-   ~io.load_obs.load_obs
-   ~io.load_obs.load_obs_tblend
    ~io.load_obs.load_strat_aod
 
 Save mesmer bundle


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

In #658 I forgot to remove the functions from the API docs - this went unnoticed as sphinx does not error on on warnings.
