### PR TITLE
allow non-dimension time coord in `upsample_yearly_data`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -230,8 +230,9 @@ Harmonic model
 -  remove fitting of linear regression with yearly temperature (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_ and
    `#488 <https://github.com/MESMER-group/mesmer/pull/488>`_) in line with (`Nath et al. 2022 <https://doi.org/10.5194/esd-13-851-2022>`_).
 -  add helper function to upsample yearly data to monthly resolution (\
-   `#418 <https://github.com/MESMER-group/mesmer/pull/418>`_, and
-   `#435 <https://github.com/MESMER-group/mesmer/pull/435>`_)
+   `#418 <https://github.com/MESMER-group/mesmer/pull/418>`_,
+   `#435 <https://github.com/MESMER-group/mesmer/pull/435>`_, and
+   `#688 <https://github.com/MESMER-group/mesmer/pull/688>`_).
 - de-duplicate the expression of months in their harmonic form (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_)
   move creation of the month array to the deepest level (`#487 <https://github.com/MESMER-group/mesmer/pull/487>`_).
 - fix indexing of harmonic model coefficients (`#415 <https://github.com/MESMER-group/mesmer/pull/415>`_)

--- a/mesmer/core/utils.py
+++ b/mesmer/core/utils.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Iterable
 from typing import cast
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from mesmer.core.datatree import _datatree_wrapper
@@ -151,8 +152,9 @@ def upsample_yearly_data(
         Upsampled yearly temperature values containing the yearly values for every month
         of the corresponding year.
     """
-    _assert_required_dims(yearly_data, "yearly_data", required_dims=time_dim)
-    _assert_required_dims(monthly_time, "monthly_time", required_dims=time_dim)
+
+    _assert_required_coords(yearly_data, "yearly_data", required_coords=time_dim)
+    _assert_required_coords(monthly_time, "monthly_time", required_coords=time_dim)
 
     # read out time coords - this also works if it's already time coords
     monthly_time = monthly_time[time_dim]
@@ -163,15 +165,27 @@ def upsample_yearly_data(
             "Length of monthly time not equal to 12 times the length of yearly data."
         )
 
-    # make sure monthly and yearly data both start at the beginning of the period
-    year = yearly_data.resample({time_dim: "YS"}).bfill()
-    month = monthly_time.resample({time_dim: "MS"}).bfill()
+    # we need to pass the dim (`time_dim` may be a no-dim-coordinate)
+    # i.e., time_dim and sample_dim may or may not be the same
+    (sample_dim,) = monthly_time.dims
 
-    # forward fill yearly values to monthly resolution
-    upsampled_yearly_data = year.reindex_like(month, method="ffill")
+    if isinstance(yearly_data.indexes.get(sample_dim), pd.MultiIndex):
+        raise ValueError(
+            f"The dimension of the time coords ({sample_dim}) is a pandas.MultiIndex,"
+            " which is currently not supported. Potentially call"
+            f" `yearly_data.reset_index('{sample_dim}')` first."
+        )
 
-    # make sure the time dimension of the upsampled data is the same as the original monthly time
-    upsampled_yearly_data = year.reindex_like(monthly_time, method="ffill")
+    upsampled_yearly_data = (
+        # repeats the data along new dimension
+        yearly_data.expand_dims({"__new__": 12})
+        # stack to remove new dim; target dim must have new name
+        .stack(__sample__=(sample_dim, "__new__"), create_index=False)
+        # so we need to rename it back
+        .swap_dims(__sample__=sample_dim)
+        # and ensure the time coords the ones from the monthly data
+        .assign_coords({time_dim: (sample_dim, monthly_time.values)})
+    )
 
     return upsampled_yearly_data
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Allow non-dimension time coord in `upsample_yearly_data` - so we can pass pooled data in #572 (where `"scenario"` is the dim and `"time"` is a non-dimension coordinate). These 4 lines of code took me almost a day :man_shrugging: :shaking_face: (discovered a new emoji)