### PR TITLE
power transformer: allow sample dimension

### DIFF
--- a/mesmer/stats/_power_transformer.py
+++ b/mesmer/stats/_power_transformer.py
@@ -392,6 +392,7 @@ def yeo_johnson_transform(
         input_core_dims=[[sample_dim], [sample_dim]],
         output_core_dims=[[sample_dim]],
         output_dtypes=[float],
+        vectorize=True,
     ).rename("transformed")
 
     return xr.merge([transformed_resids, lambdas])
@@ -469,6 +470,7 @@ def inverse_yeo_johnson_transform(
         input_core_dims=[[sample_dim], [sample_dim]],
         output_core_dims=[[sample_dim]],
         output_dtypes=[float],
+        vectorize=True,
     ).rename("inverted")
 
     return xr.merge([inverted_resids, lambdas])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

As part of #572 we have to allow `sample_dim` in the power transformer. Previously `lambdas` would be an array with `month x year x others`. Now its `time x others`.

I implemented this in `get_lambdas_from_covariates` - but now there are two more params to pass to this function, which I don't particularly like (also it's not guaranteed that `yearly_pred` and `time_coords` both use the sample dim). However, users don't usually need to interact with `get_lambdas_from_covariates` (it's called in the `transform` and `inverse_transform` function).

Alternatively we could do it in `transform` and `inverse_transform`: 

```python
    lambdas_stacked = (
        lambdas.stack(__new__=(sample_dim, "month"), create_index=False)
        .drop_vars(["month", time_dim], errors="ignore")
        .swap_dims(__new__=sample_dim)
        .assign_coords({time_dim: (sample_dim, monthly_residuals[time_dim].values)})
    )
```