### PR TITLE
fix pytest fixture usage

### DIFF
--- a/tests/integration/test_calibrate_mesmer_m.py
+++ b/tests/integration/test_calibrate_mesmer_m.py
@@ -36,7 +36,7 @@ def _load_data(*filenames):
 
 
 @pytest.mark.slow
-def test_calibrate_mesmer_m(test_data_root_dir, update_expected_files=False):
+def test_calibrate_mesmer_m(test_data_root_dir, update_expected_files):
     # define config values
     THRESHOLD_LAND = 1 / 3
 

--- a/tests/integration/test_calibrate_mesmer_newcodepath.py
+++ b/tests/integration/test_calibrate_mesmer_newcodepath.py
@@ -77,7 +77,7 @@ def test_calibrate_mesmer(
     use_hfds,
     outname,
     test_data_root_dir,
-    update_expected_files=False,
+    update_expected_files,
 ) -> None:
 
     # define config values

--- a/tests/integration/test_draw_mesmer_m.py
+++ b/tests/integration/test_draw_mesmer_m.py
@@ -6,7 +6,7 @@ import xarray as xr
 import mesmer
 
 
-def test_make_emulations_mesmer_m(test_data_root_dir, update_expected_files=False):
+def test_make_emulations_mesmer_m(test_data_root_dir, update_expected_files):
 
     # define config values
     THRESHOLD_LAND = 1 / 3

--- a/tests/integration/test_draw_realisations_mesmer_newcodepath.py
+++ b/tests/integration/test_draw_realisations_mesmer_newcodepath.py
@@ -224,7 +224,7 @@ def test_make_realisations(
     n_realisations,
     outname,
     test_data_root_dir,
-    update_expected_files=False,
+    update_expected_files,
 ):
     esm = "IPSL-CM6A-LR"
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

`pytest.fixture` is not applied if there is a default value (cc @veni-vidi-vici-dormivi - I also just learned this)


```python
import pytest


@pytest.fixture
def param():
    return True


def test_1(param):  # works
    assert param


def test_2(param=False):  # fails
    assert param
```
