### PR TITLE
Add 365D to allowed freq for _assert_annual_data

### DIFF
--- a/mesmer/_core/utils.py
+++ b/mesmer/_core/utils.py
@@ -132,7 +132,7 @@ def _assert_annual_data(time):
             "Annual data is required but data of unknown frequency was passed"
         )
     # pandas v2.2 and xarray v2023.11.0 changed the time freq string for year
-    if not (freq.startswith("A") or freq.startswith("Y")):
+    if not (freq.startswith("A") or freq.startswith("Y") or freq == "365D"):
         raise ValueError(
             f"Annual data is required but data with frequency {freq} was passed"
         )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -460,9 +460,10 @@ def _get_time(*args, **kwargs):
 @pytest.mark.parametrize(
     "calendar", ["standard", "gregorian", "proleptic_gregorian", "365_day", "julian"]
 )
-def test_assert_annual_data(calendar):
+@pytest.mark.parametrize("freq", ["YS", "YE", "YS-JUL", "YS-NOV", "A", "365D"])
+def test_assert_annual_data(calendar, freq):
 
-    time = _get_time("2000", "2005", freq="YE", calendar=calendar)
+    time = _get_time("2000", "2005", freq=freq, calendar=calendar)
 
     # no error
     mesmer._core.utils._assert_annual_data(time)


### PR DESCRIPTION
 - [x] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

One CMIP6-ng model has this (KIOST-ESM). Is there a reason we don't have this atm @mathause?
