### PR TITLE
no no-guess-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ find = {namespaces = false}  # Disable implicit namespaces
 
 [tool.setuptools_scm]
 fallback_version = "999"
-version_scheme = "no-guess-dev"
+# version_scheme = "no-guess-dev"
 
 [tool.ruff]
 # also check notebooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ find = {namespaces = false}  # Disable implicit namespaces
 
 [tool.setuptools_scm]
 fallback_version = "999"
-# version_scheme = "no-guess-dev"
 
 [tool.ruff]
 # also check notebooks


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Use the default version scheme of _setuptools_scm_. So 

`'0.10.1.dev226+g51ea60a'` instead of `'0.10.0.post1.dev226+g51ea60a'` (compare the `.1` vs `.post1`) 

(the reason we cannot do `'0.10.0.dev226+g51ea60a'` is that this release would be assumed to be before `0.10.0`...)