### PR TITLE
enable DataTree for `upsample_yearly_data`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -102,9 +102,10 @@ This was originally done with the prototype `xarray-datatree` package. After the
 - Add utility functions for :py:class:`DataTree` (`#556 <https://github.com/MESMER-group/mesmer/pull/556>`_).
 - Add a wrapper to allow :py:class:`DataTree` in many data handling functions (\
   `#632 <https://github.com/MESMER-group/mesmer/issues/632>`_,
-  `#643 <https://github.com/MESMER-group/mesmer/pull/643>`_
-  `#641 <https://github.com/MESMER-group/mesmer/pull/641>`_, , and
-  `#644 <https://github.com/MESMER-group/mesmer/pull/644>`_).
+  `#643 <https://github.com/MESMER-group/mesmer/pull/643>`_,
+  `#641 <https://github.com/MESMER-group/mesmer/pull/641>`_,
+  `#644 <https://github.com/MESMER-group/mesmer/pull/644>`_, and
+  `#682 <https://github.com/MESMER-group/mesmer/pull/682>`_).
 - Add calibration integration tests for multiple scenarios and change parameter files to netcdfs with new naming structure (`#537 <https://github.com/MESMER-group/mesmer/pull/537>`_)
 - Add new integration tests for drawing realisations (`#599 <https://github.com/MESMER-group/mesmer/pull/599>`_)
 - PRs related to xarray and xarray-datatree:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,7 +15,9 @@ def make_dummy_yearly_data(freq, calendar="standard"):
     else:
         time = xr.date_range(start="2000", periods=5, freq=freq, calendar=calendar)
 
-    data = xr.DataArray([1.0, 2.0, 3.0, 4.0, 5.0], dims=("time"), coords={"time": time})
+    data = xr.DataArray(
+        [1.0, 2.0, 3.0, 4.0, 5.0], dims=("time"), coords={"time": time}, name="data"
+    )
     return data
 
 
@@ -31,7 +33,9 @@ def make_dummy_monthly_data(freq, calendar="standard"):
     else:
         time = xr.date_range(start=start, periods=periods, freq=freq, calendar=calendar)
 
-    data = xr.DataArray(np.arange(periods), dims=("time"), coords={"time": time})
+    data = xr.DataArray(
+        np.arange(periods), dims=("time"), coords={"time": time}, name="data"
+    )
     return data
 
 
@@ -54,6 +58,40 @@ def test_upsample_yearly_data(freq_y, freq_m, calendar):
     assert (upsampled_years.groupby("time.year") == yearly_data).all()
 
 
+def test_upsample_yearly_data_dataset():
+
+    yearly_data = make_dummy_yearly_data(freq="YM")
+    monthly_data = make_dummy_monthly_data(freq="MS")
+
+    yearly_data = yearly_data.to_dataset()
+
+    upsampled_years = mesmer.core.utils.upsample_yearly_data(
+        yearly_data, monthly_data.time
+    )
+    xr.testing.assert_equal(upsampled_years.time, monthly_data.time)
+    assert isinstance(upsampled_years, xr.Dataset)
+
+
+def test_upsample_yearly_data_datatree():
+
+    yearly_data = make_dummy_yearly_data(freq="YM")
+    monthly_data = make_dummy_monthly_data(freq="MS")
+
+    # only yearly_data is a DataTree
+    yearly_data = xr.DataTree.from_dict({"scen": yearly_data.to_dataset()})
+
+    upsampled_years = mesmer.core.utils.upsample_yearly_data(yearly_data, monthly_data)
+    xr.testing.assert_equal(upsampled_years["scen"].time, monthly_data.time)
+    assert isinstance(upsampled_years, xr.DataTree)
+
+    # yearly_ data and monthly_data is a DataTree
+    monthly_data = xr.DataTree.from_dict({"scen": monthly_data.to_dataset()})
+
+    upsampled_years = mesmer.core.utils.upsample_yearly_data(yearly_data, monthly_data)
+    xr.testing.assert_equal(upsampled_years["scen"].time, monthly_data["scen"].time)
+    assert isinstance(upsampled_years, xr.DataTree)
+
+
 def test_upsample_yearly_data_wrong_dims():
     yearly_data = make_dummy_yearly_data("YS")
     yearly_data = yearly_data.rename({"time": "year"})
@@ -69,6 +107,8 @@ def test_upsample_yearly_data_wrong_dims():
 
     monthly_data = make_dummy_monthly_data("MM")
     monthly_data = monthly_data.expand_dims({"extra": 1})
+    time = monthly_data["time"].expand_dims({"extra": 1})
+    monthly_data = monthly_data.assign_coords(time=time)
     with pytest.raises(ValueError, match="monthly_time should be 1D, but is 2D"):
         mesmer.core.utils.upsample_yearly_data(yearly_data, monthly_data)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] towards #678
 - [x] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Enable `Dataset` and` `DataTree` in `upsample_yearly_data`. Maybe it would be better to enable it for the stacked data, because that is potentially more transparent what we do with respect to #678 (stack monthly data and then pass it...). Well let's start here and maybe do this later?