### PR TITLE
bump dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,12 +37,12 @@ Breaking changes
   ================= ============= =========
   Package           Old           New
   ================= ============= =========
-  **cartopy**       not specified 0.22
-  **dask**          not specified 2024.3
+  **cartopy**       not specified 0.23
+  **dask**          not specified 2024.5
   **filefisher**    not required  1.1
-  **joblib**        not specified 1.3
+  **joblib**        not specified 1.4
   **netcdf4**       not specified 1.6
-  **numpy**         not specified 1.25
+  **numpy**         not specified 1.26
   **packaging**     not specified 24.0
   **pandas**        2.0           2.2
   **pooch**         not specified 1.8
@@ -50,7 +50,7 @@ Breaking changes
   **pyproj**        not specified 3.6
   **regionmask**    0.8           0.12
   **scikit-learn**  not specified 1.4
-  **scipy**         not specified 1.12
+  **scipy**         not specified 1.13
   **shapely**       not specified 2.0
   **statsmodels**   not specified 0.14
   **xarray**        2023.04       2025.03

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,9 +30,9 @@ Breaking changes
   `#405 <https://github.com/MESMER-group/mesmer/pull/405>`_,
   `#503 <https://github.com/MESMER-group/mesmer/pull/503>`_,
   `#621 <https://github.com/MESMER-group/mesmer/pull/621>`_,
-  `#627 <https://github.com/MESMER-group/mesmer/pull/627>`_, and
-  `#683 <https://github.com/MESMER-group/mesmer/pull/683>`_,
-  ):
+  `#627 <https://github.com/MESMER-group/mesmer/pull/627>`_,
+  `#683 <https://github.com/MESMER-group/mesmer/pull/683>`_, and
+  `#686 <https://github.com/MESMER-group/mesmer/pull/686>`_,):
 
   ================= ============= =========
   Package           Old           New

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -6,12 +6,12 @@ channels:
 
 dependencies:
  - python=3.10
- - cartopy=0.22
- - dask=2024.3
+ - cartopy=0.23
+ - dask=2024.5
  - filefisher=1.1
- - joblib=1.3
+ - joblib=1.4
  - netcdf4=1.6
- - numpy=1.25
+ - numpy=1.26
  - packaging=24.0
  - pandas=2.2
  - pooch=1.8
@@ -19,7 +19,7 @@ dependencies:
  - pyproj=3.6
  - regionmask=0.12
  - scikit-learn=1.4
- - scipy=1.12
+ - scipy=1.13
  - shapely=2.0
  - statsmodels=0.14
  - xarray=2025.03

--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,8 @@ channels:
 dependencies:
  - cartopy
  - dask
- - joblib
  - filefisher
+ - joblib
  - matplotlib-base
  - nc-time-axis
  - netcdf4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "dask[array,distributed] >=2024.3",
+    "dask[array,distributed] >=2024.5",
     "filefisher >=1.0.1",
-    "joblib >=1.3",
+    "joblib >=1.4",
     "netcdf4 >=1.6",
-    "numpy >=1.25",
+    "numpy >=1.26",
     "packaging >=24.0",
     "pandas >=2.2",
     "pooch >=1.8",
@@ -38,7 +38,7 @@ dependencies = [
     "pyproj >=3.6",
     "regionmask >=0.12",
     "scikit-learn >=1.4", # only for the tests
-    "scipy >=1.12",
+    "scipy >=1.13",
     "statsmodels >=0.14",
     "xarray >=2025.3", # for xr.DataTree
 ]
@@ -57,9 +57,9 @@ BugReports = "https://github.com/MESMER-group/mesmer/issues"
 [project.optional-dependencies]
 complete = ["mesmer-emulator[viz]"]
 viz = [
-    "cartopy",
-    "matplotlib",
-    "nc-time-axis",
+    "cartopy >=0.23",
+    "matplotlib >=3.8",
+    "nc-time-axis ",
 ]
 docs = [
     "ipython",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Bump the dependencies once again. I have a _very_ small hope this can help with the failure of `py3.10 ubuntu-latest min-all-deps` in  #645.
