### PR TITLE
add `_assert_required_coords`

### DIFF
--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -233,6 +233,7 @@ def _check_dataarray_form(
     *,
     ndim: tuple[int, ...] | int | None = None,
     required_dims: str | Iterable[str] | None = None,
+    required_coords: str | Iterable[str] | None = None,
     shape: tuple[int, ...] | None = None,
 ):
     """check if a dataset conforms to some conditions
@@ -268,6 +269,8 @@ def _check_dataarray_form(
 
     _assert_required_dims(obj, name=name, required_dims=required_dims)
 
+    _assert_required_coords(obj, name=name, required_coords=required_coords)
+
     if shape is not None and obj.shape != shape:
         raise ValueError(f"{name} has wrong shape - expected {shape}, got {obj.shape}")
 
@@ -283,3 +286,16 @@ def _assert_required_dims(
     if required_dims - set(obj.dims):
         missing_dims = " ,".join(required_dims - set(obj.dims))
         raise ValueError(f"{name} is missing the required dims: {missing_dims}")
+
+
+def _assert_required_coords(
+    obj, name: str = "obj", required_coords: str | Iterable[str] | None = None
+):
+
+    __tracebackhide__ = True
+
+    required_coords = _to_set(required_coords)
+
+    if required_coords - set(obj.coords):
+        missing_coords = " ,".join(required_coords - set(obj.coords))
+        raise ValueError(f"{name} is missing the required coords: {missing_coords}")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -308,28 +308,56 @@ def test_check_dataarray_form_required_dims(required_dims):
     mesmer.core.utils._check_dataarray_form(da, required_dims={"x", "y"})
 
 
-@pytest.mark.parametrize("required_dims", ("foo", ["foo"], ["foo", "bar"]))
+def test_check_dataarray_form_required_coords():
+
+    da = xr.DataArray(np.ones((2, 2)), dims=("x", "y"))
+
+    # x & y are dims but not coords
+    for required_coords in ("foo", ["foo"], ["foo", "bar"], "x", "y"):
+        with pytest.raises(ValueError, match="obj is missing the required coords"):
+            mesmer.core.utils._check_dataarray_form(da, required_coords=required_coords)
+
+    with pytest.raises(ValueError, match="obj is missing the required coords"):
+        mesmer.core.utils._check_dataarray_form(da, required_coords="x")
+
+    # add coords and non-dimension coords
+    da = da.assign_coords(x=[0, 1], y=["a", "b"], c=("x", [0, 1]))
+
+    # no error
+    mesmer.core.utils._check_dataarray_form(da, required_coords="c")
+    mesmer.core.utils._check_dataarray_form(da, required_coords="x")
+    mesmer.core.utils._check_dataarray_form(da, required_coords="y")
+    mesmer.core.utils._check_dataarray_form(da, required_coords=["x", "y"])
+    mesmer.core.utils._check_dataarray_form(da, required_coords={"x", "y"})
+
+
 @pytest.mark.parametrize("to_dataset", (True, False))
-def test_assert_required_dims(required_dims, to_dataset):
+def test_assert_required_dims(to_dataset):
 
     obj = xr.DataArray(np.ones((2, 2)), dims=("x", "y"), name="data")
 
     if to_dataset:
         obj = obj.to_dataset()
 
-    with pytest.raises(ValueError, match="obj is missing the required dims"):
-        mesmer.core.utils._assert_required_dims(obj, required_dims=required_dims)
+    # x & y are dims but not coords
+    for required_coords in ("foo", ["foo"], ["foo", "bar"], "x", "y"):
+        with pytest.raises(ValueError, match="obj is missing the required coords"):
+            mesmer.core.utils._assert_required_coords(
+                obj, required_coords=required_coords
+            )
 
-    with pytest.raises(ValueError, match="test is missing the required dims"):
-        mesmer.core.utils._assert_required_dims(
-            obj, required_dims=required_dims, name="test"
-        )
+    with pytest.raises(ValueError, match="obj is missing the required coords"):
+        mesmer.core.utils._assert_required_coords(obj, required_coords="x")
+
+    # add coords and non-dimension coords
+    obj = obj.assign_coords(x=[0, 1], y=["a", "b"], c=("x", [0, 1]))
 
     # no error
-    mesmer.core.utils._assert_required_dims(obj, required_dims="x")
-    mesmer.core.utils._assert_required_dims(obj, required_dims="y")
-    mesmer.core.utils._assert_required_dims(obj, required_dims=["x", "y"])
-    mesmer.core.utils._assert_required_dims(obj, required_dims={"x", "y"})
+    mesmer.core.utils._assert_required_coords(obj, required_coords="c")
+    mesmer.core.utils._assert_required_coords(obj, required_coords="x")
+    mesmer.core.utils._assert_required_coords(obj, required_coords="y")
+    mesmer.core.utils._assert_required_coords(obj, required_coords=["x", "y"])
+    mesmer.core.utils._assert_required_coords(obj, required_coords={"x", "y"})
 
 
 def test_check_dataarray_form_shape():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

When stacking scenarios we get `"time"`, `"scenario"`, and `"member"` as non-dimension coordinates, which are not in `obj.dims`, so `"time" in obj.dims` is `False` and thus `required_dims` can error.

As hinted-at in #681
