### PR TITLE
sklearn PowerTransformer: fix upcoming failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,8 @@ Internal Changes
 
 - Refactor :py:func:`_ignore_warnings` (`#839 <https://github.com/MESMER-group/mesmer/pull/839>`_).
   By `Mathias Hauser`_.
+- Fix upcoming failure in a :py:class:`PowerTransformer` test case due to a change in scikit-learn (`#858 <https://github.com/MESMER-group/mesmer/pull/858>`_).
+  By `Mathias Hauser`_.
 - Use `minimum-dependency-versions <https://github.com/xarray-contrib/minimum-dependency-versions>`__ to check supported
   dependency versions (`#763 <https://github.com/MESMER-group/mesmer/pull/763>`_).
 

--- a/tests/unit/test_power_transformer.py
+++ b/tests/unit/test_power_transformer.py
@@ -208,18 +208,21 @@ def test_transform_roundtrip_special_cases(value, lmbda, lambda_delta):
     np.testing.assert_allclose(result, x)
 
 
-def test_yeo_johnson_inverse_transform_np_sklearn():
+@pytest.mark.parametrize("lmbda", (-2, -1, 0, 1, 2))
+def test_yeo_johnson_inverse_transform_np_sklearn(lmbda):
     # test if our inverse power transform is the same as sklearn's for constant lambda
     np.random.seed(0)
     n_ts = 20
 
-    lambdas = np.tile([2.0], (n_ts))
+    lambdas = np.full(n_ts, fill_value=lmbda)
 
-    monthly_residuals = sp.stats.skewnorm.rvs(2, size=n_ts)
+    monthly_residuals = sp.stats.skewnorm.rvs(lmbda, size=n_ts)
     result = _yeo_johnson_inverse_transform_np(monthly_residuals, lambdas)
 
     pt_sklearn = PowerTransformer(method="yeo-johnson", standardize=False)
-    pt_sklearn.lambdas_ = np.array([2.0])
+    # manually set the pt params
+    pt_sklearn.lambdas_ = np.array([lmbda])
+    pt_sklearn.n_features_in_ = 1
     expected = pt_sklearn.inverse_transform(monthly_residuals.reshape(-1, 1))
 
     # only approximately the same due to #494


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #850
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

scikit-learn/scikit-learn#33268 did a small change to its `PowerTransformer.inverse_transform` - it now needs `n_features_in_` to be set. Because we abuse the `PowerTransformer` to manually set `lambda` we now have to do

```python
pt_sklearn.n_features_in_ = 1
```

as well. The other changes are cosmetic but revealed an issue in our implementation...