### PR TITLE
make properscoring an optional dependency

### DIFF
--- a/mesmer/mesmer_x/_optimizers.py
+++ b/mesmer/mesmer_x/_optimizers.py
@@ -5,7 +5,6 @@
 
 
 import numpy as np
-import properscoring
 from scipy.optimize import minimize
 
 import mesmer.mesmer_x._distrib_checks as _distrib_checks
@@ -152,9 +151,18 @@ def _bic(expression, data_targ, params, data_weights):
 
 
 def _crps(expression: Expression, data_targ, data_pred, data_weights, coeffs):
+
+    try:
+        import properscoring
+    except ImportError:  # pragma: no cover
+        msg = "Computing the 'crps' metric requires the properscoring package to be installed"
+        raise ImportError(msg)
+
     # properscoring.crps_quadrature cannot be applied on conditional distributions, thu
     # calculating in each point of the sample, then averaging
-    # NOTE: WARNING, TAKES A VERY LONG TIME TO COMPUTE
+    # NOTE: TAKES A VERY LONG TIME TO COMPUTE
+    # TODO: find alternative way to compute this
+
     tmp_cprs = []
     for i in np.arange(len(data_targ)):
         distrib = expression.evaluate(coeffs, {p: data_pred[p][i] for p in data_pred})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "packaging >=24.1",
     "pandas >=2.2",
     "pooch >=1.8",
-    "properscoring >=0.1",
     "pyproj >=3.6",
     "regionmask >=0.12",
     "scikit-learn >=1.4", # only for the tests
@@ -54,7 +53,10 @@ Source = "https://github.com/MESMER-group/mesmer"
 BugReports = "https://github.com/MESMER-group/mesmer/issues"
 
 [project.optional-dependencies]
-complete = ["mesmer-emulator[viz]"]
+complete = [
+  "mesmer-emulator[viz]",
+  "properscoring >=0.1",
+]
 viz = [
     "cartopy >=0.23",
     "matplotlib >=3.8",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #605
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Instructs the user to install the dependency if `crps` should be calculate. Does not remove it completely also it's still in the _environment.yml_

https://github.com/MESMER-group/mesmer/blob/c14e89985647694b7a5c9c5306b785c7b0b467f0/environment.yml#L19

Currently not tested as we would need another ci-environment and test run.
