### PR TITLE
move  `load_stratospheric_aerosol_optical_depth_obs` to volc and make data module private

### DIFF
--- a/mesmer/_core/_data.py
+++ b/mesmer/_core/_data.py
@@ -7,33 +7,12 @@ import xarray as xr
 import mesmer
 
 
-def load_stratospheric_aerosol_optical_depth_obs(*, version="2022", resample=True):
-    """load stratospheric aerosol optical depth data - a proxy for volcanic activity
-
-    Parameters
-    ----------
-    version : str, default: "2022"
-        Which version of the dataset to load. Currently only "2022" is available.
-    resample : bool, default: True
-        Whether to resample the data to annual resolution.
-
-    Returns
-    -------
-    stratospheric_aerosol_optical_depth_obs : xr.DataArray
-        DataArray of stratospheric aerosol optical depth observations.
-    """
+# use an inner function as @cache does not preserve the signature
+@cache
+def _load_aod_obs(*, version, resample):
 
     if version != "2022":
         raise ValueError("No version other than '2022' is currently available.")
-
-    aod = _load_aod_obs(resample=resample)
-
-    return aod.copy()
-
-
-# use an inner function as @cache does not nicely preserve the signature
-@cache
-def _load_aod_obs(*, resample):
 
     filename = _fetch_remote_data("obs/tau.line_2012.12.txt")
 

--- a/mesmer/io/load_obs.py
+++ b/mesmer/io/load_obs.py
@@ -8,7 +8,7 @@ Functions to load in observations which are saved locally.
 
 import warnings
 
-from mesmer._core._data import load_stratospheric_aerosol_optical_depth_obs
+from mesmer.volc import load_stratospheric_aerosol_optical_depth_obs
 
 
 def load_strat_aod(time, dir_obs=None):

--- a/mesmer/volc.py
+++ b/mesmer/volc.py
@@ -2,10 +2,31 @@ import warnings
 
 import xarray as xr
 
-from mesmer._core._data import load_stratospheric_aerosol_optical_depth_obs
+from mesmer._core._data import _load_aod_obs
 from mesmer._core.utils import _assert_annual_data, _check_dataarray_form
 from mesmer.datatree import _datatree_wrapper
 from mesmer.stats import LinearRegression
+
+
+def load_stratospheric_aerosol_optical_depth_obs(*, version="2022", resample=True):
+    """load stratospheric aerosol optical depth data - a proxy for volcanic activity
+
+    Parameters
+    ----------
+    version : str, default: "2022"
+        Which version of the dataset to load. Currently only "2022" is available.
+    resample : bool, default: True
+        Whether to resample the data to annual resolution.
+
+    Returns
+    -------
+    stratospheric_aerosol_optical_depth_obs : xr.DataArray
+        DataArray of stratospheric aerosol optical depth observations.
+    """
+
+    aod = _load_aod_obs(version=version, resample=resample)
+
+    return aod.copy()
 
 
 def _load_and_align_strat_aod_obs(

--- a/tests/integration/test_volc.py
+++ b/tests/integration/test_volc.py
@@ -38,12 +38,28 @@ def test_fit_volcanic_influence_errors():
         mesmer.volc.fit_volcanic_influence(data, slice("1850", "2014"), dim="sample")
 
 
+def test_load_stratospheric_aerosol_optical_depth_data_not_changed_inplace():
+
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
+        version="2022", resample=True
+    )
+
+    aod.loc[{"time": slice("1900", "2000")}] = 0.25
+
+    aod_orig = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
+        version="2022", resample=True
+    )
+
+    assert aod is not aod_orig
+    assert not aod.equals(aod_orig)
+
+
 @pytest.mark.parametrize(
     "hist_period", (None, slice("1850", "2014"), slice("1900", "2000"))
 )
 def test_fit_volcanic_influence_self(hist_period):
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -55,7 +71,7 @@ def test_fit_volcanic_influence_self(hist_period):
 
 def test_fit_volcanic_influence_self_shorter():
     # test it works when passing data shorter than aod obs
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -69,7 +85,7 @@ def test_fit_volcanic_influence_self_shorter():
 
 def test_fit_volcanic_influence_self_longer():
     # test it works when passing data longer than aod obs
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -94,7 +110,7 @@ def test_fit_volcanic_influence_self_longer():
 
 def test_fit_volcanic_warns_positive():
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -109,7 +125,7 @@ def test_fit_volcanic_warns_positive():
 @pytest.mark.filterwarnings("ignore:The slope of")
 def test_fit_volcanic_influence_2D():
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -124,7 +140,7 @@ def test_fit_volcanic_influence_2D():
 @pytest.mark.filterwarnings("ignore:The slope of")
 def test_fit_volcanic_influence_hist_period():
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -149,7 +165,7 @@ def test_fit_volcanic_influence_hist_period():
 @pytest.mark.parametrize("hist_period", (None, slice("1850", "2014")))
 def test_superimpose_volcanic_influence(slope, hist_period):
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -166,7 +182,7 @@ def test_superimpose_volcanic_influence(slope, hist_period):
 
 def test_superimpose_volcanic_influence_loner_errors():
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -195,7 +211,7 @@ def test_superimpose_volcanic_influence_loner_errors():
 
 def test_superimpose_volcanic_influence_hist_period():
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 
@@ -217,7 +233,7 @@ def test_superimpose_volcanic_influence_datatree():
 
     slope = -1.5
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
+    aod = mesmer.volc.load_stratospheric_aerosol_optical_depth_obs(
         version="2022", resample=True
     )
 

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -6,19 +6,17 @@ import xarray as xr
 import mesmer
 
 
-def test_load_stratospheric_aerosol_optical_depth_obs_wrong_version():
+def test_load_aod_obs_wrong_version():
 
     with pytest.raises(
         ValueError, match="No version other than '2022' is currently available."
     ):
-        mesmer.data.load_stratospheric_aerosol_optical_depth_obs(version="2021")
+        mesmer._core._data._load_aod_obs(version="2021", resample=True)
 
 
-def test_load_stratospheric_aerosol_optical_depth_data():
+def test_load_aod_obs_data():
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
-        version="2022", resample=True
-    )
+    aod = mesmer._core._data._load_aod_obs(version="2022", resample=True)
 
     time = pd.date_range("1850", "2023", freq="YE")
     time = xr.DataArray(time, dims="time", coords={"time": time})
@@ -29,27 +27,9 @@ def test_load_stratospheric_aerosol_optical_depth_data():
     np.testing.assert_allclose(0.0, aod[-1])
 
 
-def test_load_stratospheric_aerosol_optical_depth_data_not_changed_inplace():
+def test_load_aod_obs_data_no_resample():
 
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
-        version="2022", resample=True
-    )
-
-    aod.loc[{"time": slice("1900", "2000")}] = 0.25
-
-    aod_orig = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
-        version="2022", resample=True
-    )
-
-    assert aod is not aod_orig
-    assert not aod.equals(aod_orig)
-
-
-def test_load_stratospheric_aerosol_optical_depth_data_no_resample():
-
-    aod = mesmer.data.load_stratospheric_aerosol_optical_depth_obs(
-        version="2022", resample=False
-    )
+    aod = mesmer._core._data._load_aod_obs(version="2022", resample=False)
 
     time = pd.date_range("1850", "2022-12", freq="MS")
     time = xr.DataArray(time, dims="time", coords={"time": time})


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

As per lengthy title. The function is only used internally, so not much point in exposing the  _data_ module. And it can just as well live in _volc_. 
