### PR TITLE
upstream-dev-ci: bump python version

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Saw that it still runs on 3.12. Will probably be 3.13 in the end but I use this to test if 3.14 would work.
