### PR TITLE
add authors and license to docs

### DIFF
--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -1,0 +1,2 @@
+.. include:: ../../AUTHORS
+   :parser: myst_parser.sphinx_

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ version = ".".join(release.split(".")[:2])
 
 # add sphinx extension modules
 extensions = [
+    "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,8 @@
 .. toctree::
    :maxdepth: 2
    :hidden:
-   :caption: Versions
+   :caption: Additional info
 
    changelog
+   authors
+   license

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,5 +1,5 @@
-MESMER license
-==============
+License
+=======
 
 MESMER is licensed under `GNU General Public License v3.0 or later <https://www.gnu.org/licenses/gpl-3.0.html>`__ (GPL-3.0-or-later).
 

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,0 +1,4 @@
+MESMER license
+==============
+
+.. literalinclude:: ../../LICENSE

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,4 +1,6 @@
 MESMER license
 ==============
 
+MESMER is licensed under `GNU General Public License v3.0 or later <https://www.gnu.org/licenses/gpl-3.0.html>`__ (GPL-3.0-or-later).
+
 .. literalinclude:: ../../LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ viz = [
 ]
 docs = [
     "ipython",
+    "myst-parser",
     "numpydoc",
     "sphinx",
     "sphinx-book-theme",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Adding _myst-parser_ as a dependency is overkill for adding the _AUTHORS_, however, this will also be used for #661 and potentially #521 (well this would require _myst\_nb_ but that depends on _myst-parser_).
