### PR TITLE
make more args kw only

### DIFF
--- a/mesmer/calibrate_mesmer/train_lv.py
+++ b/mesmer/calibrate_mesmer/train_lv.py
@@ -313,4 +313,6 @@ def train_lv_find_localized_ecov(y, wgt_scen_eq, aux, cfg):
 
     k_folds = cfg.max_iter_cv
 
-    return find_localized_empirical_covariance(data, weights, localizer, dim, k_folds)
+    return find_localized_empirical_covariance(
+        data, weights, localizer, dim=dim, k_folds=k_folds
+    )

--- a/mesmer/core/_data.py
+++ b/mesmer/core/_data.py
@@ -7,7 +7,7 @@ import xarray as xr
 import mesmer
 
 
-def load_stratospheric_aerosol_optical_depth_obs(version="2022", resample=True):
+def load_stratospheric_aerosol_optical_depth_obs(*, version="2022", resample=True):
     """load stratospheric aerosol optical depth data - a proxy for volcanic activity
 
     Parameters

--- a/mesmer/core/datatree.py
+++ b/mesmer/core/datatree.py
@@ -95,7 +95,7 @@ def _extract_single_dataarray_from_dt(
 
 
 def collapse_datatree_into_dataset(
-    dt: xr.DataTree, dim: str, **concat_kwargs
+    dt: xr.DataTree, *, dim: str, **concat_kwargs
 ) -> xr.Dataset:
     """
     Take a ``DataTree`` and collapse **all its subtrees** into a single ``xr.Dataset`` along dim.

--- a/mesmer/core/geospatial.py
+++ b/mesmer/core/geospatial.py
@@ -13,6 +13,7 @@ from mesmer.core.utils import _create_equal_dim_names
 def geodist_exact(
     lon: xr.DataArray | np.ndarray,
     lat: xr.DataArray | np.ndarray,
+    *,
     equal_dim_suffixes: tuple[str, str] = ("_i", "_j"),
 ):
     """exact great circle distance based on WSG 84

--- a/mesmer/mesmer_x/_expression.py
+++ b/mesmer/mesmer_x/_expression.py
@@ -407,7 +407,7 @@ class Expression:
         return eval(self._compiled_param_expr[name], None, locals)
 
     def evaluate_params(
-        self, coefficients_values, predictors_values, forced_shape=None
+        self, coefficients_values, predictors_values, *, forced_shape=None
     ):
         """
         Evaluates the parameters for the provided predictors and coefficients
@@ -543,6 +543,8 @@ class Expression:
         """
 
         params = self.evaluate_params(
-            coefficients_values, predictors_values, forced_shape
+            coefficients_values,
+            predictors_values,
+            forced_shape=forced_shape,
         )
         return self.distrib(**params)

--- a/mesmer/mesmer_x/_probability_integral_transform.py
+++ b/mesmer/mesmer_x/_probability_integral_transform.py
@@ -51,6 +51,7 @@ class ProbabilityIntegralTransform:
         target_name,
         preds_orig=None,
         preds_targ=None,
+        *,
         threshold_proba=1.0e-9,
     ):
         """

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -273,7 +273,11 @@ def _fit_auto_regression_scen_ens_dt(
 
 
 def select_ar_order(
-    data: xr.DataArray, dim: str, maxlag: int, ic: Literal["bic", "aic", "hqic"] = "bic"
+    data: xr.DataArray,
+    dim: str,
+    *,
+    maxlag: int,
+    ic: Literal["bic", "aic", "hqic"] = "bic",
 ) -> xr.DataArray:
     """Select the order of an autoregressive process
 
@@ -743,7 +747,7 @@ def _draw_innovations_correlated_np(
 
 
 def fit_auto_regression(
-    data: xr.DataArray, dim: str, lags: int | Sequence[int]
+    data: xr.DataArray, dim: str, *, lags: int | Sequence[int]
 ) -> xr.Dataset:
     """fit an auto regression
 

--- a/mesmer/stats/_localized_covariance.py
+++ b/mesmer/stats/_localized_covariance.py
@@ -84,6 +84,7 @@ def find_localized_empirical_covariance(
     weights: xr.DataArray,
     localizer: dict[float | int, xr.DataArray | np.ndarray],
     dim: str,
+    *,
     k_folds: int,
     equal_dim_suffixes: tuple[str, str] = ("_i", "_j"),
 ) -> xr.Dataset:
@@ -159,6 +160,7 @@ def find_localized_empirical_covariance_monthly(
     weights: xr.DataArray,
     localizer: dict[float | int, xr.DataArray | np.ndarray],
     dim: str,
+    *,
     k_folds: int,
     equal_dim_suffixes: tuple[str, str] = ("_i", "_j"),
 ) -> xr.Dataset:

--- a/mesmer/testing.py
+++ b/mesmer/testing.py
@@ -83,7 +83,7 @@ def assert_dict_allclose(first, second, first_name="left", second_name="right"):
             assert first_val == second_val, key
 
 
-def trend_data_1D(n_timesteps=30, intercept=0.0, slope=1.0, scale=1.0, seed=0):
+def trend_data_1D(*, n_timesteps=30, intercept=0.0, slope=1.0, scale=1.0, seed=0):
 
     time = np.arange(n_timesteps)
 
@@ -96,7 +96,7 @@ def trend_data_1D(n_timesteps=30, intercept=0.0, slope=1.0, scale=1.0, seed=0):
 
 
 def trend_data_2D(
-    n_timesteps=30, n_lat=3, n_lon=2, intercept=0.0, slope=1.0, scale=1.0
+    *, n_timesteps=30, n_lat=3, n_lon=2, intercept=0.0, slope=1.0, scale=1.0
 ) -> xr.DataArray:
 
     n_cells = n_lat * n_lon
@@ -118,7 +118,7 @@ def trend_data_2D(
 
 
 def trend_data_3D(
-    n_timesteps=30, n_lat=3, n_lon=2, intercept=0.0, slope=1.0, scale=1.0
+    *, n_timesteps=30, n_lat=3, n_lon=2, intercept=0.0, slope=1.0, scale=1.0
 ):
 
     data = trend_data_2D(

--- a/tests/integration/test_calibrate_mesmer_m.py
+++ b/tests/integration/test_calibrate_mesmer_m.py
@@ -114,7 +114,7 @@ def test_calibrate_mesmer_m(test_data_root_dir, update_expected_files):
     weights.name = "weights"
 
     localized_ecov = mesmer.stats.find_localized_empirical_covariance_monthly(
-        ar1_fit.residuals, weights, phi_gc_localizer, "time", 30
+        ar1_fit.residuals, weights, phi_gc_localizer, "time", k_folds=30
     )
 
     # we need to get the original time coordinate to be able to validate our results

--- a/tests/integration/test_calibrate_mesmer_newcodepath.py
+++ b/tests/integration/test_calibrate_mesmer_newcodepath.py
@@ -254,7 +254,11 @@ def test_calibrate_mesmer(
     k_folds = 30
 
     localized_ecov = mesmer.stats.find_localized_empirical_covariance(
-        tas_stacked_residuals, weights_stacked.weights, phi_gc_localizer, dim, k_folds
+        tas_stacked_residuals,
+        weights_stacked.weights,
+        phi_gc_localizer,
+        dim=dim,
+        k_folds=k_folds,
     )
 
     localized_ecov["localized_covariance_adjusted"] = (

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -15,7 +15,7 @@ def test_select_ar_order_1d():
 
     data = trend_data_1D()
 
-    result = mesmer.stats.select_ar_order(data, "time", 4)
+    result = mesmer.stats.select_ar_order(data, "time", maxlag=4)
 
     _check_dataarray_form(result, "selected_ar_order", ndim=0, shape=())
 
@@ -26,7 +26,7 @@ def test_select_ar_order_3d(n_lon, n_lat):
 
     data = trend_data_3D(n_lat=n_lat, n_lon=n_lon)
 
-    result = mesmer.stats.select_ar_order(data, "time", 1)
+    result = mesmer.stats.select_ar_order(data, "time", maxlag=1)
 
     _check_dataarray_form(
         result,
@@ -40,7 +40,7 @@ def test_select_ar_order_3d(n_lon, n_lat):
 def test_select_ar_order_dim():
 
     data = trend_data_3D(n_timesteps=4, n_lon=5)
-    result = mesmer.stats.select_ar_order(data, "lon", 1)
+    result = mesmer.stats.select_ar_order(data, "lon", maxlag=1)
 
     _check_dataarray_form(
         result, "selected_ar_order", ndim=2, required_dims={"time", "lat"}, shape=(4, 3)
@@ -51,7 +51,7 @@ def test_select_ar_order():
 
     data = trend_data_2D()
 
-    result = mesmer.stats.select_ar_order(data, "time", 4)
+    result = mesmer.stats.select_ar_order(data, "time", maxlag=4)
 
     coords = data.drop_vars("time").coords
 

--- a/tutorials/tutorial_mesmer_calibrate_multiple_scenarios.ipynb
+++ b/tutorials/tutorial_mesmer_calibrate_multiple_scenarios.ipynb
@@ -827,7 +827,11 @@
     "k_folds = 15\n",
     "\n",
     "localized_ecov = mesmer.stats.find_localized_empirical_covariance(\n",
-    "    resids_pooled.residuals, weights_pooled.weights, phi_gc_localizer, dim, k_folds\n",
+    "    resids_pooled.residuals,\n",
+    "    weights_pooled.weights,\n",
+    "    phi_gc_localizer,\n",
+    "    dim,\n",
+    "    k_folds=k_folds,\n",
     ")\n",
     "\n",
     "localized_ecov"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #245
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Went over all public functions in _stats_, _mesmer_x_, and _core_. It's not entirely consistent if `dim` is kw only or not.