### PR TITLE
scipy: upper pin for statsmodels

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
  - pyproj
  - regionmask>=0.12
  - scikit-learn
- - scipy
+ - scipy<=1.15.3, # https://github.com/statsmodels/statsmodels/issues/9542
  - statsmodels>=0.14
  - xarray>=2025.03
 # for testing


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

In #724 I did wonder why I did not have to add a pin for the mamba/ conda installation - turns out it was just not available yet. I hope statsmodels releases a new version soon - I would really like to avoid releasing with an upper pin :unamused: 