### PR TITLE
fix error msg for multiple missing data_vars in _check_dataset_form

### DIFF
--- a/mesmer/_core/utils.py
+++ b/mesmer/_core/utils.py
@@ -180,8 +180,8 @@ def _check_dataset_form(
 
     missing_vars = required_vars - data_vars
     if missing_vars:
-        missing = ", ".join(sorted(missing_vars))
-        raise ValueError(f"{name} is missing the required data_vars: {missing}")
+        missing = "', '".join(sorted(missing_vars))
+        raise ValueError(f"'{name}' is missing the required data_vars: '{missing}'")
 
     n_vars_except = len(data_vars - (required_vars | optional_vars))
     if requires_other_vars and n_vars_except == 0:

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -117,7 +117,7 @@ def test_draw_auto_regression_uncorrelated_wrong_input(ar_params_1D, drop):
     ar_params = ar_params_1D.drop_vars(drop)
 
     with pytest.raises(
-        ValueError, match=f"ar_params is missing the required data_vars: {drop}"
+        ValueError, match=f"'ar_params' is missing the required data_vars: '{drop}'"
     ):
 
         mesmer.stats.draw_auto_regression_uncorrelated(
@@ -285,7 +285,7 @@ def test_draw_auto_regression_correlated_wrong_input(ar_params_2D, covariance, d
     ar_params = ar_params_2D.drop_vars(drop)
 
     with pytest.raises(
-        ValueError, match=f"ar_params is missing the required data_vars: {drop}"
+        ValueError, match=f"'ar_params' is missing the required data_vars: '{drop}'"
     ):
 
         mesmer.stats.draw_auto_regression_correlated(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -275,13 +275,14 @@ def test_check_dataset_form_required_vars():
 
     ds = xr.Dataset()
 
-    with pytest.raises(ValueError, match="obj is missing the required data_vars"):
+    with pytest.raises(ValueError, match="'obj' is missing the required data_vars"):
         mesmer._core.utils._check_dataset_form(ds, required_vars="missing")
 
-    with pytest.raises(ValueError, match="test is missing the required data_vars"):
+    with pytest.raises(ValueError, match="'test' is missing the required data_vars"):
         mesmer._core.utils._check_dataset_form(ds, "test", required_vars="missing")
 
-    with pytest.raises(ValueError, match="obj is missing the required data_vars: a, b"):
+    msg = "'obj' is missing the required data_vars: 'a', 'b'"
+    with pytest.raises(ValueError, match=msg):
         mesmer._core.utils._check_dataset_form(ds, required_vars={"a", "b"})
 
     # no error


### PR DESCRIPTION
There is _always_ something more, isn't there?