### PR TITLE
rtd: use python 3.14 and ubuntu 24.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   jobs:
     post_checkout:
       # unshallow so the version works
@@ -11,7 +11,7 @@ build:
       # editable install mesmer with docs extras
       - python -m pip install -e .[docs]
   tools:
-    python: "3.12"
+    python: "3.14"
 sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,9 @@ Internal Changes
   By `Mathias Hauser`_.
 - Use `minimum-dependency-versions <https://github.com/xarray-contrib/minimum-dependency-versions>`__ to check supported
   dependency versions (`#763 <https://github.com/MESMER-group/mesmer/pull/763>`_).
+  By `Mathias Hauser`_.
+- Use python 3.14 and ubuntu 24.04 on readthedocs (`#860 <https://github.com/MESMER-group/mesmer/pull/860>`_).
+  By `Mathias Hauser`_.
 
 v1.0.0rc1 - 26.09.2025
 ----------------------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

I found that python 3.14 is faster for the tests - maybe this also holds for the docs build.
