### PR TITLE
`fit_harmonic_model`: return residuals separately

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ New Features
 Breaking changes
 ^^^^^^^^^^^^^^^^
 
+- :py:func:`fit_harmonic_model` and :py:func:`fit_auto_regression_monthly` not return the residuals as
+  separate :py:class:`xr.DataArray` instead of merging it into the :py:class:`xr.Dataset` containing the
+  fitted parameters   (`#880 <https://github.com/MESMER-group/mesmer/pull/880>`_, and `#881 <https://github.com/MESMER-group/mesmer/pull/881>`_).
+  By `Mathias Hauser`_.
 - Remove helper function to merge ``DataTree`` objects, as this is now possible with :py:func:`xr.merge` in xarray v2025.11
   (`#824 <https://github.com/MESMER-group/mesmer/pull/824>`_).
   By `Mathias Hauser`_.

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -311,13 +311,16 @@ def fit_harmonic_model(
 
     Returns
     -------
-    data_vars : `xr.Dataset`
+    fit : `xr.Dataset`
         Dataset containing
 
         - the selected order of Fourier Series (`selected_order`),
-        - the estimated coefficients of the Fourier Series (`coeffs`), and
-        - the residuals of the model (`residuals`).
+        - the estimated coefficients of the Fourier Series (`coeffs`)
 
+    residuals : `xr.DataArray`
+        DataArray containing
+
+        - the residuals of the model (`residuals`)
     """
 
     _check_dataarray_form(

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -287,7 +287,7 @@ def fit_harmonic_model(
     *,
     max_order: int = 6,
     time_dim: str = "time",
-) -> xr.Dataset:
+) -> tuple[xr.Dataset, xr.DataArray]:
     """fit harmonic model i.e. a Fourier Series to every gridcell using BIC score to
     select the order and least squares to fit the coefficients for each order.
 
@@ -376,7 +376,6 @@ def fit_harmonic_model(
     data_vars = {
         "selected_order": selected_order,
         "coeffs": coeffs,
-        "residuals": resids.transpose(sample_dim, ...),
     }
 
-    return xr.Dataset(data_vars)
+    return xr.Dataset(data_vars), resids.transpose(sample_dim, ...)

--- a/tests/integration/test_calibrate_mesmer_m.py
+++ b/tests/integration/test_calibrate_mesmer_m.py
@@ -247,7 +247,6 @@ def test_calibrate_mesmer_m(
 
     # save params
     if update_expected_files:
-        # drop unnecessary variables
         ar1_fit = ar1_fit.drop_vars(["residuals", "time"])
 
         # save

--- a/tests/integration/test_calibrate_mesmer_m.py
+++ b/tests/integration/test_calibrate_mesmer_m.py
@@ -182,7 +182,7 @@ def test_calibrate_mesmer_m(
         tas_stacked_m = mesmer.datatree.pool_scen_ens(tas_stacked_m)
 
     # fit harmonic model
-    harmonic_model_fit = mesmer.stats.fit_harmonic_model(
+    harmonic_model_fit, harmonic_model_residual = mesmer.stats.fit_harmonic_model(
         tas_stacked_y.tas, tas_stacked_m.tas
     )
 
@@ -190,11 +190,11 @@ def test_calibrate_mesmer_m(
     yj_transformer = mesmer.stats.YeoJohnsonTransformer(yj_transformation)
     pt_coefficients = yj_transformer.fit(
         tas_stacked_y.tas,
-        harmonic_model_fit.residuals,
+        harmonic_model_residual,
     )
     # find transformed residuals
     transformed_hm_resids = yj_transformer.transform(
-        tas_stacked_y.tas, harmonic_model_fit.residuals, pt_coefficients
+        tas_stacked_y.tas, harmonic_model_residual, pt_coefficients
     )
 
     # fit cyclo-stationary AR(1) process
@@ -248,7 +248,6 @@ def test_calibrate_mesmer_m(
     # save params
     if update_expected_files:
         # drop unnecessary variables
-        harmonic_model_fit = harmonic_model_fit.drop_vars(["residuals", "time"])
         ar1_fit = ar1_fit.drop_vars(["residuals", "time"])
 
         # save

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -166,10 +166,12 @@ def test_fit_harmonic_model():
     )
 
     # test if the model can recover the monthly target from perfect fourier series
-    result = mesmer.stats.fit_harmonic_model(yearly_predictor, monthly_target)
-    np.testing.assert_equal(result.selected_order.values, orders)
+    result_fit, result_residuals = mesmer.stats.fit_harmonic_model(
+        yearly_predictor, monthly_target
+    )
+    np.testing.assert_equal(result_fit.selected_order.values, orders)
     xr.testing.assert_allclose(
-        result.residuals, xr.zeros_like(monthly_target), atol=1e-6
+        result_residuals, xr.zeros_like(monthly_target), atol=1e-6
     )
 
     # test if the model can recover the underlying cycle with noise on top of monthly target
@@ -178,9 +180,11 @@ def test_fit_harmonic_model():
         loc=0, scale=0.1, size=monthly_target.shape
     )
 
-    result = mesmer.stats.fit_harmonic_model(yearly_predictor, noisy_monthly_target)
+    result_fit, result_residuals = mesmer.stats.fit_harmonic_model(
+        yearly_predictor, noisy_monthly_target
+    )
     predictions = mesmer.stats.predict_harmonic_model(
-        yearly_predictor, result.coeffs, time=monthly_time
+        yearly_predictor, result_fit.coeffs, time=monthly_time
     )
     xr.testing.assert_allclose(predictions, monthly_target, atol=0.1)
 
@@ -202,13 +206,13 @@ def test_fit_harmonic_model():
         ]
     )
 
-    result_comp = result.residuals.isel(cells=0, time=slice(0, 12)).values
+    result_comp = result_residuals.isel(cells=0, time=slice(0, 12)).values
     np.testing.assert_allclose(result_comp, expected, atol=1e-6)
 
     # ensure predictions and residuals are consistent
     expected = noisy_monthly_target - predictions
 
-    xr.testing.assert_equal(expected, result.residuals)
+    xr.testing.assert_equal(expected, result_residuals)
 
 
 def test_fit_harmonic_model_checks() -> None:
@@ -271,14 +275,14 @@ def test_fit_harmonic_model_time_dim():
     time_dim = "dates"
     monthly_target = monthly_target.rename({"time": time_dim})
     yearly_predictor = yearly_predictor.rename({"time": time_dim})
-    res = mesmer.stats.fit_harmonic_model(
+    res, res_resids = mesmer.stats.fit_harmonic_model(
         yearly_predictor, monthly_target, time_dim=time_dim
     )
 
     _check_dataarray_form(res.selected_order, required_dims="cells")
     _check_dataarray_form(res.coeffs, required_dims={"cells", "coeff"})
     _check_dataarray_form(
-        res.residuals, required_dims={"cells", "dates"}, required_coords="dates"
+        res_resids, required_dims={"cells", "dates"}, required_coords="dates"
     )
 
 
@@ -293,10 +297,10 @@ def test_fit_harmonic_model_non_dim_coords():
     monthly_target["time"] = pd.date_range("2000-01-01", periods=10 * 12, freq="ME")
     monthly_target = monthly_target.stack(sample=["time"], create_index=False)
 
-    res = mesmer.stats.fit_harmonic_model(yearly_predictor, monthly_target)
+    res, res_resids = mesmer.stats.fit_harmonic_model(yearly_predictor, monthly_target)
 
     _check_dataarray_form(res.selected_order, required_dims="cells")
     _check_dataarray_form(res.coeffs, required_dims={"cells", "coeff"})
     _check_dataarray_form(
-        res.residuals, required_dims={"cells", "sample"}, required_coords="time"
+        res_resids, required_dims={"cells", "sample"}, required_coords="time"
     )

--- a/tutorials/tutorial_mesmer_m_calibrate_multiple_scenarios.ipynb
+++ b/tutorials/tutorial_mesmer_m_calibrate_multiple_scenarios.ipynb
@@ -433,7 +433,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "harmonic_model_fit = mesmer.stats.fit_harmonic_model(tas_pooled_y.tas, tas_pooled_m.tas)\n",
+    "harmonic_model_fit, harmonic_model_residuals = mesmer.stats.fit_harmonic_model(\n",
+    "    tas_pooled_y.tas, tas_pooled_m.tas\n",
+    ")\n",
     "\n",
     "harmonic_model_fit"
    ]
@@ -484,7 +486,7 @@
     "# yj_transformer = mesmer.stats.YeoJohnsonTransformer(\"logistic\")\n",
     "\n",
     "yj_transformer = mesmer.stats.YeoJohnsonTransformer(\"constant\")\n",
-    "pt_coefficients = yj_transformer.fit(tas_pooled_y.tas, harmonic_model_fit.residuals)"
+    "pt_coefficients = yj_transformer.fit(tas_pooled_y.tas, harmonic_model_residuals)"
    ]
   },
   {
@@ -495,7 +497,7 @@
    "source": [
     "transformed_resids = yj_transformer.transform(\n",
     "    tas_pooled_y.tas,\n",
-    "    harmonic_model_fit.residuals,\n",
+    "    harmonic_model_residuals,\n",
     "    pt_coefficients,\n",
     ")"
    ]
@@ -516,7 +518,7 @@
     "f, ax = plt.subplots()\n",
     "\n",
     "ax.plot(\n",
-    "    sp.stats.skew(harmonic_model_fit.residuals, axis=0),\n",
+    "    sp.stats.skew(harmonic_model_residuals, axis=0),\n",
     "    label=\"original residuals\",\n",
     ")\n",
     "ax.plot(\n",
@@ -752,10 +754,6 @@
     "pathlib.Path(folder).mkdir(exist_ok=True, parents=True)\n",
     "\n",
     "\n",
-    "# drop unnecessary variables\n",
-    "harmonic_model_fit = harmonic_model_fit.drop_vars(\n",
-    "    [\"residuals\", \"time\"], errors=\"ignore\"\n",
-    ")\n",
     "ar1_fit = ar1_fit.drop_vars([\"residuals\", \"time\"], errors=\"ignore\")\n",
     "\n",
     "params = {\n",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #874, companion to #880
 - [x] Tests added
 - [x] Fully documented, including `CHANGELOG.rst`

Again, we can still decide not to do this. Contains changelog entry for #880 as well.