### PR TITLE
map_over_datasets: allow Dataset in all positions

### DIFF
--- a/mesmer/core/_datatreecompat.py
+++ b/mesmer/core/_datatreecompat.py
@@ -11,11 +11,18 @@ if Version(xr.__version__) < Version("2025.03"):
 
 
 def _skip_empty_nodes(func):
+
     @functools.wraps(func)
-    def _func(ds, *args, **kwargs):
-        if not ds:
-            return ds
-        return func(ds, *args, **kwargs)
+    def _func(*args, **kwargs):
+        # extract only the dataset args from args
+        ds_args = [arg for arg in args if isinstance(arg, xr.Dataset)]
+
+        # if any datasets are empty, return empty
+        if any((not ds.coords and not ds.data_vars) for ds in ds_args):
+            return xr.Dataset()
+
+        # return func with right order of args
+        return func(*args, **kwargs)
 
     return _func
 

--- a/tests/unit/test_datatree.py
+++ b/tests/unit/test_datatree.py
@@ -440,6 +440,7 @@ def test_stack_datatree_keep_other_dims():
 
 
 def test_map_over_dataset():
+    # test empty nodes are skipped
 
     ds = xr.Dataset(data_vars={"data": ("x", [1, 2])})
     dt = xr.DataTree.from_dict({"node": ds})

--- a/tests/unit/test_datatree.py
+++ b/tests/unit/test_datatree.py
@@ -437,3 +437,36 @@ def test_stack_datatree_keep_other_dims():
         required_dims=("sample", "gridpoint"),
         shape=(9, 4),
     )
+
+
+def test_map_over_dataset():
+
+    ds = xr.Dataset(data_vars={"data": ("x", [1, 2])})
+    dt = xr.DataTree.from_dict({"node": ds})
+
+    def rename(ds):
+        return ds.rename(data="variable")
+
+    result = map_over_datasets(rename, dt)
+    expected = xr.DataTree.from_dict({"node": ds.rename(data="variable")})
+    xr.testing.assert_equal(result, expected)
+
+    # test not-first arg is a DataTree
+
+    def rename_second(new_name, ds):
+        return ds.rename(data=new_name)
+
+    result = map_over_datasets(rename_second, "variable", dt)
+    expected = xr.DataTree.from_dict({"node": ds.rename(data="variable")})
+    xr.testing.assert_equal(result, expected)
+
+    # test if there are only coords
+    ds_coords = xr.Dataset(coords={"x": [1, 2]})
+    dt = xr.DataTree.from_dict({"node": ds_coords})
+
+    def rename_coords(ds):
+        return ds.rename(x="y")
+
+    result = map_over_datasets(rename_coords, dt)
+    expected = xr.DataTree.from_dict({"node": ds_coords.rename(x="y")})
+    xr.testing.assert_equal(result, expected)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Extracted from #677 - so this is actually by @veni-vidi-vici-dormivi - thanks! The only think I changed is 

```diff
-if any((not ds.coords and not ds.data_vars and not ds.dims) for ds in ds_args):
+if any((not ds.coords and not ds.data_vars) for ds in ds_args):
```

I think a ds can only have `dims` if it either has `coords` or `data_vars`. I'll merge fast.