### PR TITLE
fix xarray cftime deprecations warnings

### DIFF
--- a/examples/example_mesmer_m.ipynb
+++ b/examples/example_mesmer_m.ipynb
@@ -84,11 +84,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)\n",
     "# yearly temperature\n",
     "tas_y = xr.open_mfdataset(\n",
     "    [fN_hist_ann, fN_proj_ann],\n",
     "    combine=\"by_coords\",\n",
-    "    use_cftime=True,\n",
+    "    decode_times=time_coder,\n",
     "    combine_attrs=\"override\",\n",
     "    data_vars=\"minimal\",\n",
     "    compat=\"override\",\n",
@@ -100,7 +101,7 @@
     "tas_m = xr.open_mfdataset(\n",
     "    [fN_hist_mon, fN_proj_mon],\n",
     "    combine=\"by_coords\",\n",
-    "    use_cftime=True,\n",
+    "    decode_times=time_coder,\n",
     "    combine_attrs=\"override\",\n",
     "    data_vars=\"minimal\",\n",
     "    compat=\"override\",\n",
@@ -273,7 +274,7 @@
     "\n",
     "\n",
     "```python\n",
-    "monthly_time = xr.cftime_range(\"1850-01-01\", \"2100-12-31\", freq=\"MS\", calendar=\"gregorian\")\n",
+    "monthly_time = xr.date_range(\"1850-01-01\", \"2100-12-31\", freq=\"MS\", calendar=\"gregorian\")\n",
     "monthly_time = xr.DataArray(monthly_time, dims=\"time\", coords={\"time\": monthly_time})\n",
     "```"
    ]

--- a/mesmer/io/_load_cmipng.py
+++ b/mesmer/io/_load_cmipng.py
@@ -355,7 +355,8 @@ def _load_cmipng_file(run_path, gen, scen):
     if gen == 5:
 
         # use_cftime because of employed calendar,
-        data = xr.open_dataset(run_path, use_cftime=True)
+        time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+        data = xr.open_dataset(run_path, decode_times=time_coder)
 
         # rename to time for consistency with cmip6
         data = data.rename({"year": "time"})

--- a/tests/integration/test_calibrate_mesmer_m.py
+++ b/tests/integration/test_calibrate_mesmer_m.py
@@ -21,7 +21,8 @@ def _load_data(*filenames):
     #     drop_variables=["height", "file_qf"],
     # ).load()
 
-    load_opt = {"drop_variables": ["height", "file_qf"], "use_cftime": True}
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+    load_opt = {"drop_variables": ["height", "file_qf"], "decode_times": time_coder}
     datasets = [xr.open_dataset(fN, **load_opt) for fN in filenames]
 
     ds = xr.combine_by_coords(
@@ -152,31 +153,32 @@ def test_calibrate_mesmer_m(test_data_root_dir, update_expected_files):
     # testing
     else:
         # load expected values
+        time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
         expected_hm_params = xr.open_dataset(
             TEST_PATH
             / "harmonic_model"
             / f"params_harmonic_model_tas_{esm}_{scenario}.nc",
-            use_cftime=True,
+            decode_times=time_coder,
         )
         expected_pt_params = xr.open_dataset(
             TEST_PATH
             / "power_transformer"
             / f"params_power_transformer_tas_{esm}_{scenario}.nc",
-            use_cftime=True,
+            decode_times=time_coder,
         )
         expected_AR1_params = xr.open_dataset(
             TEST_PATH / "local_variability" / f"params_AR1_tas_{esm}_{scenario}.nc",
-            use_cftime=True,
+            decode_times=time_coder,
         )
         expected_localized_ecov = xr.open_dataset(
             TEST_PATH
             / "local_variability"
             / f"params_localized_ecov_tas_{esm}_{scenario}.nc",
-            use_cftime=True,
+            decode_times=time_coder,
         )
         expected_m_time = xr.open_dataset(
             TEST_PATH / "time" / f"params_monthly_time_tas_{esm}_{scenario}.nc",
-            use_cftime=True,
+            decode_times=time_coder,
         )
 
         # the following parameters should be exactly the same

--- a/tests/integration/test_calibrate_mesmer_newcodepath.py
+++ b/tests/integration/test_calibrate_mesmer_newcodepath.py
@@ -137,7 +137,8 @@ def test_calibrate_mesmer(
         # load all members for a scenario
         members = []
         for fN, meta in files.items():
-            ds = xr.open_dataset(fN, use_cftime=True)
+            time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+            ds = xr.open_dataset(fN, decode_times=time_coder)
             # drop unnecessary variables
             ds = ds.drop_vars(["height", "time_bnds", "file_qf"], errors="ignore")
             # assign member-ID as coordinate
@@ -166,7 +167,8 @@ def test_calibrate_mesmer(
 
             members = []
             for fN, meta in files.items():
-                ds = xr.open_dataset(fN, use_cftime=True)
+                time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+                ds = xr.open_dataset(fN, decode_times=time_coder)
                 ds = ds.drop_vars(
                     ["height", "time_bnds", "file_qf", "area"], errors="ignore"
                 )
@@ -383,11 +385,14 @@ def assert_params_allclose(
     localized_ecov_file,
 ):
     # test params
-    exp_volcanic_params = xr.open_dataset(volcanic_file, use_cftime=True)
-    exp_global_ar_params = xr.open_dataset(global_ar_file, use_cftime=True)
-    exp_local_forced_params = xr.open_dataset(local_forced_file, use_cftime=True)
-    exp_local_ar_params = xr.open_dataset(local_ar_file, use_cftime=True)
-    exp_localized_ecov = xr.open_dataset(localized_ecov_file, use_cftime=True)
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+    exp_volcanic_params = xr.open_dataset(volcanic_file, decode_times=time_coder)
+    exp_global_ar_params = xr.open_dataset(global_ar_file, decode_times=time_coder)
+    exp_local_forced_params = xr.open_dataset(
+        local_forced_file, decode_times=time_coder
+    )
+    exp_local_ar_params = xr.open_dataset(local_ar_file, decode_times=time_coder)
+    exp_localized_ecov = xr.open_dataset(localized_ecov_file, decode_times=time_coder)
 
     xr.testing.assert_allclose(volcanic_params, exp_volcanic_params)
     xr.testing.assert_allclose(global_ar_params, exp_global_ar_params)

--- a/tests/integration/test_calibrate_mesmer_x.py
+++ b/tests/integration/test_calibrate_mesmer_x.py
@@ -68,10 +68,11 @@ def test_calibrate_mesmer_x(
     fN_hist = path_tas / f"tas_ann_{esm}_historical_r1i1p1f1_g025.nc"
     fN_ssp585 = path_tas / f"tas_ann_{esm}_{scenario}_r1i1p1f1_g025.nc"
 
-    tas_hist = xr.open_dataset(fN_hist, use_cftime=True).drop_vars(
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+    tas_hist = xr.open_dataset(fN_hist, decode_times=time_coder).drop_vars(
         ["height", "file_qf", "time_bnds"]
     )
-    tas_ssp585 = xr.open_dataset(fN_ssp585, use_cftime=True).drop_vars(
+    tas_ssp585 = xr.open_dataset(fN_ssp585, decode_times=time_coder).drop_vars(
         ["height", "file_qf", "time_bnds"]
     )
 
@@ -88,8 +89,9 @@ def test_calibrate_mesmer_x(
     fN_hist = path_target / f"{target_name}_ann_{esm}_historical_r1i1p1f1_g025.nc"
     fN_ssp585 = path_target / f"{target_name}_ann_{esm}_{scenario}_r1i1p1f1_g025.nc"
 
-    targ_hist = xr.open_dataset(fN_hist, use_cftime=True)
-    targ_ssp585 = xr.open_dataset(fN_ssp585, use_cftime=True)
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+    targ_hist = xr.open_dataset(fN_hist, decode_times=time_coder)
+    targ_ssp585 = xr.open_dataset(fN_ssp585, decode_times=time_coder)
 
     # target = DataTree({"hist": targ_hist, "ssp585": targ_ssp585})
 

--- a/tests/integration/test_draw_mesmer_m.py
+++ b/tests/integration/test_draw_mesmer_m.py
@@ -33,7 +33,7 @@ def test_make_emulations_mesmer_m(test_data_root_dir, update_expected_files):
     tas_y = xr.open_mfdataset(
         [fN_hist_ann, fN_proj_ann],
         combine="by_coords",
-        use_cftime=True,
+        decode_times=time_coder,
         combine_attrs="override",
         data_vars="minimal",
         compat="override",

--- a/tests/integration/test_draw_mesmer_m.py
+++ b/tests/integration/test_draw_mesmer_m.py
@@ -29,6 +29,7 @@ def test_make_emulations_mesmer_m(test_data_root_dir, update_expected_files):
     fN_hist_ann = path_tas_ann / f"tas_ann_{esm}_historical_r1i1p1f1_g025.nc"
     fN_proj_ann = path_tas_ann / f"tas_ann_{esm}_{scenario}_r1i1p1f1_g025.nc"
 
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
     tas_y = xr.open_mfdataset(
         [fN_hist_ann, fN_proj_ann],
         combine="by_coords",
@@ -46,27 +47,27 @@ def test_make_emulations_mesmer_m(test_data_root_dir, update_expected_files):
         PARAMS_PATH
         / "harmonic_model"
         / f"params_harmonic_model_tas_{esm}_{scenario}.nc",
-        use_cftime=True,
+        decode_times=time_coder,
     )
     pt_params = xr.open_dataset(
         PARAMS_PATH
         / "power_transformer"
         / f"params_power_transformer_tas_{esm}_{scenario}.nc",
-        use_cftime=True,
+        decode_times=time_coder,
     )
     AR1_params = xr.open_dataset(
         PARAMS_PATH / "local_variability" / f"params_AR1_tas_{esm}_{scenario}.nc",
-        use_cftime=True,
+        decode_times=time_coder,
     )
     localized_ecov = xr.open_dataset(
         PARAMS_PATH
         / "local_variability"
         / f"params_localized_ecov_tas_{esm}_{scenario}.nc",
-        use_cftime=True,
+        decode_times=time_coder,
     )
     m_time = xr.open_dataset(
         PARAMS_PATH / "time" / f"params_monthly_time_tas_{esm}_{scenario}.nc",
-        use_cftime=True,
+        decode_times=time_coder,
     )
 
     # preprocess yearly data
@@ -114,7 +115,8 @@ def test_make_emulations_mesmer_m(test_data_root_dir, update_expected_files):
 
     # testing
     else:
-        exp = xr.open_dataset(test_file, use_cftime=True)
+        time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+        exp = xr.open_dataset(test_file, decode_times=time_coder)
         xr.testing.assert_allclose(result, exp)
 
         # make sure we can get onto a lat lon grid from what is saved

--- a/tests/integration/test_draw_realisations_mesmer_newcodepath.py
+++ b/tests/integration/test_draw_realisations_mesmer_newcodepath.py
@@ -59,7 +59,8 @@ def create_forcing_data(test_data_root_dir, scenarios, use_hfds, use_tas2):
 
     def load_hist(meta, fc_hist):
         fN = _get_hist_path(meta, fc_hist)
-        return xr.open_dataset(fN, use_cftime=True)
+        time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+        return xr.open_dataset(fN, decode_times=time_coder)
 
     def load_hist_scen_continuous(fc_hist, fc_scens):
         dt = xr.DataTree()
@@ -75,7 +76,8 @@ def create_forcing_data(test_data_root_dir, scenarios, use_hfds, use_tas2):
                 except FileNotFoundError:
                     continue
 
-                proj = xr.open_dataset(fN, use_cftime=True)
+                time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+                proj = xr.open_dataset(fN, decode_times=time_coder)
 
                 ds = xr.combine_by_coords(
                     [hist, proj],

--- a/tests/integration/test_draw_realisations_mesmer_newcodepath.py
+++ b/tests/integration/test_draw_realisations_mesmer_newcodepath.py
@@ -365,7 +365,8 @@ def test_make_realisations(
         result.to_netcdf(expected_output_file)
         pytest.skip("Updated expected output file.")
     else:
-        expected = xr.open_datatree(expected_output_file, use_cftime=True)
+        time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+        expected = xr.open_datatree(expected_output_file, decode_times=time_coder)
         for scen in scenarios:
             exp_scen = expected[scen].to_dataset()
             res_scen = result[scen].to_dataset()

--- a/tests/integration/test_draw_realisations_mesmer_x.py
+++ b/tests/integration/test_draw_realisations_mesmer_x.py
@@ -48,11 +48,11 @@ def test_make_realisations_mesmer_x(
 
     fN_hist = path_tas / f"tas_ann_{esm}_historical_r1i1p1f1_g025.nc"
     fN_ssp585 = path_tas / f"tas_ann_{esm}_ssp585_r1i1p1f1_g025.nc"
-
-    tas_hist = xr.open_dataset(fN_hist, use_cftime=True).drop_vars(
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+    tas_hist = xr.open_dataset(fN_hist, decode_times=time_coder).drop_vars(
         ["height", "file_qf", "time_bnds"]
     )
-    tas_ssp585 = xr.open_dataset(fN_ssp585, use_cftime=True).drop_vars(
+    tas_ssp585 = xr.open_dataset(fN_ssp585, decode_times=time_coder).drop_vars(
         ["height", "file_qf", "time_bnds"]
     )
     # tas = DataTree({"hist": tas_hist, "ssp585": tas_ssp585})
@@ -123,7 +123,8 @@ def test_make_realisations_mesmer_x(
         pytest.skip(f"Updated {expected_output_file}")
     else:
         # load the output
-        expected_emus = xr.open_dataarray(expected_output_file, use_cftime=True)
+        time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+        expected_emus = xr.open_dataarray(expected_output_file, decode_times=time_coder)
         xr.testing.assert_allclose(emus, expected_emus)
 
         # make sure we can get onto a lat lon grid from what is saved

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -40,12 +40,16 @@ def test_generate_fourier_series_np():
 def test_predict_harmonic_model():
     n_years = 10
     n_lat, n_lon, n_gridcells = 2, 3, 2 * 3
-    time = xr.cftime_range(start="2000-01-01", periods=n_years, freq="YS")
+    time = xr.date_range(
+        start="2000-01-01", periods=n_years, freq="YS", use_cftime=True
+    )
     yearly_predictor = xr.DataArray(
         np.zeros((n_years, n_gridcells)), dims=["time", "cells"], coords={"time": time}
     )
 
-    time = xr.cftime_range(start="2000-01-01", periods=n_years * 12, freq="MS")
+    time = xr.date_range(
+        start="2000-01-01", periods=n_years * 12, freq="MS", use_cftime=True
+    )
     monthly_time = xr.DataArray(time, dims=["time"], coords={"time": time})
 
     coeffs = get_2D_coefficients(order_per_cell=[1, 2, 3], n_lat=n_lat, n_lon=n_lon)
@@ -141,11 +145,13 @@ def test_fit_harmonic_model():
         "time", "cells"
     )
 
-    yearly_predictor["time"] = xr.cftime_range(
-        start="2000-01-01", periods=n_ts, freq="YS"
+    yearly_predictor["time"] = xr.date_range(
+        start="2000-01-01", periods=n_ts, freq="YS", use_cftime=True
     )
 
-    time = xr.cftime_range(start="2000-01-01", periods=n_ts * 12, freq="MS")
+    time = xr.date_range(
+        start="2000-01-01", periods=n_ts * 12, freq="MS", use_cftime=True
+    )
     monthly_time = xr.DataArray(time, dims=["time"], coords={"time": time})
 
     monthly_target = predict_harmonic_model(

--- a/tests/unit/test_power_transformer.py
+++ b/tests/unit/test_power_transformer.py
@@ -199,7 +199,9 @@ def skewed_data_2D(n_timesteps=30, n_lat=3, n_lon=2):
     """
 
     n_cells = n_lat * n_lon
-    time = xr.cftime_range(start="2000-01-01", periods=n_timesteps, freq="MS")
+    time = xr.date_range(
+        start="2000-01-01", periods=n_timesteps, freq="MS", use_cftime=True
+    )
 
     ts_array = np.empty((n_cells, n_timesteps))
     rng = np.random.default_rng(0)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Not sure how big of a fan I am of these changes in xarray...

```diff
- data = xr.open_dataset(path, use_cftime=True)
+ time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+ data = xr.open_dataset(path, decode_times=time_coder)
```