### PR TITLE
fix typos

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -194,7 +194,7 @@ Weighted operations: calculate global mean
    ~weighted.equal_scenario_weights_from_datatree
    ~weighted.get_weights_density
 
-DataTree heplers
+DataTree helpers
 ----------------
 
 .. autosummary::

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -183,7 +183,7 @@ These tools automatically format the code for us and tell us where the errors ar
 
 Documenting
 -----------
-We strongly encourage you to document your code. By this we mean mainting a transparent workflow via git and github and commenting your code lines but above all we want to encourage documenting your new functions via a docstring, explaining what the function does and how it can be used. This makes it easier for others to understand what you have done and how to use it.
+We strongly encourage you to document your code. By this we mean maintaining a transparent workflow via git and github and commenting your code lines but above all we want to encourage documenting your new functions via a docstring, explaining what the function does and how it can be used. This makes it easier for others to understand what you have done and how to use it.
 
 We use Sphinx_ to generate our documentation. To get started with Sphinx, we began with `this example <https://pythonhosted.org/an_example_pypi_project/sphinx.html>`_ and then used `Sphinx's getting started guide <https://www.sphinx-doc.org/en/master/usage/quickstart.html>`_.
 After setting up the development environment (see `Development setup`_) and adding your documentation, building the docs is done by running ``make docs`` (note, run ``make -B docs`` to force the docs to rebuild and ignore make when it says '... index.html is up to date'). This will build the docs for you. You can preview them by opening ``docs/build/html/index.html`` in a browser.

--- a/mesmer/distrib/_expression.py
+++ b/mesmer/distrib/_expression.py
@@ -220,7 +220,7 @@ class Expression:
 
         # prepare boundaries on parameters
         # default is [-inf, inf] except for scale which must be positive
-        # only set bounds for scale - avoids comparing values to deault of +- inf
+        # only set bounds for scale - avoids comparing values to default of +- inf
         if "scale" in self.parameters_list and "scale" not in self.boundaries_params:
             self.boundaries_params["scale"] = [0, np.inf]
 

--- a/mesmer/distrib/_first_guess.py
+++ b/mesmer/distrib/_first_guess.py
@@ -131,7 +131,7 @@ class _FirstGuess:
 
         self.data_targ = data_targ
 
-        # smooting to help with location & scale
+        # smoothing to help with location & scale
         self._prepare_smooth_data(self.data_pred, self.data_targ)
 
         self.data_weights = data_weights
@@ -154,7 +154,7 @@ class _FirstGuess:
 
         l_smooth = 5
 
-        # smooting to help with location & scale
+        # smoothing to help with location & scale
         smooth_targ = _smooth_data(data_targ, length=l_smooth)
         smooth_targ_dev_sq = (data_targ[l_smooth:-l_smooth] - smooth_targ) ** 2
         smooth_pred = {

--- a/mesmer/distrib/_probability_integral_transform.py
+++ b/mesmer/distrib/_probability_integral_transform.py
@@ -73,7 +73,7 @@ class ProbabilityIntegralTransform:
         threshold_proba : float, default: 1.e-9.
             Threshold for the probability of the sample on the original distribution.
             The probabilities of samples outside this threshold (on both sides of the
-            distribtion) will be set to the threshold. This should avoid very unlikely
+            distribution) will be set to the threshold. This should avoid very unlikely
             values
 
         Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ module = [
 # abbreviations
 varn = "varn"
 strat = "strat"
+Nead = "Nead"
 
 [tool.typos.type.jupyter]
 # avoid fixing the id hashes in jupyter notebooks

--- a/tests/unit/test_mesmer_x_conditional_distribution.py
+++ b/tests/unit/test_mesmer_x_conditional_distribution.py
@@ -15,7 +15,7 @@ from mesmer.distrib._conditional_distribution import OptimizerNLL
 from mesmer.testing import trend_data_1D, trend_data_2D
 
 
-# fixture for default distribtion
+# fixture for default distribution
 @pytest.fixture
 def default_distrib():
     expression = Expression("norm(loc=c1 * __tas__, scale=c2)", expr_name="exp1")

--- a/tutorials/tutorial_mesmer_m_calibrate_multiple_scenarios.ipynb
+++ b/tutorials/tutorial_mesmer_m_calibrate_multiple_scenarios.ipynb
@@ -116,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We search for the intial (annual) data for ssp126 and ssp585 as well as the corresponding historical data:"
+    "We search for the initial (annual) data for ssp126 and ssp585 as well as the corresponding historical data:"
    ]
   },
   {
@@ -475,7 +475,7 @@
     "$$\n",
     "\n",
     "\n",
-    " These two options are implementes as `\"constant\"` and `\"logistic\"`. We here use `\"constant\"` for performance reasons. "
+    " These two options are implements as `\"constant\"` and `\"logistic\"`. We here use `\"constant\"` for performance reasons. "
    ]
   },
   {

--- a/tutorials/tutorial_mesmer_m_emulate_multiple_scenarios.ipynb
+++ b/tutorials/tutorial_mesmer_m_emulate_multiple_scenarios.ipynb
@@ -116,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We search for the intial (annaul) data for ssp126 and ssp585 as well as the corresponding historical data:"
+    "We search for the initial (annaul) data for ssp126 and ssp585 as well as the corresponding historical data:"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We load the data using a helper function. For emulation, the historical and projection timeseries needs to be loaded in continously "
+    "We load the data using a helper function. For emulation, the historical and projection timeseries needs to be loaded in continuously "
    ]
   },
   {

--- a/tutorials/tutorial_mesmer_x.ipynb
+++ b/tutorials/tutorial_mesmer_x.ipynb
@@ -90,7 +90,7 @@
    "source": [
     "### Load and prepare predictor and forcing data\n",
     "\n",
-    "MESMER-X expectes the predictor and forcing data in the same format as MESMER and MESMER-M. First define helper functions to load data from the cmip6-ng example data archive.\n",
+    "MESMER-X expects the predictor and forcing data in the same format as MESMER and MESMER-M. First define helper functions to load data from the cmip6-ng example data archive.\n",
     "\n",
     ":::{caution}\n",
     "- In the original cmip6-ng archive annual tasmax archive is not the annual maximum temperature (TXx) but the annual mean daily maximum temperature. In MESMER's example data archive the annual maximum is provided.\n",
@@ -369,7 +369,7 @@
    "source": [
     "### Fit conditional distribution\n",
     "\n",
-    "Fitting data to arbitrary distributions and covariate structures is a challenging feat - `find_first_guess` uses a multi-step approach to find an inital value for each coefficient:"
+    "Fitting data to arbitrary distributions and covariate structures is a challenging feat - `find_first_guess` uses a multi-step approach to find an initial value for each coefficient:"
    ]
   },
   {
@@ -711,7 +711,7 @@
    "id": "36137cc9",
    "metadata": {},
    "source": [
-    "### Create temporally and spatially corelated samples"
+    "### Create temporally and spatially correlated samples"
    ]
   },
   {
@@ -783,7 +783,7 @@
    "id": "760f3deb",
    "metadata": {},
    "source": [
-    "and fially back-transform the realizations"
+    "and finally back-transform the realizations"
    ]
   },
   {


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

```bash
codespell --skip=".git,devel,build" --ignore-words-list "varn, THIRDPARTY, strat, nD" . --write-changes -i 3
typos
typos -w
```

Again a nice list of typos has accumulated.
