### PR TITLE
restrict threads and make them selectable

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -73,6 +73,9 @@ jobs:
         echo ""
         echo "Number of cpus and threads"
         python -c "import psutil; print(f'cpus: {psutil.cpu_count(logical=False)}; threads: {psutil.cpu_count()}')"
+        echo ""
+        echo "threadpool info:"
+        python -c "import numpy; import threadpoolctl; print(threadpoolctl.threadpool_info())"
 
     - name: Install mesmer
       run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ New Features
   By `Mathias Hauser`_.
 - Passing ``hist_period`` to the volcaninc helper functions is no longer needed (\
   `#649 <https://github.com/MESMER-group/mesmer/pull/649>`_). By `Mathias Hauser`_.
+- Added :py:class:`set_options` to mesmer which can, currently, be used to control
+  the number of used threads for matrix decomposition
+  (`#349 <https://github.com/MESMER-group/mesmer/issues/349>`_, and
+  `#713 <https://github.com/MESMER-group/mesmer/pull/713>`_).
+  By `Mathias Hauser`_.
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,6 +5,14 @@ API reference
 
 This page provides an auto-generated summary of mesmers' API.
 
+Top-level functions
+===================
+
+.. autosummary::
+   :toctree: generated/
+
+   set_options
+   get_options
 
 Statistical functions
 =====================

--- a/mesmer/__init__.py
+++ b/mesmer/__init__.py
@@ -21,6 +21,7 @@ from mesmer.core import (
     volc,
     weighted,
 )
+from mesmer.core.options import get_options, set_options
 
 # "legacy" modules
 __all__ = [
@@ -38,8 +39,10 @@ __all__ += [
     "datatree",
     "example_data",
     "geospatial",
+    "get_options",
     "grid",
     "mask",
+    "set_options",
     "stats",
     "testing",
     "volc",

--- a/mesmer/core/options.py
+++ b/mesmer/core/options.py
@@ -1,0 +1,97 @@
+# adapted from xarray under the terms of its license - see licences/XARRAY_LICENSE
+from __future__ import annotations
+
+import sys
+from typing import Any, Literal, TypedDict
+
+# TODO: Unpack defined in python 3.11+
+if sys.version_info < (3, 11):
+    Unpack: Any
+else:
+    from typing import Unpack
+
+
+class _OPTIONS(TypedDict, total=False):
+    threads: Literal["default"] | int | None
+
+
+OPTIONS: _OPTIONS = {
+    "threads": "default",
+}
+
+
+def _assert_valid_threads_option(name, threads):
+
+    if not (
+        threads == "default"
+        or threads is None
+        or (isinstance(threads, int) and threads > 0)
+    ):
+        msg = f"'{name}' must be 'default', a positive integer or None, got '{threads}'"
+        raise ValueError(msg)
+
+
+_VALIDATORS = {
+    "threads": _assert_valid_threads_option,
+}
+
+
+class set_options:
+    """
+    Set options for regionmask in a controlled context.
+
+    Parameters
+    ----------
+    threads : "default" |  int | None, default: "default"
+        Number of threads to use. Restricting the number of threads was found to speed
+        up matrix decomposition on linux systems. Only applied within mesmer.
+
+        * "default": uses ``min(os.cpu_count() // 2, 16)``
+
+        * None: no restrictions
+
+        * int: use this
+
+    Examples
+    --------
+    >>> import mesmer
+    >>> mesmer.set_options(threads=None)
+
+    """
+
+    def __init__(self, **kwargs: Unpack[_OPTIONS]):
+
+        self.old = {}
+
+        for key, value in kwargs.items():
+            if key not in OPTIONS:
+                raise ValueError(
+                    f"{key!r} is not in the set of valid options {set(OPTIONS)!r}"
+                )
+
+            _VALIDATORS[key](key, value)
+
+            # mypy does not know that key must be a literal from _OPTIONS TypedDict
+            self.old[key] = OPTIONS[key]  # type:ignore[literal-required]
+
+        self._apply_update(kwargs)
+
+    def _apply_update(self, options_dict):
+        OPTIONS.update(options_dict)
+
+    def __enter__(self):
+        return
+
+    def __exit__(self, type, value, traceback):
+        self._apply_update(self.old)
+
+
+def get_options():
+    """
+    Get options for regionmask.
+
+    See Also
+    --------
+    set_options
+    """
+    return OPTIONS

--- a/mesmer/core/options.py
+++ b/mesmer/core/options.py
@@ -48,9 +48,9 @@ class set_options:
 
         * "default": uses ``min(os.cpu_count() // 2, 16)``
 
-        * None: no restrictions
+        * None: uses the currently selected number of threads
 
-        * int: use this
+        * int: sets the maximum number of threads to `threads`
 
     Examples
     --------

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -16,6 +16,7 @@ from mesmer.core.utils import (
     LinAlgWarning,
     _check_dataarray_form,
     _check_dataset_form,
+    _set_threads_from_options,
 )
 
 
@@ -713,6 +714,7 @@ def _draw_auto_regression_correlated_np(
     return out[:, buffer:, :]
 
 
+@_set_threads_from_options()
 def _draw_innovations_correlated_np(
     covariance, rng, n_gridcells, n_samples, n_ts, buffer
 ):

--- a/mesmer/stats/_localized_covariance.py
+++ b/mesmer/stats/_localized_covariance.py
@@ -9,6 +9,7 @@ from mesmer.core.utils import (
     _check_dataarray_form,
     _create_equal_dim_names,
     _minimize_local_discrete,
+    _set_threads_from_options,
 )
 
 
@@ -280,6 +281,7 @@ def _find_localized_empirical_covariance_np(data, weights, localizer, k_folds):
     return localization_radius, covariance, localized_covariance
 
 
+@_set_threads_from_options()
 def _ecov_crossvalidation(localization_radius, *, data, weights, localizer, k_folds):
     """k-fold crossvalidation for a single localization radius"""
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -1,0 +1,50 @@
+import os
+import threadpoolctl
+
+from mesmer.core.utils import _set_threads_from_options
+import pytest
+
+import mesmer
+
+
+@pytest.mark.parametrize("invalid_option", [None, "None", "__foo__"])
+def test_option_invalid_error(invalid_option) -> None:
+
+    with pytest.raises(ValueError, match="not in the set of valid options"):
+
+        mesmer.set_options(invalid_option=invalid_option)  # type:ignore[call-arg]
+
+
+def test_options_threads_errors() -> None:
+
+    default = mesmer.core.options.OPTIONS["threads"]
+    assert default == "default"
+
+    msg = "'threads' must be 'default', a positive integer or None"
+
+    with pytest.raises(ValueError, match=msg):
+        mesmer.set_options(threads=0)
+
+    with pytest.raises(ValueError, match=msg):
+        mesmer.set_options(threads=-3)
+
+    with pytest.raises(ValueError, match=msg):
+        mesmer.set_options(threads=3.5)  # type:ignore[arg-type]
+
+
+def test_options_threads() -> None:
+
+    @_set_threads_from_options()
+    def func():
+        # return number of selected threads - not sure how brittle this is
+        return threadpoolctl.threadpool_info()[0]["num_threads"]
+
+    expected_default = min(16, os.cpu_count() // 2)
+
+    assert func() == expected_default
+
+    with mesmer.set_options(threads=1):
+        assert func() == 1
+
+    with mesmer.set_options(threads=None):
+        assert func() == os.cpu_count()

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -46,5 +46,8 @@ def test_options_threads() -> None:
     with mesmer.set_options(threads=1):
         assert func() == 1
 
+    # many systems use os.cpu_count(), but windows on GHA does not
+    system_default = threadpoolctl.threadpool_info()[0]["num_threads"]
+
     with mesmer.set_options(threads=None):
-        assert func() == os.cpu_count()
+        assert func() == system_default


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #349, supersedes and therefore closes #712
 - [x] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

My tests in #712 were a bit underwhelming, however, I think this is still worth it.

- Large calibrations are likely run on linux systems & I saw good gains on our systems
- I get considerable gains on my old laptop
- There seems to be no speed loss on Mac/ Windows

I think it's more likely to run several jobs in parallel on large systems, so I made an upper limit. The `16` were semi-randomly chosen (`2 ** 4`), happy to adjust to something else.

I think there are currently only two places where we do a matrix decomposition.

I added `options`, a bit overkill for one option :man_shrugging:. I copied it from regionmask (originally adjusted from xarray).