### PR TITLE
fit_auto_regression_monthly: keep order of sample dim

### DIFF
--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -894,7 +894,7 @@ def fit_auto_regression_monthly(
             # and last December has no following January
             prev_month = monthly_groups[12].isel({sample_dim: slice(None, -1)})
             cur_month = monthly_groups[1].isel({sample_dim: slice(1, None)})
-            i = 11
+            i = 11 # values only start the second year & first ts is removed
         else:
             prev_month = monthly_groups[month - 1]
             cur_month = monthly_groups[month]

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -894,7 +894,7 @@ def fit_auto_regression_monthly(
             # and last December has no following January
             prev_month = monthly_groups[12].isel({sample_dim: slice(None, -1)})
             cur_month = monthly_groups[1].isel({sample_dim: slice(1, None)})
-            i = 11 # values only start the second year & first ts is removed
+            i = 11  # values only start the second year & first ts is removed
         else:
             prev_month = monthly_groups[month - 1]
             cur_month = monthly_groups[month]

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -773,6 +773,13 @@ def test_fit_auto_regression_monthly(stack) -> None:
         shape=(12, n_gridcells),
     )
 
+    sample_dim = "sample" if stack else "time"
+    # check coordinates are the same
+    result_coords = result[sample_dim].coords
+    expected_coords = data[sample_dim].isel({sample_dim: slice(1, None)}).coords
+
+    assert result_coords.equals(expected_coords)
+
     with pytest.raises(TypeError, match="Expected monthly_data to be an xr.DataArray"):
         mesmer.stats.fit_auto_regression_monthly(data.values)  # type: ignore[arg-type]
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #707
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Turns out the time dim was not ordered (even before), however, the order does not matter for the next step in the chain (estimating the covariance matrix). Also directly uses a linear regression.