### PR TITLE
Expression: remove evaluate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,8 @@ Breaking changes
   By `Mathias Hauser`_.
 - Removed the deprecated function :py:func:`mask_percentage` (`#654 <https://github.com/MESMER-group/mesmer/pull/654>`_)
   By `Mathias Hauser`_.
+- Removed `Expression.evaluate` - use `Expression.evaluate_params` instead (`#786 <https://github.com/MESMER-group/mesmer/pull/786>`_)
+  By `Mathias Hauser`_.
 - The supported versions of some dependencies were changed
   (`#399 <https://github.com/MESMER-group/mesmer/pull/399>`_,
   `#405 <https://github.com/MESMER-group/mesmer/pull/405>`_,

--- a/mesmer/distrib/_expression.py
+++ b/mesmer/distrib/_expression.py
@@ -521,39 +521,3 @@ class Expression:
                 )
 
         return parameters_values
-
-    def evaluate(self, coefficients_values, predictors_values, forced_shape=None):
-        """
-        Evaluates the distribution with the provided predictors and coefficients
-
-        Parameters
-        ----------
-        coefficients_values : dict | xr.Dataset(c_i) | list of values
-            Coefficient arrays or scalars. Can have the following form
-            - dict(c_i = values or np.array())
-            - xr.Dataset(c_i)
-            - list of values
-        predictors_values : dict | xr.Dataset
-            Input arrays or scalars. Can be passed as
-            - dict(pred_i = values or np.array())
-            - xr.Dataset(pred_i)
-        forced_shape : None | tuple or list of dimensions
-            coefficients_values and predictors_values for transposition of the shape
-
-        Returns
-        -------
-        distr: scipy stats frozen distribution
-            Frozen distribution with the realized parameters applied to.
-
-        Warnings
-        --------
-        with xarrays for coefficients_values and predictors_values, the outputs will
-        have the dimensions of the coefficients first, then the ones of the predictors
-        """
-
-        params = self.evaluate_params(
-            coefficients_values,
-            predictors_values,
-            forced_shape=forced_shape,
-        )
-        return self.distrib(**params)

--- a/mesmer/distrib/_optimizers.py
+++ b/mesmer/distrib/_optimizers.py
@@ -168,11 +168,18 @@ def _crps(expression: Expression, data_targ, data_pred, data_weights, coeffs):
 
     tmp_cprs = []
     for i in np.arange(len(data_targ)):
-        distrib = expression.evaluate(coeffs, {p: data_pred[p][i] for p in data_pred})
+
+        # pre-compute params for the cdf function
+        predictor_values = {p: data_pred[p][i] for p in data_pred}
+        params = expression.evaluate_params(coeffs, predictor_values)
+
+        def cdf(x):
+            return expression.distrib.cdf(x, **params)
+
         tmp_cprs.append(
             properscoring.crps_quadrature(
                 x=data_targ[i],
-                cdf_or_dist=distrib,
+                cdf_or_dist=cdf,
                 xmin=-10 * np.abs(data_targ[i]),
                 xmax=10 * np.abs(data_targ[i]),
                 tol=1.0e-4,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

Removes `Expression.evaluate` in favor of `Expression.evaluate_params` and rewrites the last instance where it was used. Does make the computation of `crps` ever so slightly faster.