### PR TITLE
test errors in test_find_localized_empirical_covariance

### DIFF
--- a/mesmer/stats/_localized_covariance.py
+++ b/mesmer/stats/_localized_covariance.py
@@ -139,6 +139,12 @@ def find_localized_empirical_covariance(
     (other_dim,) = set(all_dims) - {sample_dim}
     out_dims = _create_equal_dim_names(other_dim, equal_dim_suffixes)
 
+    if not isinstance(k_folds, int) or k_folds <= 1:
+        raise ValueError(f"'k_folds' must be an integer larger than 1, got {k_folds}.")
+
+    if data[dim].size != weights.size:
+        raise ValueError("weights and data have incompatible shape")
+
     out = xr.apply_ufunc(
         _find_localized_empirical_covariance_np,
         data,
@@ -259,12 +265,6 @@ def _find_localized_empirical_covariance_np(data, weights, localizer, k_folds):
     Runs a k-fold cross validation if ``k_folds`` is smaller than the number of samples
     and a leave-one-out cross validation otherwise.
     """
-
-    if not isinstance(k_folds, int) or k_folds <= 1:
-        raise ValueError(f"'k_folds' must be an integer larger than 1, got {k_folds}.")
-
-    if data.shape[0] != weights.size:
-        raise ValueError("weights and data have incompatible shape")
 
     localization_radii = sorted(localizer.keys())
 

--- a/tests/unit/test_localized_covariance.py
+++ b/tests/unit/test_localized_covariance.py
@@ -49,6 +49,35 @@ def get_weights(n_samples):
     return xr.DataArray(weights, dims="time")
 
 
+def test_find_localized_empirical_covariance_errors():
+
+    n_samples = 20
+    n_gridpoints = 3
+
+    data = get_random_data(n_samples, n_gridpoints)
+    localizer = get_localizer_dict(n_gridpoints, as_dataarray=True)
+    weights = get_weights(n_samples)
+
+    with pytest.raises(
+        ValueError, match="'k_folds' must be an integer larger than 1, got 0.5."
+    ):
+        mesmer.stats.find_localized_empirical_covariance(
+            data, weights, localizer, dim="time", k_folds=0.5
+        )
+
+    with pytest.raises(
+        ValueError, match="'k_folds' must be an integer larger than 1, got -1"
+    ):
+        mesmer.stats.find_localized_empirical_covariance(
+            data, weights, localizer, dim="time", k_folds=-1
+        )
+
+    with pytest.raises(ValueError, match="weights and data have incompatible shape"):
+        mesmer.stats.find_localized_empirical_covariance(
+            data, weights[1:], localizer, dim="time", k_folds=15
+        )
+
+
 @pytest.mark.filterwarnings("ignore:First element is local minimum.")
 def test_find_localized_empirical_covariance():
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

These were previously untested and indeed the second of them can not be raised in `xr.apply_ufunc` because xarray already checks if the dimensions can be aligned (could also leave it away but this error msg is clearer). Also `_find_localized_empirical_covariance_np` is only called in one place.
