### PR TITLE
rename stack -> pool

### DIFF
--- a/mesmer/core/datatree.py
+++ b/mesmer/core/datatree.py
@@ -131,7 +131,7 @@ def collapse_datatree_into_dataset(
     return ds
 
 
-def pool_scenarios(
+def pool_scen_ens(
     dt: xr.DataTree,
     *,
     member_dim: str | None = "member",
@@ -202,7 +202,7 @@ def pool_scenarios(
 
 
 @overload
-def broadcast_and_pool_scenarios(
+def broadcast_and_pool_scen_ens(
     predictors: xr.DataTree,
     target: xr.DataTree,
     weights: None = None,
@@ -213,7 +213,7 @@ def broadcast_and_pool_scenarios(
     sample_dim: str = "sample",
 ) -> tuple[xr.Dataset, xr.Dataset, None]: ...
 @overload
-def broadcast_and_pool_scenarios(
+def broadcast_and_pool_scen_ens(
     predictors: xr.DataTree,
     target: xr.DataTree,
     weights: xr.DataTree,
@@ -225,7 +225,7 @@ def broadcast_and_pool_scenarios(
 ) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]: ...
 
 
-def broadcast_and_pool_scenarios(
+def broadcast_and_pool_scen_ens(
     predictors: xr.DataTree,
     target: xr.DataTree,
     weights: xr.DataTree | None = None,
@@ -308,14 +308,14 @@ def broadcast_and_pool_scenarios(
     )
 
     # 2) stack
-    predictors_stacked = pool_scenarios(pred_broadcast, **dims)
+    predictors_stacked = pool_scen_ens(pred_broadcast, **dims)
 
     # prepare target
-    target_stacked = pool_scenarios(target, **dims)
+    target_stacked = pool_scen_ens(target, **dims)
 
     # prepare weights
     if weights is not None:
-        weights_stacked = pool_scenarios(weights, **dims)
+        weights_stacked = pool_scen_ens(weights, **dims)
     else:
         weights_stacked = None
 

--- a/tests/integration/test_calibrate_mesmer_newcodepath.py
+++ b/tests/integration/test_calibrate_mesmer_newcodepath.py
@@ -220,7 +220,7 @@ def test_calibrate_mesmer(
     )
 
     predictors_stacked, target_stacked, weights_stacked = (
-        mesmer.core.datatree.broadcast_and_stack_scenarios(predictors, target, weights)
+        mesmer.datatree.broadcast_and_pool_scen_ens(predictors, target, weights)
     )
 
     local_forced_response_lr = mesmer.stats.LinearRegression()

--- a/tests/unit/test_datatree.py
+++ b/tests/unit/test_datatree.py
@@ -168,7 +168,7 @@ def test_extract_single_dataarray_from_dt():
         mesmer.datatree._extract_single_dataarray_from_dt(xr.DataTree())
 
 
-def test_broadcast_and_stack_scenarios():
+def test_broadcast_and_pool_scen_ens():
     n_ts, n_lat, n_lon = 30, 2, 3
     member_dim = "member"
     time_dim = "time"
@@ -209,7 +209,7 @@ def test_broadcast_and_stack_scenarios():
     )
 
     predictors_stacked, target_stacked, weights_stacked = (
-        mesmer.datatree.broadcast_and_pool_scenarios(
+        mesmer.datatree.broadcast_and_pool_scen_ens(
             predictors,
             target,
             weights,
@@ -261,13 +261,13 @@ def test_broadcast_and_stack_scenarios():
     xr.testing.assert_equal(weights_stacked, weights_aligned)
 
     predictors_stacked, target_stacked, weights_stacked = (
-        mesmer.datatree.broadcast_and_pool_scenarios(predictors, target, None)
+        mesmer.datatree.broadcast_and_pool_scen_ens(predictors, target, None)
     )
     assert weights_stacked is None, "Weights should be None if not provided"
 
     # check if exclude_dim can be empty
     predictors_stacked, target_stacked, weights_stacked = (
-        mesmer.datatree.broadcast_and_pool_scenarios(
+        mesmer.datatree.broadcast_and_pool_scen_ens(
             predictors,
             target.sel(cells=0),
             weights,
@@ -316,7 +316,7 @@ def test_datatree_wrapper():
 @pytest.mark.parametrize("time_dim", ("time", "t"))
 @pytest.mark.parametrize("member_dim", ("member", "m"))
 @pytest.mark.parametrize("sample_dim", ("sample", "s"))
-def test_stack_datatree(scenario_dim, time_dim, member_dim, sample_dim):
+def test_pool_scen_ens(scenario_dim, time_dim, member_dim, sample_dim):
 
     time = np.arange(3)
     data = np.arange(6).reshape(2, 3).T
@@ -336,7 +336,7 @@ def test_stack_datatree(scenario_dim, time_dim, member_dim, sample_dim):
 
     dt = xr.DataTree.from_dict({"scen1": ds1, "scen2": ds2})
 
-    result = mesmer.datatree.pool_scenarios(
+    result = mesmer.datatree.pool_scen_ens(
         dt,
         member_dim=member_dim,
         time_dim=time_dim,
@@ -364,7 +364,7 @@ def test_stack_datatree(scenario_dim, time_dim, member_dim, sample_dim):
     xr.testing.assert_equal(result, expected)
 
 
-def test_stack_datatree_missing_member_dim():
+def test_pool_scen_ens_missing_member_dim():
 
     time = np.arange(2)
     data = np.arange(2)
@@ -375,10 +375,10 @@ def test_stack_datatree_missing_member_dim():
     with pytest.raises(
         ValueError, match=r"`member_dim` \('member'\) not available in node 'scen'"
     ):
-        mesmer.datatree.pool_scenarios(dt)
+        mesmer.datatree.pool_scen_ens(dt)
 
 
-def test_stack_datatree_no_member_dim():
+def test_pool_scen_ens_no_member_dim():
 
     time = np.arange(2)
     data = np.arange(2)
@@ -387,7 +387,7 @@ def test_stack_datatree_no_member_dim():
 
     dt = xr.DataTree.from_dict({"scen": ds})
 
-    result = mesmer.datatree.pool_scenarios(dt, member_dim=None)
+    result = mesmer.datatree.pool_scen_ens(dt, member_dim=None)
 
     # =========
     scen = ["scen"] * 2
@@ -405,7 +405,7 @@ def test_stack_datatree_no_member_dim():
     xr.testing.assert_equal(result, expected)
 
 
-def test_stack_datatree_keep_other_dims():
+def test_pool_scen_ens_keep_other_dims():
 
     time = np.arange(2)
     data = np.arange(2 * 3 * 4).reshape(2, 3, 4)
@@ -428,7 +428,7 @@ def test_stack_datatree_keep_other_dims():
 
     dt = xr.DataTree.from_dict({"scen1": ds1, "scen2": ds2})
 
-    result = mesmer.datatree.pool_scenarios(dt)
+    result = mesmer.datatree.pool_scen_ens(dt)
 
     mesmer.core.utils._check_dataset_form(result, "result", required_vars="var")
     mesmer.core.utils._check_dataarray_form(

--- a/tests/unit/test_datatree.py
+++ b/tests/unit/test_datatree.py
@@ -209,7 +209,7 @@ def test_broadcast_and_stack_scenarios():
     )
 
     predictors_stacked, target_stacked, weights_stacked = (
-        mesmer.datatree.broadcast_and_stack_scenarios(
+        mesmer.datatree.broadcast_and_pool_scenarios(
             predictors,
             target,
             weights,
@@ -261,13 +261,13 @@ def test_broadcast_and_stack_scenarios():
     xr.testing.assert_equal(weights_stacked, weights_aligned)
 
     predictors_stacked, target_stacked, weights_stacked = (
-        mesmer.datatree.broadcast_and_stack_scenarios(predictors, target, None)
+        mesmer.datatree.broadcast_and_pool_scenarios(predictors, target, None)
     )
     assert weights_stacked is None, "Weights should be None if not provided"
 
     # check if exclude_dim can be empty
     predictors_stacked, target_stacked, weights_stacked = (
-        mesmer.datatree.broadcast_and_stack_scenarios(
+        mesmer.datatree.broadcast_and_pool_scenarios(
             predictors,
             target.sel(cells=0),
             weights,
@@ -336,7 +336,7 @@ def test_stack_datatree(scenario_dim, time_dim, member_dim, sample_dim):
 
     dt = xr.DataTree.from_dict({"scen1": ds1, "scen2": ds2})
 
-    result = mesmer.datatree._stack_datatree(
+    result = mesmer.datatree.pool_scenarios(
         dt,
         member_dim=member_dim,
         time_dim=time_dim,
@@ -375,7 +375,7 @@ def test_stack_datatree_missing_member_dim():
     with pytest.raises(
         ValueError, match=r"`member_dim` \('member'\) not available in node 'scen'"
     ):
-        mesmer.datatree._stack_datatree(dt)
+        mesmer.datatree.pool_scenarios(dt)
 
 
 def test_stack_datatree_no_member_dim():
@@ -387,7 +387,7 @@ def test_stack_datatree_no_member_dim():
 
     dt = xr.DataTree.from_dict({"scen": ds})
 
-    result = mesmer.datatree._stack_datatree(dt, member_dim=None)
+    result = mesmer.datatree.pool_scenarios(dt, member_dim=None)
 
     # =========
     scen = ["scen"] * 2
@@ -428,7 +428,7 @@ def test_stack_datatree_keep_other_dims():
 
     dt = xr.DataTree.from_dict({"scen1": ds1, "scen2": ds2})
 
-    result = mesmer.datatree._stack_datatree(dt)
+    result = mesmer.datatree.pool_scenarios(dt)
 
     mesmer.core.utils._check_dataset_form(result, "result", required_vars="var")
     mesmer.core.utils._check_dataarray_form(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

1. In #572 I use `_stack_datatree` in the example so this should be made public.
2. we have `mask_and_stack`, so I ended up with `tas_stacked_stacked_y` :grimacing: so my suggestion is to rename it to `pool`

(I am also not sure `datatree` is the best namespace but #348 :disappointed:)

@veni-vidi-vici-dormivi do you have thoughts on this?

