### PR TITLE
doc: reflow and fix

### DIFF
--- a/mesmer/_core/options.py
+++ b/mesmer/_core/options.py
@@ -31,7 +31,7 @@ _VALIDATORS = {
 
 class set_options:
     """
-    Set options for regionmask in a controlled context.
+    Set options for mesmer in a controlled context.
 
     Parameters
     ----------
@@ -81,7 +81,7 @@ class set_options:
 
 def get_options():
     """
-    Get options for regionmask.
+    Get options for mesmer.
 
     See Also
     --------

--- a/mesmer/_core/utils.py
+++ b/mesmer/_core/utils.py
@@ -61,7 +61,8 @@ def _minimize_local_discrete(func: Callable, sequence: Iterable, **kwargs):
 
     Raises
     ------
-    ValueError : if `func` returns negative infinity for any input or all elements are `inf`.
+    ValueError : if `func` returns negative infinity for any input or all elements are
+                 `inf`.
 
     Notes
     -----

--- a/mesmer/datatree.py
+++ b/mesmer/datatree.py
@@ -76,7 +76,8 @@ def _extract_single_dataarray_from_dt(
     dt: xr.DataTree, name: str = "node"
 ) -> xr.DataArray:
     """
-    Extract a single DataArray from a DataTree node, holding a ``Dataset`` with one ``DataArray``.
+    Extract a single DataArray from a DataTree node, holding a ``Dataset`` with one
+    ``DataArray``.
     """
 
     if not dt.has_data:
@@ -98,14 +99,15 @@ def collapse_datatree_into_dataset(
     dt: xr.DataTree, *, dim: str, **concat_kwargs
 ) -> xr.Dataset:
     """
-    Take a ``DataTree`` and collapse **all its subtrees** into a single ``xr.Dataset`` along dim.
-    Shallow wrapper around ``xr.concat``.
+    Take a ``DataTree`` and collapse **all its subtrees** into a single ``xr.Dataset``
+    along dim. Shallow wrapper around ``xr.concat``.
 
     All subtrees are converted to ``xr.Dataset`` objects and concatenated along the
-    specified dimension. The dimension along which the datasets are concatenated will be added as a
-    coordinate to the resulting dataset and the name of each subtree will be used as the coordinate
-    value for this new dimension. Internally, xr.concat is used to concatenate the datasets, so
-    all keyword arguments that can be passed to xr.concat can be passed to this function as well.
+    specified dimension. The dimension along which the datasets are concatenated will be
+    added as a coordinate to the resulting dataset and the name of each subtree will be
+    used as the coordinate value for this new dimension. Internally, xr.concat is used
+    to concatenate the datasets, so all keyword arguments that can be passed to
+    xr.concat can be passed to this function as well.
 
     Parameters
     ----------
@@ -309,22 +311,28 @@ def broadcast_and_pool_scen_ens(
     Returns
     -------
     tuple of pooled predictors, target and weights
-        Tuple of the prepared predictors, target and weights. The predictors are broadcast
-        against the target. And then predictors, target, and weights are pooled along
-        the sample dimension, by stacking the scenario nodes and ensemble member dimension.
+        Tuple of the prepared predictors, target and weights. The predictors are
+        broadcast against the target. And then predictors, target, and weights are
+        pooled along the sample dimension, by stacking the scenario nodes and ensemble
+        member dimension.
 
     Notes
     -----
-    Dimensions which exist along the target but are not in the stacking_dims will be excluded from the
-    broadcasting of the predictors.
+    Dimensions which exist along the target but are not in the stacking_dims will be
+    excluded from the broadcasting of the predictors.
 
     Example for how the predictor ``DataTree`` should look like:
-    ├─ hist
-    |        datavars: tas, hfds, ...
-    ├─ scen1
-    |        datavars: tas, hfds, ...
-    └─ ...
-    with 'hist' and 'scen1' being the scenarios, holding each a dataset with the same dimensions.
+
+    .. code::
+
+       ├─ hist
+       |        data_vars: tas, hfds, ...
+       ├─ scen1
+       |        data_vars: tas, hfds, ...
+       └─ ...
+
+    with 'hist' and 'scen1' being the scenarios, holding each a dataset with the same
+    dimensions.
     """
 
     # exclude target dimensions from broadcasting which are not in the stacking_dims
@@ -402,19 +410,20 @@ def merge(
     combine_attrs: CombineAttrsOptions = "override",
 ):
     """
-    Merge the datasets of each node of isomorphic DataTree objects together.
-    Wraps `xarray.merge <https://docs.xarray.dev/en/stable/generated/xarray.merge.html>`_.
+    Merge the datasets of each node of isomorphic DataTree objects together. Wraps
+    `xarray.merge <https://docs.xarray.dev/en/stable/generated/xarray.merge.html>`_.
 
     Parameters
     ----------
     objects : Iterable of DataTree
-        The DataTree objects to merge. All DataTree objects must have the same structure, i.e. be isomorphic.
+        The DataTree objects to merge. All DataTree objects must have the same
+        structure, i.e. be isomorphic.
     compat : {'no_conflicts', 'identical', 'equals', 'override', 'broadcast_equals'}, default: 'no_conflicts'
-        String indicating how to compare variables of the same name for potential conflicts,
-        for details see `xarray.merge`.
+        String indicating how to compare variables of the same name for potential
+        conflicts, for details see `xarray.merge`.
     join : {'outer', 'inner', 'left', 'right'}, default: 'outer'
-        String indicating how to join the datasets of the DataTree objects, for details see
-        `xarray.merge`.
+        String indicating how to join the datasets of the DataTree objects, for details
+        see `xarray.merge`.
     fill_value : object, default: dtypes.NA
         Value to use for missing data, for details see `xarray.merge`.
     combine_attrs : {'no_conflicts', 'identical', 'equals', 'override', 'drop'}, default: 'override'
@@ -424,7 +433,8 @@ def merge(
     Returns
     -------
     xr.DataTree
-        A new DataTree object containing the merged datasets from each node of the input DataTree objects.
+        A new DataTree object containing the merged datasets from each node of the input
+        DataTree objects.
     """
     kwargs = {
         "compat": compat,

--- a/mesmer/distrib/_conditional_distribution.py
+++ b/mesmer/distrib/_conditional_distribution.py
@@ -35,9 +35,10 @@ class ConditionalDistribution:
         ----------
         Expression : class py:class:`Expression`
             Expression defining the conditional distribution.
-        minimize_options : class py:class:`MinimizeOptions` | None, default: MinimizeOptions()
+        minimize_options : `py:class:`MinimizeOptions` | None, default: MinimizeOptions()
             Class defining the optimizer options used during first guess and training of
-            distributions. If not passed uses "Nelder-Mead" minimizer with default settings.
+            distributions. If not passed uses "Nelder-Mead" minimizer with default
+            settings.
         second_minimizer : class py:class:`MinimizeOptions` | None, default: None
             Run a second minimization algorithm for all steps. ``method="Powell"``
             is recommended. It can be beneficial to run more than one minimization
@@ -85,14 +86,15 @@ class ConditionalDistribution:
         ----------
         predictors : dict of xr.DataArray | xr.Dataset
             A dict of DataArray objects used as predictors or a Dataset, holding each
-            predictor as a data variable. Each predictor must be 1D and contain `sample_dim`.
+            predictor as a data variable. Each predictor must be 1D and contain
+            `sample_dim`.
         target : xr.DataArray
             Target DataArray.
         weights : xr.DataArray.
             Individual weights for each sample.
         first_guess : xr.Dataset
-            First guess for the coefficients, each coefficient is a data variable in the Dataset
-            and has the corresponding name of the coefficient in the expression.
+            First guess for the coefficients, each coefficient is a data variable in the
+            Dataset and has the corresponding name of the coefficient in the expression.
         sample_dim : str
             Dimension along which to fit the distribution.
         smooth_coeffs : bool, default: False
@@ -116,9 +118,9 @@ class ConditionalDistribution:
         n_coeffs_fg = len(first_guess.data_vars)
         if n_coeffs_fg != self.expression.n_coeffs:
             raise ValueError(
-                "The provided first guess does not have the correct number of coeffs, "
-                f"Expression suggests a number of {self.expression.n_coeffs} coefficients, "
-                f"but `first_guess` has {n_coeffs_fg} data_variables."
+                "The provided first guess does not have the correct number of coeffs,"
+                f" Expression suggests a number of {self.expression.n_coeffs}"
+                f" coefficients, but `first_guess` has {n_coeffs_fg} data_variables."
             )
 
         first_guess_da = first_guess.to_dataarray(dim="coefficient")
@@ -226,7 +228,7 @@ class ConditionalDistribution:
         sample_dim: str = "sample",
     ):
         """
-        Find a first guess for all coefficients of a conditional distribution for each grid point.
+        Find a first guess for all coefficients of a conditional distribution
 
         Parameters
         ----------
@@ -234,23 +236,24 @@ class ConditionalDistribution:
             Conditional distribution object to find the first guess for.
         predictors : dict of xr.DataArray | xr.Dataset
             A dict of DataArray objects used as predictors or a Dataset, holding each
-            predictor as a data variable. Each predictor must be 1D and contain `sample_dim`.
+            predictor as a data variable. Each predictor must be 1D and contain
+            `sample_dim`.
         target : xr.DataArray
             Target DataArray, contains at least `sample_dim`.
         weights : xr.DataArray.
             Individual weights for each sample, must be 1D along `sample_dim`.
         first_guess : xr.Dataset, default: None
-            If provided, will use these values as first guess for the first guess. If None,
-            will use all zeros. Must contain the first guess for each coefficient in a
-            DataArray with the name of the coefficient.
+            If provided, will use these values as first guess for the first guess. If
+            None, will use all zeros. Must contain the first guess for each coefficient
+            in a DataArray with the name of the coefficient.
         sample_dim : str
             Dimension along which to fit the first guess.
 
         Returns
         -------
         :obj:`xr.Dataset`
-            Dataset of first guess for each coefficient of the conditional distribution as a
-            data variable with the name of the coefficient.
+            Dataset of first guess for each coefficient of the conditional distribution
+            as a data variable with the name of the coefficient.
         """
 
         # make fg with zeros if none
@@ -342,7 +345,8 @@ class ConditionalDistribution:
         ----------
         predictors : dict of xr.DataArray | xr.Dataset
             A dict of DataArray objects used as predictors or a DataTree, holding each
-            predictor as a data variable. Each predictor must be 1D and contain `sample_dim`.
+            predictor as a data variable. Each predictor must be 1D and contain
+            `sample_dim`.
         target : xr.DataArray
             Target DataArray.
         sample_dim : str

--- a/mesmer/distrib/_distrib_checks.py
+++ b/mesmer/distrib/_distrib_checks.py
@@ -78,9 +78,9 @@ def _params_in_distr_support(expression: Expression, params, data):
 
 def _targ_gt_min_proba(expression: Expression, threshold_min_proba, params, data_targ):
     """
-    Test that all cdf(data) >= threshold_min_proba and 1 - cdf(data) >= threshold_min_proba
-    Ensures that data lies within a confidence interval of threshold_min_proba for the tested
-    distribution.
+    Checks all cdf(data) >= threshold_min_proba and 1 - cdf(data) >= threshold_min_proba
+    Ensures that data lies within a confidence interval of threshold_min_proba for the
+    tested distribution.
     """
     # NOTE: DONT write 'x=data', because 'x' may be called differently for some
     # distribution (eg 'k' for poisson).
@@ -116,15 +116,16 @@ def _validate_coefficients(
     -------
 
     coeffs_in_bounds : bool
-        True if the coefficients are within conditional_distrib.expression.boundaries_coeffs. If
+        True if coefficients are in conditional_distrib.expression.boundaries_coeffs. If
         False, all other tests will also be set to False and not tested.
 
     params_in_bounds : bool
         True if the params are within conditional_distrib.expression.boundaries_params
 
     params_in_support : bool
-        True if parameters are within conditional_distrib.expression.boundaries_params and within the support of the distribution.
-        False if not or if test_coeff is False. If False, test_proba will be set to False and not tested.
+        True if parameters are within conditional_distrib.expression.boundaries_params
+        and within the support of the distribution. False if not or if test_coeff is
+        False. If False, test_proba will be set to False and not tested.
 
     test_proba : bool
         Only tested if conditional_distrib.threshold_min_proba is not None.
@@ -133,7 +134,8 @@ def _validate_coefficients(
         False if not or if test_coeff or test_param or test_coeff is False.
 
     params : dict
-        The evaluated params for the given coefficients, if any of the tests fail, empty dict.
+        The evaluated params for the given coefficients, if any of the tests fail, empty
+        dict.
 
     """
     params = {}

--- a/mesmer/distrib/_expression.py
+++ b/mesmer/distrib/_expression.py
@@ -29,8 +29,8 @@ class Expression:
     ):
         """Symbolic expression of a conditional distribution.
 
-        When initialized, the class identifies the distribution, predictors, parameters and
-        coefficients. The expression is then compiled so that it can be evaluated.
+        When initialized, the class identifies the distribution, predictors, parameters
+        and coefficients. The expression is then compiled so that it can be evaluated.
 
         Parameters
         ----------
@@ -42,15 +42,15 @@ class Expression:
 
         boundaries_params : dict, optional
             Boundaries for the parameters. The keys are the names of the parameters, and
-            the values are lists of two elements, the lower and upper bounds. The default
-            is None, which will set the boundaries to [-inf, inf] for all parameters
-            found in the expression, except `scale` which must be positive, so the lower boundary
-            will be set to 0. These boundaries will later be enforced when fitting the conditional
-            distribution.
+            the values are lists of two elements, the lower and upper bounds. The
+            default is None, which will set the boundaries to [-inf, inf] for all
+            parameters found in the expression, except `scale` which must be positive,
+            so the lower boundary will be set to 0. These boundaries will later be
+            enforced when fitting the conditional distribution.
 
         boundaries_coeffs : dict, optional
-            Boundaries for the coefficients. The keys are the names of the coefficients as
-            they are written in the expression, and the values are lists of two elements,
+            Boundaries for the coefficients. The keys are the names of the coefficients
+            as written in the expression, and the values are lists of two elements,
             the lower and upper bounds. The default is None. These boundaries will later
             be enforced when fitting the conditional distribution.
 
@@ -58,24 +58,21 @@ class Expression:
         -----
         A valid expression of a distribution contains the following elements:
 
-            - a distribution: must be the name of a distribution in `scipy.stats` (discrete
-              or continuous): https://docs.scipy.org/doc/scipy/reference/stats.html
-
-            - the parameters: all names for the parameters of the distributions must be
-              provided (as named in the `scipy.stats` distribution): ``loc``, ``scale``,
-              ``shape``, ``mu``, ``a``, ``b``, ``c``, etc.
-
-            - predictors: predictors that the distribution will be conditional to, must
-              be written like a variable in python and surrounded by "__":
-              e.g. ``__GMT__``, ``__X1__``, ``__gmt_tm1__``, but NOT ``__gmt-1__``,
-              ``__#days__``, ``__GMT``, ``_GMT_`` etc.
-
-            - coefficients: coefficients of the predictors, must be named "c#", with # being
-              the number of the coefficient: e.g. ``c1``, ``c2``, ``c3`` ().
-
-            - mathematical terms: mathematical terms for the evolutions are be written
-              as they would be normally in python. Only functions from numpy (``np.*``)
-              are supported. Spaces do not matter in the equations.
+        - a distribution: must be the name of a distribution in `scipy.stats
+          <https://docs.scipy.org/doc/scipy/reference/stats.html>`__ (discrete or
+          or continuous)
+        - the parameters: all names for the parameters of the distributions must be
+          provided (as named in the `scipy.stats` distribution): ``loc``, ``scale``,
+          ``shape``, ``mu``, ``a``, ``b``, ``c``, etc.
+        - predictors: predictors that the distribution will be conditional to, must
+          be written like a variable in python and surrounded by ``"__"``:
+          e.g. ``__GMT__``, ``__X1__``, ``__gmt_tm1__``, but NOT ``__gmt-1__``,
+          ``__#days__``, ``__GMT``, ``_GMT_`` etc.
+        - coefficients: coefficients of the predictors, must be named ``"c#"``, with #
+          being the number of the coefficient: e.g. ``c1``, ``c2``, ``c3``.
+        - mathematical terms: mathematical terms for the evolutions are be written
+          as they would be normally in python. Only functions from numpy (``np.*``)
+          are supported. Spaces do not matter in the equations.
 
         .. warning::
             Currently, the expression can only contain integers as numbers, no floats!
@@ -83,9 +80,14 @@ class Expression:
 
         Examples
         --------
-
-        - ``Expression("genextreme(loc=c1 + c2 * __pred1__, scale=c3 + c4 * __pred2__**2, c=c5", "expr1")``
-        - ``Expression("norm(loc=c1 + (c2 - c1) / ( 1 + np.exp(c3 * __GMT_t__ + c4 * __GMT_tm1__ - c5) ), scale=c6)", "expr2")``
+        >>> Expression(
+        ...     "genextreme(loc=c1 + c2 * __pred1__, scale=c3 + c4 * __pred2__**2, c=c5)",
+        ...     "expr1"
+        ... )
+        >>> Expression(
+        ...     "norm(loc=c1 + (c2 - c1) / ( 1 + np.exp(c3 * __GMT_t__ + c4 * __GMT_tm1__ - c5) ), scale=c6)",
+        ...     "expr2"
+        ... )
         """
         # TODO: Forcing values of certain parameters (eg mu for poisson) to be integers?
 
@@ -142,8 +144,8 @@ class Expression:
         if self.is_distrib_discrete:
             msg = (
                 "You selected a discrete distribution but these are not well tested. "
-                "They have integer parameters, which do not work well with minimization."
-                "Consider approximating it with a normal distribution. "
+                "They have integer parameters, which do not work well with"
+                "minimization. Consider approximating it with a normal distribution. "
             )
             warnings.warn(msg)
 
@@ -166,9 +168,9 @@ class Expression:
                 self.parameters_expressions[param] = sub
             else:
                 raise ValueError(
-                    f"The parameter '{param}' is not part of prepared expression in scipy.stats:"
+                    f"The parameter '{param}' is not part of the distribution "
+                    f"'{self.distrib.name}' in scipy.stats, see"
                     " https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats."
-                    f" of the distribution '{self.distrib.name}'"
                 )
 
         # recommend not to try to fill in missing information on parameters with
@@ -207,9 +209,10 @@ class Expression:
             self.boundaries_params["scale"] = [0, np.inf]
 
         if "scale" in self.boundaries_params and self.boundaries_params["scale"][0] < 0:
-            warnings.warn(
-                "Found lower boundary on scale parameter that is negative, setting to 0."
+            msg = (
+                "Found lower boundary on scale parameter that is negative, setting to 0"
             )
+            warnings.warn(msg)
             self.boundaries_params["scale"][0] = 0
 
     def _find_coefficients(self):
@@ -293,9 +296,9 @@ class Expression:
         self.predictors_list.sort(key=len, reverse=True)
 
     def _correct_expr_parameters(self):
-        # list of predictors and coefficients, sorted by descending length, to be sure that
-        # when removing them, will remove the good ones and not those with their short
-        # name contained in the long name of another
+        # list of predictors and coefficients, sorted by descending length, to be sure
+        # that when removing them, will remove the good ones and not those with their
+        # short name contained in the long name of another
 
         tmp_list = self.predictors_list + self.coefficients_list + ["__"]
         tmp_list.sort(key=len, reverse=True)
@@ -436,13 +439,14 @@ class Expression:
         -------
         params: dict
             Realized parameters for the given expression, coefficients and covariates;
-            to pass ``self.distrib(**params)`` or its methods.
+            to pass to the methods of ``Expression(...).distrib``, e.g.
+            ``expression.distrib.ppf(**params)``.
 
         Warnings
         --------
-        with xarrays for coefficients_values and predictors_values, the outputs will have
-        for shape first the one of the coefficient, then the one of the predictors
-        --> trying to avoid this issue with 'forced_shape'
+        with xarray objects for coefficients_values and predictors_values, the outputs
+        will have for shape first the one of the coefficient, then the one of the
+        predictors --> trying to avoid this issue with 'forced_shape'
         """
 
         # TODO:
@@ -480,7 +484,7 @@ class Expression:
         if len(shapes) > 1:
             raise ValueError("shapes of predictors must be equal")
 
-        # gather coefficients and covariates (can't use d1 | d2, does not work for dataset)
+        # gather coefficients and covariates (d1 | d2, does not work for dataset)
         locals = {**coefficients_values, **predictors_values}
 
         # evaluate parameters
@@ -543,8 +547,8 @@ class Expression:
 
         Warnings
         --------
-        with xarrays for coefficients_values and predictors_values, the outputs will have
-        the dimensions of the coefficients first, then the ones of the predictors
+        with xarrays for coefficients_values and predictors_values, the outputs will
+        have the dimensions of the coefficients first, then the ones of the predictors
         """
 
         params = self.evaluate_params(

--- a/mesmer/distrib/_first_guess.py
+++ b/mesmer/distrib/_first_guess.py
@@ -62,14 +62,15 @@ class _FirstGuess:
         Parameters
         ----------
         expression : Expression
-            Expression for the conditional distribution we want to find the first guess of.
+            Expression of the conditional distribution
 
         minimizer_options : MinimizeOptions
             Options for the fit.
 
         data_pred : numpy array 1D or 2D of shape (n_samples, n_preds)
             Predictors for the training sample. If 2D, the first dimension must be the
-            number of predictors, and the second dimension the number of samples, i.e. (n_samples, n_preds).
+            number of predictors, and the second dimension the number of samples, i.e.
+            (n_samples, n_preds).
 
         predictor_names : list of str
             Names of the predictors as named in the `expression`.
@@ -81,8 +82,8 @@ class _FirstGuess:
             Weights for the training sample. Must be 1D, i.e. (n_samples,).
 
         first_guess : numpy array, default: None
-            If provided, will use these values as first guess for the first guess, must be one value
-            per coeff in expression.coefficients_list.
+            If provided, will use these values as first guess for the first guess, must
+            be one value per coeff in expression.coefficients_list.
 
         """
 
@@ -119,8 +120,9 @@ class _FirstGuess:
                 data_pred = data_pred[:, np.newaxis]
             if data_pred.ndim > 2 or data_pred.shape[1] != n_preds:
                 raise ValueError(
-                    "data_pred must be 1D or a 2D array with shape (n_samples, n_preds), "
-                    f"n_preds from `predictor_names` is {n_preds} but shape of data_pred is {data_pred.shape}."
+                    "data_pred must be 1D or a 2D array with shape (n_samples, n_preds)"
+                    f", n_preds from `predictor_names` is {n_preds} but shape of"
+                    f" data_pred is {data_pred.shape}."
                 )
 
         # build dictionary
@@ -138,7 +140,8 @@ class _FirstGuess:
 
         # check first guess
         self.fg_coeffs = np.copy(first_guess)
-        # make sure all values are floats bc if fg_coeff[ind] = type(int) we can only put ints in it too
+        # ensure all values are floats bc if fg_coeff[ind] == type(int) it converts
+        # float to int
         self.fg_coeffs = self.fg_coeffs.astype(float)
 
         # check if the first guess is valid
@@ -185,30 +188,34 @@ class _FirstGuess:
 
         Method:
             1. Improve very first guess for the location by finding a global fit of the
-                coefficients for the location by fitting for coefficients that give location that
-                is a) close to the mean of the target samples and b) has a similar change with the
-                predictor as the target, i.e. the approximation of the first derivative of the location
-                as function of the predictors is close to the one of the target samples. The first
-                derivative is approximated by computing the quotient of the differences in the mean
-                of high (outside +1 std) samples and low (outside -1 std) samples and their
-                corresponding predictor values.
+               coefficients for the location by fitting for coefficients that give
+               location that is a) close to the mean of the target samples and b) has a
+               similar change with the predictor as the target, i.e. the approximation
+               of the first derivative of the location as function of the predictors is
+               close to the one of the target samples. The first derivative is
+               approximated by computing the quotient of the differences in the mean
+               of high (outside +1 std) samples and low (outside -1 std) samples and
+               their corresponding predictor values.
             2. Fit of the coefficients of the location, assuming that the center of the
-                distribution should be close to its location by minimizing mean squared error
-                between location and target samples.
+               distribution should be close to its location by minimizing mean squared
+               error between location and target samples.
             3. Fit of the coefficients of the scale, assuming that the deviation of the
-                distribution should be close from its scale, by minimizing mean squared error between
-                the scale and the absolute deviations of the target samples from the location.
+               distribution should be close from its scale, by minimizing mean squared
+               error between the scale and the absolute deviations of the target
+               samples from the location.
             4. Fit of remaining coefficients, assuming that the sample must be within
-                the support of the distribution, with some margin. Optimizing for coefficients
-                that yield a support such that all samples are within this support.
+               the support of the distribution, with some margin. Optimizing for
+               coefficients that yield a support such that all samples are within this
+               support.
             5. Improvement of all coefficients: better coefficients on location & scale,
-                and especially estimating those on shape. Optimized using the Negative Log
-                Likelihoog, albeit without the validity of the coefficients.
-            6. If step 5 yields invalid coefficients, fit coefficients on log-likelihood to the power n
-                to ensure that all points are within a likely
-                support of the distribution. Two possibilities tried: based on CDF or based on NLL^n. The idea is
-                to penalize very unlikely values, both works, but NLL^n works as well for
-                extremely unlikely values, that lead to division by 0 with CDF)
+               and especially estimating those on shape. Optimized using the Negative
+               Log Likelihoog, albeit without the validity of the coefficients.
+            6. If step 5 yields invalid coefficients, fit coefficients on log-likelihood
+               to the power n to ensure that all points are within a likely support of
+               the distribution. Two possibilities tried: based on CDF or based on
+               NLL^n. The idea is to give very unlikely values more weight, both works,
+               but NLL^n works as well for extremely unlikely values, that lead to
+               division by 0 with CDF).
 
         Risks for the method:
             The only risk that I identify is if the user sets boundaries on coefficients
@@ -220,18 +227,21 @@ class _FirstGuess:
             robustness, validity & flexibility.
 
             a. In theory, this problem could be solved with a global optimization. Among
-                the global optimizers available in scipy, they come with two types of
-                requirements:
-                - basinhopping: requires a first guess. Tried with first guess close from
-                    optimum, good performances, but lacks in reproductibility and
-                    stability: not reliable enough here. Ok if runs much longer.
-                - brute, differential_evolution, shgo, dual_annealing, direct: requires
-                  bounds
-                    - brute, dual_annealing, direct: performances too low & too slow
-                    - differential_evolution: lacks in reproductibility & stability
-                    - shgo: good performances with the right sampling method, relatively
-                      fast, but still adds ~10s. Highly dependent on the bounds, must not
-                      be too large.
+               the global optimizers available in scipy, they come with two types of
+               requirements:
+
+               - basinhopping: requires a first guess. Tried with first guess close from
+                 optimum, good performances, but lacks in reproductibility and
+                 stability: not reliable enough here. Ok if runs much longer.
+
+               - brute, differential_evolution, shgo, dual_annealing, direct: requires
+                 bounds
+
+                   - brute, dual_annealing, direct: performances too low & too slow
+                   - differential_evolution: lacks in reproductibility & stability
+                   - shgo: good performances with the right sampling method, relatively
+                     fast, but still adds ~10s. Highly dependent on the bounds, must not
+                     be too large.
 
                 The best global optimizer, shgo, would then require bounds that are not
                 too large.
@@ -245,21 +255,23 @@ class _FirstGuess:
                 identified...
                 This is the tricky part, here are the different elements that I used to
                 tackle this problem:
+
                 - all combinations of local & global optimizers of scipy
                 - including or not the tests for validity
                 - assessment of bounds for global optimizers based on ratio of NLL or
-                    domain of data_targ
+                  domain of data_targ
                 - first optimizations based on mean & spread
                 - brute force approach on logspace valid for parameters (not scalable
-                    with # of parameters)
-                c. The only solution that was working is inspired by what the
-                semi-analytical solution used in the original code of MESMER-X. Its
-                principle is to use fits first for location coefficients, then scale,
-                then improve.
-                The steps are described in the section Method, steps 1-5. At step 5 that
-                these coefficients are very close from the global minimum. shgo usually
-                does not bring much at the expense of speed.
-                Thus skipping global minimum unless asked.
+                  with # of parameters)
+
+            c. The only solution that was working is inspired by what the
+               semi-analytical solution used in the original code of MESMER-X. Its
+               principle is to use fits first for location coefficients, then scale,
+               then improve.
+               The steps are described in the section Method, steps 1-5. At step 5 that
+               these coefficients are very close from the global minimum. shgo usually
+               does not bring much at the expense of speed.
+               Thus skipping global minimum unless asked.
 
         Warnings
         --------
@@ -385,7 +397,8 @@ class _FirstGuess:
         #     self.fg_coeffs[fg_ind_others] = localfit_others.x
 
         # Step 5: fit coefficients using NLL (objective: improving all coefficients,
-        # necessary to get good estimates for shape parameters, and avoid some local minima)
+        # necessary to get good estimates for shape parameters, and avoid some local
+        # minima)
         localfit_nll = _optimizers._minimize(
             func=self._fg_fun_nll_no_checks,
             x0=self.fg_coeffs,
@@ -405,12 +418,14 @@ class _FirstGuess:
             )
         )
 
-        # if any of validate_coefficients test fail (e.g. any of the coefficients are out of bounds)
+        # if any of validate_coefficients test fail (e.g. any of the coefficients are
+        # out of bounds)
         if not (
             coeffs_in_bounds and params_in_bounds and params_in_support and test_proba
         ):
             # Step 6: fit on LL^n (objective: improving all coefficients, necessary
-            # to have all points within support. NB: NLL does not behave well enough here)
+            # to have all points within support. NB: NLL does not behave well enough
+            # here)
 
             # NOTE: _fg_fun_nll_cubed only helps for threshold_min_proba
 
@@ -470,7 +485,8 @@ class _FirstGuess:
         )
         diff = derivative_loc - derivative_targ
         return (
-            # change of the location with the predictor should be similar to the change of the target with the predictor
+            # change of the location with the predictor should be similar to the change
+            # of the target with the predictor
             # np.sum((derivative_loc - derivative_targ) ** 2)
             np.dot(diff, diff)
             # location should not be too far from the mean of the samples
@@ -480,8 +496,8 @@ class _FirstGuess:
     def _fg_fun_loc(self, x_loc):
         r"""
         Loss function for the location coefficients. The objective is to get a location
-        such that the center of the distribution is close to the location, thus we fit a mean
-        squared error between the location and the smoothed target samples.
+        such that the center of the distribution is close to the location, thus we fit a
+        mean squared error between the location and the smoothed target samples.
 
         The loss is computed as follows:
 
@@ -513,9 +529,10 @@ class _FirstGuess:
 
     def _fg_fun_scale(self, x_scale):
         r"""
-        Loss function for the scale coefficients. The objective is to get a scale such that
-        the deviation of the distribution is close to the scale, thus we fit a mean squared
-        error between the deviation of the (not smoothed) target samples from the location and the scale.
+        Loss function for the scale coefficients. The objective is to get a scale such
+        that the deviation of the distribution is close to the scale, thus we fit a mean
+        squared error between the deviation of the (not smoothed) target samples from
+        the location and the scale.
 
         The loss is computed as follows:
 
@@ -546,9 +563,10 @@ class _FirstGuess:
 
     def _fg_fun_others(self, x_others, margin=1.0e-3):
         """
-        Loss function for other coefficients than loc and scale. Objective is to tune parameters such
-        that target samples are within a likely range of the distribution. Instead of relying on the
-        support, we use the cumulative distribution function (CDF) to penalize unlikely samples.
+        Loss function for other coefficients than loc and scale. Objective is to tune
+        parameters such that target samples are within a likely range of the
+        distribution. Instead of relying on the support, we use the cumulative
+        distribution function (CDF) to penalize unlikely samples.
         """
         # prepare coefficients
         x = np.copy(self.fg_coeffs)

--- a/mesmer/distrib/_optimizers.py
+++ b/mesmer/distrib/_optimizers.py
@@ -61,9 +61,9 @@ def _minimize(
         options=minimize_options.options,
     )
 
-    # NOTE: observed that Powell solver is much faster, but less robust. May rarely create
-    # directly NaN coefficients or wrong local optimum => Nelder-Mead can be used at
-    # critical steps or when Powell fails.
+    # NOTE: observed that Powell solver is much faster, but less robust. May rarely
+    # create directly NaN coefficients or wrong local optimum => Nelder-Mead can be used
+    # at critical steps or when Powell fails.
 
     if second_minimizer is not None:
         second_fit = minimize(
@@ -155,10 +155,13 @@ def _crps(expression: Expression, data_targ, data_pred, data_weights, coeffs):
     try:
         import properscoring
     except ImportError:  # pragma: no cover
-        msg = "Computing the 'crps' metric requires the properscoring package to be installed"
+        msg = (
+            "Computing the 'crps' metric requires the properscoring package to be"
+            " installed"
+        )
         raise ImportError(msg)
 
-    # properscoring.crps_quadrature cannot be applied on conditional distributions, thu
+    # properscoring.crps_quadrature cannot be applied on conditional distributions, thus
     # calculating in each point of the sample, then averaging
     # NOTE: TAKES A VERY LONG TIME TO COMPUTE
     # TODO: find alternative way to compute this

--- a/mesmer/distrib/_probability_integral_transform.py
+++ b/mesmer/distrib/_probability_integral_transform.py
@@ -72,8 +72,9 @@ class ProbabilityIntegralTransform:
             not require any.
         threshold_proba : float, default: 1.e-9.
             Threshold for the probability of the sample on the original distribution.
-            The probabilities of samples outside this threshold (on both sides of the distribtion)
-            will be set to the threshold. This should avoid very unlikely values
+            The probabilities of samples outside this threshold (on both sides of the
+            distribtion) will be set to the threshold. This should avoid very unlikely
+            values
 
         Returns
         -------

--- a/mesmer/grid.py
+++ b/mesmer/grid.py
@@ -104,7 +104,8 @@ def stack_lat_lon(
     multiindex : bool, default: False
         If the new `stack_dim` should be returned as a MultiIndex.
     dropna : bool, default: True
-        Drops each 'gridcell' if any NA values are present at any point in the timeseries.
+        Drops each 'gridcell' if any NA values are present at any point in the
+        timeseries.
 
     Returns
     -------

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -82,7 +82,8 @@ def select_ar_order_scen_ens(
     Parameters
     ----------
     objs : DataTree, xr.DataArrays or dict of DataArrays
-        A DataTree, ``xr.DataArray``s or dict of ``xr.DataArray`` to estimate the auto regression order over.
+        A DataTree, ``xr.DataArray``s or dict of ``xr.DataArray`` to estimate the auto
+        regression order over.
     dim : str
         Dimension along which to determine the order.
     ens_dim : str
@@ -121,13 +122,15 @@ def _select_ar_order_scen_ens_dt(
     Parameters
     ----------
     dt : a DataTree
-        A DataTree holding one or several ``xr.Dataset`` to estimate the auto regression order over,
-        each representing one scenario, potentially with several ensemble members along `ens_dim`.
-        Each ``xr.DataSet`` should only hold one variable, the one for which to estimate the autoregression.
+        A DataTree holding one or several ``xr.Dataset`` to estimate the auto regression
+        order over, each representing one scenario, potentially with several ensemble
+        members along `ens_dim`. Each ``xr.DataSet`` should only hold one variable, the
+        one for which to estimate the autoregression.
     dim : str
         Dimension along which to determine the order.
     ens_dim : str
-        Dimension name of the ensemble members. Must be the same for all scenarios and have coordinates if not None.
+        Dimension name of the ensemble members. Must be the same for all scenarios and
+        have coordinates if not None.
     maxlag : int
         The maximum lag to consider.
     ic : {'aic', 'hqic', 'bic'}, default 'bic'
@@ -186,13 +189,16 @@ def fit_auto_regression_scen_ens(
     Parameters
     ----------
     obj : DataTree, xr.DataArrays or dict of DataArrays
-        A ``DataTree`` holding one or several ``xr.Dataset``, ``xr.DataArray``s, or dict of ``xr.DataArray``s to estimate the auto regression order over,
-        each representing one scenario, potentially with several ensemble members along `ens_dim`.
-        If a ``DataTree``, each ``xr.Dataset`` should only hold one variable, the one for which to estimate the autoregression.
+        A ``DataTree`` holding one or several ``xr.Dataset``, ``xr.DataArray`` objects,
+        or dict of ``xr.DataArray`` objects to estimate the auto regression order over,
+        each representing one scenario, potentially with several ensemble members along
+        `ens_dim`. If a ``DataTree``, each ``xr.Dataset`` should only hold one variable,
+        the one for which to estimate the autoregression.
     dim : str
         Dimension along which to fit the auto regression (often time).
     ens_dim : str
-        Dimension name of the ensemble members, None if no ensemble is provided.  Must be the same for all scenarios and have coordinates if not None.
+        Dimension name of the ensemble members, None if no ensemble is provided.  Must
+        be the same for all scenarios and have coordinates if not None.
     lags : int
         The number of lags to include in the model.
 
@@ -204,10 +210,11 @@ def fit_auto_regression_scen_ens(
 
     Notes
     -----
-    If `ens_dim` is not `None`, calculates the mean auto regression first over all ensemble
-    members and then over scenarios. This is done to weight scenarios equally, consequently
-    ensemble members are not weighted equally, if the number of members differs between scenarios.
-    If no ensemble members are provided, the mean is calculated over scenarios only.
+    If `ens_dim` is not `None`, calculates the mean auto regression first over all
+    ensemble members and then over scenarios. This is done to weight scenarios equally,
+    consequently ensemble members are not weighted equally, if the number of members
+    differs between scenarios. If no ensemble members are provided, the mean is
+    calculated over scenarios only.
     """
     dt = _scen_ens_inputs_to_dt(objs)
     return _fit_auto_regression_scen_ens_dt(dt, dim, ens_dim, lags)
@@ -223,13 +230,15 @@ def _fit_auto_regression_scen_ens_dt(
     Parameters
     ----------
     dt : a DataTree
-        A ``DataTree`` holding one or several ``xr.Dataset`` to estimate the auto regression order over,
-        each representing one scenario, potentially with several ensemble members along `ens_dim`.
-        Each ``xr.DataSet`` should only hold one variable, the one for which to estimate the autoregression.
+        A ``DataTree`` holding one or several ``xr.Dataset`` to estimate the auto
+        regression order over, each representing one scenario, potentially with several
+        ensemble members along `ens_dim`. Each ``xr.DataSet`` should only hold one
+        variable, the one for which to estimate the autoregression.
     dim : str
         Dimension along which to fit the auto regression (often time).
     ens_dim : str
-        Dimension name of the ensemble members, None if no ensemble is provided.  Must be the same for all scenarios and have coordinates if not None.
+        Dimension name of the ensemble members, None if no ensemble is provided. Must be
+        the same for all scenarios and have coordinates if not None.
     lags : int
         The number of lags to include in the model.
 
@@ -241,10 +250,11 @@ def _fit_auto_regression_scen_ens_dt(
 
     Notes
     -----
-    If `ens_dim` is not `None`, calculates the mean auto regression first over all ensemble
-    members and then over scenarios. This is done to weight scenarios equally, consequently
-    ensemble members are not weighted equally, if the number of members differs between scenarios.
-    If no ensemble members are provided, the mean is calculated over scenarios only.
+    If `ens_dim` is not `None`, calculates the mean auto regression first over all
+    ensemble members and then over scenarios. This is done to weight scenarios equally,
+    consequently ensemble members are not weighted equally, if the number of members
+    differs between scenarios. If no ensemble members are provided, the mean is
+    calculated over scenarios only.
     """
 
     ar_params_scen = map_over_datasets(
@@ -401,7 +411,8 @@ def draw_auto_regression_uncorrelated(
         - variance
 
     time : int | DataArray | Index
-        Defines the number of auto-correlated samples to draw and possibly its coordinates.
+        Defines the number of auto-correlated samples to draw and possibly its
+        coordinates.
 
         - ``int``: defines the number of time steps to draw
         - ``DataArray`` or ``Index``: defines the coordinates and its length the number
@@ -412,8 +423,9 @@ def draw_auto_regression_uncorrelated(
         See ``time`` for details.
 
     seed : int | xr.DataTree
-        Seed used to initialize the pseudo-random number generator. Can be an int or a xr.DataTree that
-        contains Datasets with a single variable "seed" with the seed value, to draw samples for multiple scenarios.
+        Seed used to initialize the pseudo-random number generator. Can be an int or a
+        xr.DataTree that contains Datasets with a single variable "seed" with the seed
+        value, to draw samples for multiple scenarios.
 
     buffer : int
         Buffer to initialize the autoregressive process (ensures that start at 0 does
@@ -462,9 +474,11 @@ def _draw_auto_regression_uncorrelated(
         or ar_params.coeffs.ndim != 1
         or ar_params.variance.ndim != 0
     ):
-        raise ValueError(
-            "``_draw_auto_regression_uncorrelated`` can currently only handle single points"
+        msg = (
+            "``draw_auto_regression_uncorrelated`` can currently only handle single "
+            "points"
         )
+        raise ValueError(msg)
 
     # _draw_ar_corr_xr_internal expects 2D arrays
     ar_params = ar_params.expand_dims("__gridpoint__")
@@ -517,7 +531,8 @@ def draw_auto_regression_correlated(
         The (co-)variance array. Must be symmetric and positive-semidefinite.
 
     time : int | DataArray | Index
-        Defines the number of auto-correlated samples to draw and possibly its coordinates.
+        Defines the number of auto-correlated samples to draw and possibly its
+        coordinates.
 
         - ``int``: defines the number of time steps to draw
         - ``DataArray`` or ``Index``: defines the coordinates and its length the number
@@ -528,8 +543,9 @@ def draw_auto_regression_correlated(
         See ``time`` for details.
 
     seed : int | xr.DataTree
-        Seed used to initialize the pseudo-random number generator. Can be an int or a xr.DataTree that
-        contains Datasets with a single variable "seed" with the seed value, used to draw samples for multiple scenarios.
+        Seed used to initialize the pseudo-random number generator. Can be an int or a
+        xr.DataTree that contains Datasets with a single variable "seed" with the seed
+        value, used to draw samples for multiple scenarios.
 
     buffer : int
         Buffer to initialize the autoregressive process (ensures that start at 0 does
@@ -731,8 +747,12 @@ def _draw_innovations_correlated_np(
         if "Matrix is not positive definite" in str(e):
             w, v = np.linalg.eigh(covariance)
             cov = scipy.stats.Covariance.from_eigendecomposition((w, v))
+            msg = (
+                "Covariance matrix is not positive definite, using eigh instead of "
+                "cholesky."
+            )
             warnings.warn(
-                "Covariance matrix is not positive definite, using eigh instead of cholesky.",
+                msg,
                 LinAlgWarning,
             )
 
@@ -765,7 +785,8 @@ def fit_auto_regression(
     -------
     :obj:`xr.Dataset`
         Dataset containing the estimated parameters of the ``intercept``, the AR
-        ``coeffs``, the ``variance`` of the residuals and the number of observations ``nobs``.
+        ``coeffs``, the ``variance`` of the residuals and the number of observations
+        ``nobs``.
     """
 
     if not isinstance(data, xr.DataArray):
@@ -842,32 +863,13 @@ def fit_auto_regression_monthly(
     This is based on the assumption that e.g. June depends on May differently
     than July on June. The auto regression is fit along `time_dim`.
 
-    A cyclo-stationary AR(1) process is defined as follows:
-
-    .. math::
-
-        \\mathbf{X}_{t, \\tau} = \\alpha_{0, \\tau} + \\alpha_{1, \\tau} \\mathbf{X}_{t, \\tau -1}
-        + \\epsilon_{t, \\tau}
-
-
-    where :math:`\\tau \\in \\{1, \\ldots, N\\}` counts the seasons of some seasonal cycle, here the
-    months of a year :math:`(N=12)` and :math:`t` counts the repetitions of this seasonal cycle,
-    here the years. Here :math:`\\epsilon` is a white noise process, i.e. :math:`\\epsilon \\sim N(0, \\sigma^2)`.
-    The covariance matrix of the driving white noise process should be estimated on the residuals of the AR(1)
-    process. The residuals are returned here and should be passed to
-    :func:`find_localized_empirical_covariance_monthly <mesmer.stats.find_localized_empirical_covariance_monthly>`.
-
-    For more information refer to Storch and Zwiers (1999) Chapter 10.3.8 [1].
-
-    [1] Storch H von, Zwiers FW. Statistical Analysis in Climate Research.
-        **Cambridge University Press; 1999,** `DOI:10.1017/CBO9780511612336 <https://doi.org/10.1017/CBO9780511612336>`_.
-
 
     Parameters
     ----------
     monthly_data : ``xr.DataArray``
-        A ``xr.DataArray`` to estimate the auto regression over, must contain `time_dim` and can have more dims,
-        for example a gridcell and/or a member dim. Each month has a value.
+        A ``xr.DataArray`` to estimate the auto regression over, must contain `time_dim`
+        and can have more dims, for example a gridcell and/or a member dim. Each month
+        has a value.
     time_dim : str
         Name of the time dimension (dimension along which to fit the auto regression).
 
@@ -880,8 +882,40 @@ def fit_auto_regression_monthly(
         - the ``slope`` for each month and
         - the ``residuals`` (needed for the estimation of the covariance matrices).
 
-        ``intercept`` and ``slope`` have `"month"` and the additional dims of the input data as dimensions,
-        the residuals have `time_dim` and the additional dims of the input data as dimensions.
+        ``intercept`` and ``slope`` have `"month"` and the additional dims of the input
+        data as dimensions, the residuals have `time_dim` and the additional dims of the
+        input data as dimensions.
+
+    Notes
+    -----
+
+    A cyclo-stationary AR(1) process is defined as follows:
+
+    .. math::
+
+        \\mathbf{X}_{t, \\tau} = \\alpha_{0, \\tau} + \\alpha_{1, \\tau}
+        \\mathbf{X}_{t, \\tau -1} + \\epsilon_{t, \\tau}
+
+
+    where :math:`\\tau \\in \\{1, \\ldots, N\\}` counts the seasons of some seasonal
+    cycle, here the months of a year :math:`(N=12)` and :math:`t` counts the repetitions
+    of this seasonal cycle, here the years. Here :math:`\\epsilon` is a white noise
+    process, i.e. :math:`\\epsilon \\sim N(0, \\sigma^2)`. The covariance matrix of the
+    driving white noise process should be estimated on the residuals of the AR(1)
+    process. The residuals are returned here and should be passed to
+    :func:`find_localized_empirical_covariance_monthly
+    <mesmer.stats.find_localized_empirical_covariance_monthly>`.
+
+    For more information refer to Storch and Zwiers (1999) Chapter 10.3.8 [1]_.
+
+    References
+    ----------
+
+    .. [1] Storch H von, Zwiers FW. Statistical Analysis in Climate Research.
+        **Cambridge University Press; 1999,** `DOI:10.1017/CBO9780511612336
+        <https://doi.org/10.1017/CBO9780511612336>`_.
+
+
     """
     _check_dataarray_form(monthly_data, "monthly_data", required_coords=time_dim)
     monthly_groups = monthly_data.groupby(f"{time_dim}.month")
@@ -967,9 +1001,9 @@ def draw_auto_regression_monthly(
     realisation_dim: str = "realisation",
 ) -> xr.Dataset:
     """draw time series of a cyclo-stationary auto-regressive process of lag one (AR(1))
-    using individual parameters for each month including spatially-correlated innovations.
-    For more information on the cyclo-stationary AR(1) process please refer to
-    :func:`fit_auto_regression_monthly <mesmer.stats.fit_auto_regression_monthly>`.
+    using individual parameters for each month including spatially-correlated
+    innovations. For more information on the cyclo-stationary AR(1) process please refer
+    to :func:`fit_auto_regression_monthly <mesmer.stats.fit_auto_regression_monthly>`.
 
     Parameters
     ----------
@@ -992,8 +1026,9 @@ def draw_auto_regression_monthly(
     n_realisations : int
         The number of realisations to draw.
     seed : int | xr.DataTree
-        Seed used to initialize the pseudo-random number generator. Can be an int or a xr.DataTree that
-        contains Datasets with a single variable "seed" with the seed value, used to draw samples for multiple scenarios.
+        Seed used to initialize the pseudo-random number generator. Can be an int or a
+        xr.DataTree that contains Datasets with a single variable "seed" with the seed
+        value, used to draw samples for multiple scenarios.
     buffer : int
         Buffer to initialize the autoregressive process (ensures that start at 0 does
         not influence overall result).
@@ -1004,9 +1039,10 @@ def draw_auto_regression_monthly(
 
     Returns
     -------
-    result : xr.Dataset with samples of shape (n_realisations, n_timesteps, n_gridpoints)
+    result : xr.Dataset
         Predicted time series of the specified AR(1) process including spatially
-        correlated innovations. The array has shape n_timesteps x n_gridpoints.
+        correlated innovations. The array has shape n_realisations x n_timesteps
+        x n_gridpoints.
 
     """
 
@@ -1131,11 +1167,13 @@ def _draw_auto_regression_monthly_np(
     slope : np.array of shape (12, gridpoints)
         The slope of the AR(1) process for each month.
     covariance: np.array of shape (12, n_gridpoints, n_gridpoints)
-        The covariance matrix representing spatial correlation between gridpoints for each month.
+        The covariance matrix representing spatial correlation between gridpoints for
+        each month.
     n_samples : int
         The number of realisations to draw.
     n_ts : int
-        The number of time steps to draw (i.e. the number of months in the whole timeseries).
+        The number of time steps to draw (i.e. the number of months in the whole
+        timeseries).
     buffer : int
         Buffer to initialize the autoregressive process (ensures that start at 0 does
         not influence overall result). The number given is used for every month such
@@ -1144,7 +1182,8 @@ def _draw_auto_regression_monthly_np(
     Returns
     -------
     out : np.array of shape (n_samples, n_ts, n_gridpoints)
-        Predicted time series of the specified AR(1) including spatially correlated innovations.
+        Predicted time series of the specified AR(1) including spatially correlated
+        innovations.
     """
     intercept = np.asarray(intercept)
     covariance = np.atleast_3d(covariance)

--- a/mesmer/stats/_gaspari_cohn.py
+++ b/mesmer/stats/_gaspari_cohn.py
@@ -67,6 +67,9 @@ def gaspari_cohn(
 
     - r = d / L, with d = geographical distance in km, L = localisation radius in km
 
+    References
+    ----------
+
     .. [1] Gaspari, G. and Cohn, S.E. (1999), Construction of correlation functions in
        two and three dimensions. Q.J.R. Meteorol. Soc., 125: 723-757.
        https://doi.org/10.1002/qj.49712555417

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -294,15 +294,18 @@ def fit_harmonic_model(
     Parameters
     ----------
     yearly_predictor : xr.DataArray
-        Yearly values used as predictors, containing one value per year. Contains `time_dim`
-        and possibly additional dimensions for example for gridcells or members.
+        Yearly values used as predictors, containing one value per year. Contains
+        `time_dim` and possibly additional dimensions for example for gridcells or
+        members.
     monthly_target : xr.DataArray
         Monthly values to fit to, containing one value per month, for every year in
-        `yearly_predictor` (starting with January). So `n_months` = 12 :math:`\\cdot` `n_years`.
-        Must contain `time_dim` and possibly additional dimensions as `yearly_predictor`.
+        `yearly_predictor` (starting with January). So `n_months` = 12 :math:`\\cdot`
+        `n_years`. Must contain `time_dim` and possibly additional dimensions as
+        `yearly_predictor`.
     max_order : Integer, default 6
-        Maximum order of Fourier Series to fit for. Default is 6 since highest meaningful
-        maximum order is sample_frequency/2, i.e. 12/2 to fit for monthly data.
+        Maximum order of Fourier Series to fit for. Default is 6 since highest
+        meaningful maximum order is sample_frequency/2, i.e. 12/2 to fit for monthly
+        data.
     time_dim: str, default: "time"
         Name of the time dimension on `yearly_predictor` and `monthly_target`.
 

--- a/mesmer/stats/_linear_regression.py
+++ b/mesmer/stats/_linear_regression.py
@@ -82,17 +82,19 @@ class LinearRegression:
         Parameters
         ----------
         predictors : dict of xr.DataArray | xr.Dataset | xr.DataTree
-            Either a dict of ``DataArray`` objects used as predictors with predictor names as keys,
-            or a ``xr.Dataset`` where each predictor is a ``DataArray``. Each predictor must be 1D
-            and contain ``dim``.
-            One can also make predictions for multiple trajectories/scenarios at once, in this case,
-            pass a ``xr.DataTree`` where each leaf holds a ``Dataset`` with the predictors for a scenario.
+            Either a dict of ``DataArray`` objects used as predictors with predictor
+            names as keys, or a ``xr.Dataset`` where each predictor is a ``DataArray``.
+            Each predictor must be 1D and contain ``dim``.
+            One can also make predictions for multiple trajectories/scenarios at once,
+            in this case, pass a ``xr.DataTree`` where each leaf holds a ``Dataset``
+            with the predictors for a scenario.
         exclude : str or set of str, default: None
             Set of variables to exclude in the prediction. May include ``"intercept"``
             to initialize the prediction with 0. Mutually exclusive with ``only``.
         only :  str or set of str, default: None
             Set of variables to include in the prediction. May include ``"intercept"``
-            otherwise the prediction is initialized with 0. Mutually exclusive with ``exclude``.
+            otherwise the prediction is initialized with 0. Mutually exclusive with
+            ``exclude``.
 
         Returns
         -------

--- a/mesmer/stats/_localized_covariance.py
+++ b/mesmer/stats/_localized_covariance.py
@@ -47,14 +47,17 @@ def adjust_covariance_ar1(
     - This formula is wrong in [1]_. However, it is correct in the code. See also [2]_
       and [3]_.
 
-    .. [1] Beusch, L., Gudmundsson, L., and Seneviratne, S. I.: Emulating Earth system model
-       temperatures with MESMER: from global mean temperature trajectories to grid-point-
-       level realizations on land, Earth Syst. Dynam., 11, 139–159,
+    References
+    ----------
+
+    .. [1] Beusch, L., Gudmundsson, L., and Seneviratne, S. I.: Emulating Earth system
+       model temperatures with MESMER: from global mean temperature trajectories to
+       grid-point-level realizations on land, Earth Syst. Dynam., 11, 139-159,
        https://doi.org/10.5194/esd-11-139-2020, 2020.
 
-    .. [2] Humphrey, V. and Gudmundsson, L.: GRACE-REC: a reconstruction of climate-driven
-       water storage changes over the last century, Earth Syst. Sci. Data, 11, 1153–1170,
-       https://doi.org/10.5194/essd-11-1153-2019, 2019.
+    .. [2] Humphrey, V. and Gudmundsson, L.: GRACE-REC: a reconstruction of climate-
+       driven water storage changes over the last century, Earth Syst. Sci. Data, 11,
+       1153-1170, https://doi.org/10.5194/essd-11-1153-2019, 2019.
 
     .. [3] Cressie, N. and Wikle, C. K.: Statistics for spatio-temporal data, John Wiley
        & Sons, Hoboken, New Jersey, USA, 2011.
@@ -164,16 +167,17 @@ def find_localized_empirical_covariance_monthly(
     k_folds: int,
     equal_dim_suffixes: tuple[str, str] = ("_i", "_j"),
 ) -> xr.Dataset:
-    """determine localized empirical covariance by cross validation for each month. `data`
-    should be the residuals of the cyclo-stationary AR(1) process, see
-    :func:`fit_auto_regression_monthly <mesmer.stats.fit_auto_regression_monthly>`. Note that here,
-    no additional adjustment is necessary.
+    """determine localized empirical covariance by cross validation for each month.
+
+    `data` should be the residuals of the cyclo-stationary AR(1) process, see
+    :func:`fit_auto_regression_monthly <mesmer.stats.fit_auto_regression_monthly>`. Note
+    that here, no additional adjustment is necessary.
 
     Parameters
     ----------
     data : xr.DataArray
-        2D DataArray with monthly data to calculate the covariance for (residuals of the AR(1)
-        process).
+        2D DataArray with monthly data to calculate the covariance for (residuals of the
+        AR(1) process).
     weights : xr.DataArray
         Weights for the individual samples.
     localizer : dict of DataArray
@@ -235,8 +239,9 @@ def _find_localized_empirical_covariance_np(data, weights, localizer, k_folds):
         Weights for the individual samples.
     localizer : dict of array-like
         Dictionary containing the localization radii as keys and the localization matrix
-        as values. The localization must be 2D and of shape nr_gridpoints x nr_gridpoints.
-        Currently only the Gaspari-Cohn localizer is implemented in MESMER.
+        as values. The localization must be 2D and of shape nr_gridpoints x
+        nr_gridpoints. Currently only the Gaspari-Cohn localizer is implemented in
+        MESMER.
     k_folds : int
         Number of folds to use for cross validation.
 

--- a/mesmer/stats/_power_transformer.py
+++ b/mesmer/stats/_power_transformer.py
@@ -28,7 +28,8 @@ def _yeo_johnson_transform_np(data, lambdas):
             :math:`X_{trans} = - log(-X + 1)`
 
     Note that :math:`X` and :math:`X_{trans}`have the same sign.
-    Also see `sklearn's PowerTransformer <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.PowerTransformer.html>`_
+    Also see `sklearn's PowerTransformer
+    <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.PowerTransformer.html>`_
     """
 
     return _yeo_johnson_transform_optimized(data)(lambdas)
@@ -132,8 +133,9 @@ def logistic_lambda_function(
     Parameters
     ----------
     coeffs : ndarray of shape (2,)
-        Coefficients for the logistic function. The first coefficient (:math:`\xi_0`) controls the intercept,
-        the second coefficient (:math:`\xi_1`) controls the slope.
+        Coefficients for the logistic function. The first coefficient (:math:`\xi_0`)
+        controls the intercept, the second coefficient (:math:`\xi_1`) controls the
+        slope.
     local_yearly_T : ndarray of shape (n_years,)
         Yearly values of one gridcell and month used as predictor
         for lambda.
@@ -149,8 +151,7 @@ def logistic_lambda_function(
 def constant_lambda_function(
     coeffs: np.ndarray, local_yearly_T: np.ndarray
 ) -> np.ndarray:
-    r"""Use logistic function to calculate lambda depending on the local yearly
-    values. The function is defined as
+    r"""Use a constant for lambda. The function is defined as
 
     .. math::
 
@@ -164,6 +165,10 @@ def constant_lambda_function(
     local_yearly_T : ndarray of shape (n_years,)
         Unused.
 
+    Notes
+    -----
+    ``local_yearly_T`` is passed for consistency.
+
     Returns
     -------
     lambdas : ndarray of float of shape (n_years,)
@@ -176,7 +181,7 @@ class YeoJohnsonTransformer:
     def __init__(self, name: Literal["constant", "logistic"]):
         """Apply a Yeo-Johnson Power Transformer to make data more Gaussian
 
-        In contrast to sklearn's PowerTransformer makes the parameter ``lambdas``
+        In contrast to sklearn's PowerTransformer the parameter ``lambdas`` can be
         dependent on a covariate.
 
         Parameters
@@ -185,8 +190,10 @@ class YeoJohnsonTransformer:
             Name of the covariate function. See the ``covariate_function`` of the
             returned object for details. Possible are
 
-            * ``"logistic"``:  logistic function, see ``logistic_lambda_function`` for
-              details
+            * ``"constant"``:  constant function, see :py:func:`constant_lambda_function()
+              <mesmer.stats._power_transformer.constant_lambda_function>` for details.
+            * ``"logistic"``:  logistic function, see :py:func:`logistic_lambda_function
+              <mesmer.stats._power_transformer.logistic_lambda_function>` for details.
         """
 
         if name == "logistic":
@@ -218,7 +225,7 @@ class YeoJohnsonTransformer:
         if lambda_function_name is not None and lambda_function_name != self.name:
             msg = (
                 f"Passed `lambda_coeffs` fitted on a '{lambda_function_name}' lambda"
-                f" function, but currently '{self.name}' is selected as lambda function."
+                f" function, but currently '{self.name}' is selected as lambda function"
             )
             raise ValueError(msg)
 
@@ -258,8 +265,8 @@ class YeoJohnsonTransformer:
         data_log1p_sum = data_log1p.sum()
 
         def _neg_log_likelihood(coeffs):
-            """Return the negative log likelihood of the observed local monthly residuals
-            as a function of lambda.
+            """Return the negative log likelihood of the observed local monthly
+            residuals as a function of lambda.
             """
             lambdas = self.lambda_function(coeffs, yearly_pred)
 
@@ -294,14 +301,16 @@ class YeoJohnsonTransformer:
         time_coords: None | xr.DataArray = None,
     ) -> xr.DataArray:
         """function that relates fitted coefficients and the yearly predictor
-        to the lambdas. See :meth:`lambda_function <mesmer.stats.YeoJohnsonTransformer.lambda_function>`.
+        to the lambdas. See :meth:`lambda_function
+        <mesmer.stats.YeoJohnsonTransformer.lambda_function>`.
 
         Parameters
         ----------
         lambda_coeffs : ``xr.DataArray``
             The parameters of the power transformation for each month along "month",
             with coefficients along "coeff" calculated using ``fit_yeo_johnson_transform``.
-            Can have additional dimensions, like for example a gridcell or member dimension.
+            Can have additional dimensions, like for example a gridcell or member
+            dimension.
         yearly_pred : ``xr.DataArray``
             yearly values used as predictors for the lambdas, contains dims for time
             and possibly additional dims as for lambda_coeffs.
@@ -362,24 +371,26 @@ class YeoJohnsonTransformer:
         time_dim: str = "time",
     ) -> xr.DataArray:
         """
-        estimate the optimal coefficients for the parameters :math:`\\lambda` for each gridcell,
-        to normalize monthly residuals conditional on yearly predictor. Here, :math:`\\lambda`
-        depends on the yearly predictor according to :meth:`lambda_function <mesmer.stats.YeoJohnsonTransformer.lambda_function>`.
+        estimate the optimal coefficients for the parameters :math:`\\lambda` for each
+        gridcell, to normalize monthly residuals conditional on yearly predictor. Here,
+        :math:`\\lambda` depends on the yearly predictor according to
+        :meth:`lambda_function <mesmer.stats.YeoJohnsonTransformer.lambda_function>`.
         The optimal coefficients for the lambda parameters for minimizing skewness are
         estimated on each gridcell independently using maximum likelihood.
 
         Parameters
         ----------
         yearly_pred : ``xr.DataArray``
-            yearly values used as predictors for the lambdas, must contain time_dim but can have
-            additional dimensions for example gridcells or members.
+            yearly values used as predictors for the lambdas, must contain time_dim but
+            can have additional dimensions for example gridcells or members.
         monthly_residuals : ``xr.DataArray``
-            Monthly residuals after removing harmonic model fits, used to fit for the optimal
-            transformation parameters (lambdas). Has time_dim which is of length ``yearly_pred[time_dim].size * 12``
-            and can also contain the same additional dimensions as yearly_pred.
+            Monthly residuals after removing harmonic model fits, used to fit for the
+            optimal transformation parameters (lambdas). Has time_dim which is of length
+            ``yearly_pred[time_dim].size * 12`` and can also contain the same additional
+            dimensions as yearly_pred.
         time_dim : str, default: "time"
-            Name of the time dimension in the input data used to align monthly residuals and
-            yearly predictor data (needs to be the same in both).
+            Name of the time dimension in the input data used to align monthly residuals
+            and yearly predictor data (needs to be the same in both).
 
         Returns
         -------
@@ -434,30 +445,33 @@ class YeoJohnsonTransformer:
     ) -> xr.Dataset:
         """
         transform `monthly_residuals` following Yeo-Johnson transformer
-        with parameters :math:`\\lambda`, fit with :func:`fit_yeo_johnson_transform <mesmer.stats.fit_yeo_johnson_transform>`.
+        with parameters :math:`\\lambda`, fit with :func:`fit_yeo_johnson_transform
+        <mesmer.stats.fit_yeo_johnson_transform>`.
 
         Parameters
         ----------
         yearly_pred : ``xr.DataArray``
-            yearly values used as predictors for the lambdas, must contain time_dim but can have
-            additional dimensions for example gridcells or members.
+            yearly values used as predictors for the lambdas, must contain time_dim but
+            can have additional dimensions for example gridcells or members.
         monthly_residuals : ``xr.DataArray``
             Monthly residuals after removing harmonic model fits, used to fit for the
-            optimal transformation parameters (lambdas). Has time_dim which is of length len(yearly_pred[time_dim]) * 12
-            and can also contain the same additional dimensions as yearly_pred.
+            optimal transformation parameters (lambdas). Has time_dim which is of length
+            len(yearly_pred[time_dim]) * 12 and can also contain the same additional
+            dimensions as yearly_pred.
         lambda_coeffs : ``xr.DataArray``
             DataArray containing the estimated coefficients needed to compute
-            lambda with dimensions "month", "coeff" and additional dims on inputs. Calculated using
-            :meth:`lambda_function <mesmer.stats.YeoJohnsonTransformer.lambda_function>`.
+            lambda with dimensions "month", "coeff" and additional dims on inputs.
+            Calculated using :meth:`lambda_function
+            <mesmer.stats.YeoJohnsonTransformer.lambda_function>`.
         time_dim : str, default: "time"
-            Name of the time dimension in the input data used to align monthly residuals and
-            yearly predictor data (needs to be the same in both).
+            Name of the time dimension in the input data used to align monthly residuals
+            and yearly predictor data (needs to be the same in both).
 
         Returns
         -------
         :obj:`xr.Dataset`
-            Dataset containing the transformed monthly residuals and the parameters of the
-            power transformation for each gridcell.
+            Dataset containing the transformed monthly residuals and the parameters of
+            the power transformation for each gridcell.
 
         Notes
         -----
@@ -473,7 +487,8 @@ class YeoJohnsonTransformer:
                 :math:`X_{trans} = - log(-X + 1)`
 
         Note that :math:`X` and :math:`X_{trans}` have the same sign.
-        Also see `sklearn's PowerTransformer <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.PowerTransformer.html>`_.
+        Also see `sklearn's PowerTransformer
+        <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.PowerTransformer.html>`_.
         """
         _check_dataarray_form(
             monthly_residuals, name="monthly_residuals", required_coords=time_dim
@@ -523,18 +538,20 @@ class YeoJohnsonTransformer:
         Parameters
         ----------
         yearly_pred : ``xr.DataArray``
-            yearly values used as predictors for the lambdas, must contain time_dim but can have
-            additional dimensions for example gridcells or members.
+            yearly values used as predictors for the lambdas, must contain time_dim but
+            can have additional dimensions for example gridcells or members.
         monthly_residuals : ``xr.DataArray``
-            The data to be transformed back to the original scale. Has time_dim which is of length ``yearly_pred[time_dim].size * 12``
-            and can also contain the same additional dimensions as yearly_pred.
+            The data to be transformed back to the original scale. Has time_dim which is
+            of length ``yearly_pred[time_dim].size * 12`` and can also contain the same
+            additional dimensions as yearly_pred.
         lambda_coeffs : ``xr.DataArray``
             DataArray containing the estimated coefficients needed to compute
-            lambda with dimensions "month", "coeff" and additional dims on inputs. Calculated using
-            :meth:`lambda_function <mesmer.stats.YeoJohnsonTransformer.lambda_function>`.
+            lambda with dimensions "month", "coeff" and additional dims on inputs.
+            Calculated using :meth:`lambda_function
+            <mesmer.stats.YeoJohnsonTransformer.lambda_function>`.
         time_dim : str, default: "time"
-            Name of the time dimension in the input data used to align monthly residuals and
-            yearly predictor data (needs to be the same in both).
+            Name of the time dimension in the input data used to align monthly residuals
+            and yearly predictor data (needs to be the same in both).
 
         Returns
         -------

--- a/mesmer/stats/_smoothing.py
+++ b/mesmer/stats/_smoothing.py
@@ -62,7 +62,7 @@ def lowess(
         mesmer.stats.lowess(data, "time", frac=0.3).mean("cells")
     """
 
-    from statsmodels.nonparametric.smoothers_lowess import lowess
+    from statsmodels.nonparametric.smoothers_lowess import lowess as sm_lowess
 
     if not isinstance(dim, str):
         raise ValueError("Can only pass a single dimension.")
@@ -78,7 +78,8 @@ def lowess(
 
         if n_steps > n_coords:
             raise ValueError(
-                f"``n_steps`` ({n_steps}) cannot be be larger than the length of '{dim}' ({n_coords})"
+                f"``n_steps`` ({n_steps}) cannot be be larger than the length of"
+                f" '{dim}' ({n_coords})"
             )
 
         frac = n_steps / n_coords
@@ -119,7 +120,7 @@ def lowess(
             return da
 
         out = xr.apply_ufunc(
-            lowess,
+            sm_lowess,
             da,
             x,
             input_core_dims=[[dim], [dim]],

--- a/mesmer/volc.py
+++ b/mesmer/volc.py
@@ -61,9 +61,9 @@ def _load_and_align_strat_aod_obs(
         aod_beg, aod_end = aod.time[0].dt.year.item(), aod.time[-1].dt.year.item()
         if beg < aod_beg or end > aod_end:
             msg = (
-                f"Time period of passed array ({beg}-{end}) exceeds time of stratospheric"
-                f" aerosol optical depth observations ({aod_beg}-{aod_end}). Do you need"
-                " to pass ``hist_period``?"
+                f"Time period of passed array ({beg}-{end}) exceeds time of"
+                f" stratospheric aerosol optical depth observations ({aod_beg}-"
+                f"{aod_end}). Do you need to pass ``hist_period``?"
             )
             raise ValueError(msg)
 
@@ -96,7 +96,8 @@ def fit_volcanic_influence(
         influence from.
     hist_period : slice | None
         Slice object indicating the years of the historical period. E.g.
-        ``slice("1850", "2014")``.  If None uses the entire time period of ``tas_residuals``.
+        ``slice("1850", "2014")``.  If None uses the entire time period of
+        ``tas_residuals``.
     dim : str, default: "time"
         Dimension along which to estimate the volcanic influence.
     version : str, default: "2022"

--- a/mesmer/weighted.py
+++ b/mesmer/weighted.py
@@ -153,34 +153,43 @@ def equal_scenario_weights_from_datatree(
     dt: xr.DataTree, ens_dim: str = "member", time_dim: str = "time"
 ) -> xr.DataTree:
     """
-    Create a DataTree isomorphic to ``dt``, holding the weights for each scenario to weight the ensemble members of each
-    scenario such that each scenario contributes equally to some fitting procedure.
-    The weight of each member = 1 / number of members in the scenario, so weights = 1 / ds[ens_dim].size.
+    Create a DataTree isomorphic to ``dt``, holding the weights for each scenario to
+    weight the ensemble members of each scenario such that each scenario contributes
+    equally to some fitting procedure. The weight of each member = 1 / number of members
+    in the scenario, so weights = 1 / ds[ens_dim].size.
 
     Thus, if all scenarios have the same number of members, all weights will be equal.
     If one scenario has more members than the others, its weights will be smaller.
-    Weights are always along the time and ens dim, if there are more dimensions in a dataset, they will be dropped.
+    Weights are always along the time and ens dim, if there are more dimensions in a
+    dataset, they will be dropped.
 
     Parameters:
     -----------
     dt : DataTree
-        DataTree holding the ``xr.Datasets`` for which the weights should be created. Each dataset must have at least
-        ens_dim and time_dim as dimensions, but can have more dimensions.
-    ens_dim : str
-        Name of the dimension along which the weights should be created. Default is "member".
-    time_dim : str
-        Name of the time dimension, will be filled with equal values for each ensemble member. Default is "time".
+        DataTree holding the ``xr.Datasets`` for which the weights should be created.
+        Each dataset must have at least ens_dim and time_dim as dimensions, but can have
+        more dimensions.
+    ens_dim : str, default: "member"
+        Name of the dimension along which the weights should be created.
+    time_dim : str, default: "time"
+        Name of the time dimension, will be filled with equal values for each ensemble
+        member.
 
     Returns:
     --------
     DataTree
-        DataTree holding the weights for each scenario isomorphic to dt, where each dataset has dimensions (time_dim, ens_dim).
+        DataTree holding the weights for each scenario isomorphic to dt, where each
+        dataset has dimensions (time_dim, ens_dim).
 
     Example:
     --------
-    >>> dt = DataTree()
-    >>> dt["ssp119"] = DataTree(xr.Dataset({"tas": xr.DataArray(np.ones((20, 3)), dims=("time", "member"))}))
-    >>> dt["ssp585"] = DataTree(xr.Dataset({"tas": xr.DataArray(np.ones((20, 2)), dims=("time", "member"))}))
+    >>> dt = xr.DataTree()
+    >>> dt["ssp119"] = xr.DataTree(
+    ...     xr.Dataset({"tas": xr.DataArray(np.ones((20, 3)), dims=("time", "member"))})
+    ... )
+    >>> dt["ssp585"] = xr.DataTree(
+    ...     xr.Dataset({"tas": xr.DataArray(np.ones((20, 2)), dims=("time", "member"))})
+    ... )
     >>> weights = equal_scenario_weights_from_datatree(dt)
     >>> weights
     DataTree('None', parent=None)
@@ -304,11 +313,11 @@ def get_weights_density(pred_data):
 
         return _unpool_scen_ens(weights_stacked)
 
-    elif isinstance(pred_data, xr.Dataset):
+    if isinstance(pred_data, xr.Dataset):
 
         return _weights_ds(pred_data).to_dataset(name="weights")
 
-    elif isinstance(pred_data, np.ndarray):
+    if isinstance(pred_data, np.ndarray):
         array_pred = pred_data
         return _weights(array_pred)
 

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -133,7 +133,7 @@ def test_draw_auto_regression_uncorrelated_2D_errors(ar_params_2D):
 
     with pytest.raises(
         ValueError,
-        match="``_draw_auto_regression_uncorrelated`` can currently only handle single points",
+        match="``draw_auto_regression_uncorrelated`` can currently only handle single points",
     ):
 
         mesmer.stats.draw_auto_regression_uncorrelated(

--- a/tests/unit/test_mesmer_x_expression.py
+++ b/tests/unit/test_mesmer_x_expression.py
@@ -66,7 +66,7 @@ def test_expression_warn_scale_bound():
 
     with pytest.warns(
         UserWarning,
-        match=r"Found lower boundary on scale parameter that is negative, setting to 0.",
+        match=r"Found lower boundary on scale parameter that is negative, setting to 0",
     ):
         expr = Expression(
             "norm(scale=5, loc=2)",

--- a/tutorials/tutorial_mesmer_calibrate_multiple_scenarios.ipynb
+++ b/tutorials/tutorial_mesmer_calibrate_multiple_scenarios.ipynb
@@ -148,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we load all the files we found into a ``DataTree``, a data structure provided by [xarray](https://docs.xarray.dev/en/stable/index.html). It is a container to hold xarray `Dataset` objects that are not alignable. This is useful for us since we have historical and future data, which have different time coordinates. Moreover, the scenarios may also have different numbers of members (as e.g., ssp126, which only has one). Thus, we store the data of each scenario in a `Dataset` with all its ensemble members along a `member` dimension. Then we store all the scenario datasets in one `DataTree` node. The `DataTree` allows us to perform computations on each of the scenarios separately.\n",
+    "Now we load all the files we found into a ``DataTree``, a data structure provided by [xarray](https://docs.xarray.dev/en/stable/index.html). It is a container to hold xarray `Dataset` objects that are not alignable. This is useful for us since we have historical and future data, which have different time coordinates. Moreover, the scenarios may also have different numbers of members (as e.g., SSP1-2.6, which only has one). Thus, we store the data of each scenario in a `Dataset` with all its ensemble members along a `member` dimension. Then we store all the scenario datasets in one `DataTree` node. The `DataTree` allows us to perform computations on each of the scenarios separately.\n",
     "\n",
     "We define a helper function to load the data from the cmip6_ng example data repository:"
    ]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR reflows docstrings and comments to 88 characters (where reasonable). I also went over the API docs and quickly checked if they are rendered correctly. Fixed some issues with code blocks and lists, and also some other random stuff...
