### PR TITLE
rtd: use uv for installation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ build:
       # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged docs/source/conf.py
     install:
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extras docs
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extra docs
   tools:
     python: "3.14"
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,16 +6,16 @@ build:
       # unshallow so the version works
       - git fetch --unshallow
     pre_create_environment:
-        - asdf plugin add uv
-        - asdf install uv latest
-        - asdf global uv latest
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
     create_environment:
-        - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     pre_install:
-        # see https://github.com/readthedocs/readthedocs.org/issues/8201
+      # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged docs/source/conf.py
     install:
-        - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extras docs
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extras docs
   tools:
     python: "3.14"
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,11 +5,17 @@ build:
     post_checkout:
       # unshallow so the version works
       - git fetch --unshallow
+    pre_create_environment:
+        - asdf plugin add uv
+        - asdf install uv latest
+        - asdf global uv latest
+    create_environment:
+        - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     pre_install:
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged docs/source/conf.py
-      # editable install mesmer with docs extras
-      - python -m pip install -e .[docs]
+    install:
+        - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extras docs
   tools:
     python: "3.14"
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,8 @@ build:
       # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged docs/source/conf.py
     install:
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extra docs
+      # TODO: enable --frozen if defining a uv.lock file
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --extra docs
   tools:
     python: "3.14"
 sphinx:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,8 @@ Internal Changes
   By `Mathias Hauser`_.
 - Use python 3.14 and ubuntu 24.04 on readthedocs (`#860 <https://github.com/MESMER-group/mesmer/pull/860>`_).
   By `Mathias Hauser`_.
+- Install dependencies on readthedocs with uv to speed up the docs build  (`#861 <https://github.com/MESMER-group/mesmer/pull/861>`_).
+  By `Mathias Hauser`_.
 
 v1.0.0rc1 - 26.09.2025
 ----------------------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

To hopefully make the docs build faster. Following the instructions in the [rtd docs](https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv). Let's see if it works without a editable install. I can't remember why this was necessary...