### PR TITLE
MESMER-M calibration test: load using DataTree

### DIFF
--- a/tests/integration/test_calibrate_mesmer_m.py
+++ b/tests/integration/test_calibrate_mesmer_m.py
@@ -15,7 +15,7 @@ def find_hist_proj_simulations(
     resolution="g025",
 ):
 
-    cmip6_data_path = mesmer.example_data.cmip6_ng_path(relative=True)
+    cmip6_data_path = mesmer.example_data.cmip6_ng_path(relative=False)
 
     cmip_filefinder = filefisher.FileFinder(
         path_pattern=cmip6_data_path / "{variable}/{time_res}/{resolution}",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Part of #719
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`


Loads the data via datatree.