### PR TITLE
generate less test realisations

### DIFF
--- a/tests/integration/test_draw_mesmer_m.py
+++ b/tests/integration/test_draw_mesmer_m.py
@@ -16,7 +16,7 @@ def test_make_emulations_mesmer_m(test_data_root_dir, update_expected_files):
     esm = "IPSL-CM6A-LR"
     scenario = "ssp585"
 
-    nr_emus = 10
+    nr_emus = 2
     buffer = 20
     seed = 0
 

--- a/tests/integration/test_draw_realisations_mesmer_newcodepath.py
+++ b/tests/integration/test_draw_realisations_mesmer_newcodepath.py
@@ -164,14 +164,14 @@ def create_forcing_data(scenarios, use_hfds, use_tas2):
             ["ssp585"],
             False,
             False,
-            30,
+            3,
             "tas/one_scen_multi_ens",
         ),
         pytest.param(
             ["ssp126", "ssp585"],
             False,
             False,
-            100,
+            10,
             "tas/multi_scen_multi_ens",
         ),
         # tas and tas**2


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #666
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Create less emulations in the tests - so we need to store less data files. It's important that we test `n > 1` but I don't think it matters much whether it's `2` or more. As #697 to be merged before #677 to avoid re-creating the data files twice. (Will lead to failed tests).