### PR TITLE
extract `_assert_required_dims` from `_check_dataarray_form`

### DIFF
--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -258,9 +258,20 @@ def _check_dataarray_form(
         ndim_options = (a and ", ".join(a) + " or " or "") + b
         raise ValueError(f"{name} should be {ndim_options}, but is {obj.ndim}D")
 
-    if required_dims - set(obj.dims):
-        missing_dims = " ,".join(required_dims - set(obj.dims))
-        raise ValueError(f"{name} is missing the required dims: {missing_dims}")
+    _assert_required_dims(obj, name=name, required_dims=required_dims)
 
     if shape is not None and obj.shape != shape:
         raise ValueError(f"{name} has wrong shape - expected {shape}, got {obj.shape}")
+
+
+def _assert_required_dims(
+    obj, name: str = "obj", required_dims: str | Iterable[str] | None = None
+):
+
+    __tracebackhide__ = True
+
+    required_dims = _to_set(required_dims)
+
+    if required_dims - set(obj.dims):
+        missing_dims = " ,".join(required_dims - set(obj.dims))
+        raise ValueError(f"{name} is missing the required dims: {missing_dims}")

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -247,8 +247,6 @@ def _check_dataarray_form(
 
     __tracebackhide__ = True
 
-    required_dims = _to_set(required_dims)
-
     if not isinstance(obj, xr.DataArray):
         raise TypeError(f"Expected {name} to be an xr.DataArray, got {type(obj)}")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -268,6 +268,30 @@ def test_check_dataarray_form_required_dims(required_dims):
     mesmer.core.utils._check_dataarray_form(da, required_dims={"x", "y"})
 
 
+@pytest.mark.parametrize("required_dims", ("foo", ["foo"], ["foo", "bar"]))
+@pytest.mark.parametrize("to_dataset", (True, False))
+def test_assert_required_dims(required_dims, to_dataset):
+
+    obj = xr.DataArray(np.ones((2, 2)), dims=("x", "y"), name="data")
+
+    if to_dataset:
+        obj = obj.to_dataset()
+
+    with pytest.raises(ValueError, match="obj is missing the required dims"):
+        mesmer.core.utils._assert_required_dims(obj, required_dims=required_dims)
+
+    with pytest.raises(ValueError, match="test is missing the required dims"):
+        mesmer.core.utils._assert_required_dims(
+            obj, required_dims=required_dims, name="test"
+        )
+
+    # no error
+    mesmer.core.utils._assert_required_dims(obj, required_dims="x")
+    mesmer.core.utils._assert_required_dims(obj, required_dims="y")
+    mesmer.core.utils._assert_required_dims(obj, required_dims=["x", "y"])
+    mesmer.core.utils._assert_required_dims(obj, required_dims={"x", "y"})
+
+
 def test_check_dataarray_form_shape():
 
     da = xr.DataArray(np.ones((2, 2)), dims=("x", "y"))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Extract the `_assert_required_dims` part from `_check_dataarray_form`. This is can also be relevant for `Dataset`.

1. Maybe we should actually check the `coords` and not the `dims`, as there can be `dims` without `coords` (but I don't know if _non-dimension-coords_ are a problem, so I don't have the nerve to go into this right now).
1. `_check_dataarray_form` should maybe also be renamed to `_assert_dataarray_form`.
2. (`__tracebackhide__` is a pytest thingy)
