### PR TITLE
`fit_auto_regression_monthly`: return residuals separately

### DIFF
--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -857,7 +857,7 @@ def _fit_auto_regression_np(data: np.ndarray, lags: int | Sequence[int]):
 
 def fit_auto_regression_monthly(
     monthly_data: xr.DataArray, time_dim: str = "time"
-) -> xr.Dataset:
+) -> tuple[xr.Dataset, xr.DataArray]:
     """fit a cyclo-stationary auto-regressive process of lag one (AR(1)) on monthly
     data. The parameters are estimated for each month and gridpoint separately.
     This is based on the assumption that e.g. June depends on May differently
@@ -919,7 +919,7 @@ def fit_auto_regression_monthly(
     """
     _check_dataarray_form(monthly_data, "monthly_data", required_coords=time_dim)
     monthly_groups = monthly_data.groupby(f"{time_dim}.month")
-    ar_params_res = []
+    ar_params_res: list[xr.Dataset] = []
 
     (sample_dim,) = monthly_data[time_dim].dims
 
@@ -958,7 +958,7 @@ def fit_auto_regression_monthly(
     month_dim = xr.Variable("month", np.arange(1, 13))
     ar_params = xr.concat(ar_params_res, dim=month_dim)
 
-    return xr.merge([ar_params, residuals], compat="override")
+    return ar_params, residuals
 
 
 def _fit_auto_regression_monthly_np(data_month, data_prev_month):

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -875,16 +875,22 @@ def fit_auto_regression_monthly(
 
     Returns
     -------
-    obj : ``xr.Dataset``
+    fit : ``xr.Dataset``
         Dataset containing
 
         - the ``intercept`` for each month of the AR(1) process,
-        - the ``slope`` for each month and
-        - the ``residuals`` (needed for the estimation of the covariance matrices).
+        - the ``slope`` for each month.
 
         ``intercept`` and ``slope`` have `"month"` and the additional dims of the input
-        data as dimensions, the residuals have `time_dim` and the additional dims of the
-        input data as dimensions.
+        data as dimensions.
+
+    residuals : ``xr.DataArray``
+        DataArray containing
+
+        - the ``residuals`` (needed for the estimation of the covariance matrices).
+
+        the residuals have `time_dim` and the additional dims of the input data as
+        dimensions.
 
     Notes
     -----

--- a/tests/integration/test_calibrate_mesmer_m.py
+++ b/tests/integration/test_calibrate_mesmer_m.py
@@ -198,7 +198,7 @@ def test_calibrate_mesmer_m(
     )
 
     # fit cyclo-stationary AR(1) process
-    ar1_fit = mesmer.stats.fit_auto_regression_monthly(
+    ar1_fit, ar1_residuals = mesmer.stats.fit_auto_regression_monthly(
         transformed_hm_resids.transformed
     )
 
@@ -210,17 +210,17 @@ def test_calibrate_mesmer_m(
     )
 
     if n_ens == "one":
-        weights = xr.ones_like(ar1_fit.residuals.isel(gridcell=0))
+        weights = xr.ones_like(ar1_residuals.residuals.isel(gridcell=0))
         weights.name = "weights"
     else:
         weights = mesmer.weighted.equal_scenario_weights_from_datatree(tas_anoms_m)
         weights = mesmer.datatree.pool_scen_ens(weights)
 
-        # because ar1_fit.residuals lost the first ts, we have to remove it here as well
+        # because ar1_residuals lost the first ts, we have to remove it here as well
         weights = weights.isel(sample=slice(1, None)).weights
 
     localized_ecov = mesmer.stats.find_localized_empirical_covariance_monthly(
-        ar1_fit.residuals, weights, phi_gc_localizer, "time", k_folds=30
+        ar1_residuals.residuals, weights, phi_gc_localizer, "time", k_folds=30
     )
 
     # we need to get the original time coordinate to be able to validate our results
@@ -249,7 +249,6 @@ def test_calibrate_mesmer_m(
     if update_expected_files:
         # drop unnecessary variables
         harmonic_model_fit = harmonic_model_fit.drop_vars(["residuals", "time"])
-        ar1_fit = ar1_fit.drop_vars(["residuals", "time"])
 
         # save
         harmonic_model_fit.to_netcdf(local_hm_file)

--- a/tests/integration/test_calibrate_mesmer_m.py
+++ b/tests/integration/test_calibrate_mesmer_m.py
@@ -210,7 +210,7 @@ def test_calibrate_mesmer_m(
     )
 
     if n_ens == "one":
-        weights = xr.ones_like(ar1_residuals.residuals.isel(gridcell=0))
+        weights = xr.ones_like(ar1_residuals.isel(gridcell=0))
         weights.name = "weights"
     else:
         weights = mesmer.weighted.equal_scenario_weights_from_datatree(tas_anoms_m)
@@ -220,7 +220,7 @@ def test_calibrate_mesmer_m(
         weights = weights.isel(sample=slice(1, None)).weights
 
     localized_ecov = mesmer.stats.find_localized_empirical_covariance_monthly(
-        ar1_residuals.residuals, weights, phi_gc_localizer, "time", k_folds=30
+        ar1_residuals, weights, phi_gc_localizer, "time", k_folds=30
     )
 
     # we need to get the original time coordinate to be able to validate our results

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -753,29 +753,37 @@ def test_fit_auto_regression_monthly(stack) -> None:
     )
 
     if stack:
-        data = data.stack(sample=["time"], create_index=False)
+        data = data.stack(sample=["time"], create_index=False).T
 
-    result = mesmer.stats.fit_auto_regression_monthly(data)
+    result_fit, result_residuals = mesmer.stats.fit_auto_regression_monthly(data)
 
-    _check_dataset_form(result, "result", required_vars={"slope", "intercept"})
+    _check_dataset_form(result_fit, "result", required_vars={"slope", "intercept"})
     _check_dataarray_form(
-        result.slope,
+        result_fit.slope,
         "slope",
         ndim=2,
         required_dims={"month", "gridcell"},
         shape=(12, n_gridcells),
     )
     _check_dataarray_form(
-        result.intercept,
+        result_fit.intercept,
         "intercept",
         ndim=2,
         required_dims={"month", "gridcell"},
         shape=(12, n_gridcells),
     )
 
+    _check_dataarray_form(
+        result_residuals,
+        "residuals",
+        required_dims=data.dims,
+        required_coords=set(data.coords.keys()),
+        shape=(n_years * 12 - 1, n_gridcells),
+    )
+
     sample_dim = "sample" if stack else "time"
     # check coordinates are the same
-    result_coords = result[sample_dim].coords
+    result_coords = result_residuals[sample_dim].coords
     expected_coords = data[sample_dim].isel({sample_dim: slice(1, None)}).coords
 
     assert result_coords.equals(expected_coords)

--- a/tutorials/tutorial_mesmer_m_calibrate_multiple_scenarios.ipynb
+++ b/tutorials/tutorial_mesmer_m_calibrate_multiple_scenarios.ipynb
@@ -558,7 +558,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ar1_fit = mesmer.stats.fit_auto_regression_monthly(transformed_resids.transformed)\n",
+    "ar1_fit, ar1_residuals = mesmer.stats.fit_auto_regression_monthly(\n",
+    "    transformed_resids.transformed\n",
+    ")\n",
     "ar1_fit"
    ]
   },
@@ -625,7 +627,7 @@
     "weights = mesmer.weighted.equal_scenario_weights_from_datatree(tas_anoms_m)\n",
     "weights = mesmer.datatree.pool_scen_ens(weights)\n",
     "\n",
-    "# because ar1_fit.residuals lost the first ts, we have to remove it here as well\n",
+    "# because ar1_residuals lost the first ts, we have to remove it here as well\n",
     "weights = weights.isel(sample=slice(1, None))\n",
     "weights"
    ]
@@ -651,7 +653,7 @@
     "k_folds = 30\n",
     "\n",
     "localized_ecov = mesmer.stats.find_localized_empirical_covariance_monthly(\n",
-    "    ar1_fit.residuals,\n",
+    "    ar1_residuals,\n",
     "    weights.weights,\n",
     "    phi_gc_localizer,\n",
     "    dim=dim,\n",
@@ -756,7 +758,6 @@
     "harmonic_model_fit = harmonic_model_fit.drop_vars(\n",
     "    [\"residuals\", \"time\"], errors=\"ignore\"\n",
     ")\n",
-    "ar1_fit = ar1_fit.drop_vars([\"residuals\", \"time\"], errors=\"ignore\")\n",
     "\n",
     "params = {\n",
     "    \"harmonic-model\": harmonic_model_fit,\n",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] part of #874
 - [x] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

`fit_auto_regression_monthly`: return residuals separately. This is not yet a commitment but to get an idea how this would look like. Need to do the same for `fit_harmonic_model` in case we want to do this.