### PR TITLE
Deduplicate calculation of residuals in HarmonicModel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,8 +20,8 @@ Breaking changes
 ^^^^^^^^^^^^^^^^
 
 - Add a :py:class:`HarmonicModel` class instead of the two functions :py:func:`fit_harmonic_model` and
-  :py:func:`predict_harmonic_model` (`#882 <https://github.com/MESMER-group/mesmer/pull/882>`_).
-  By `Mathias Hauser`_.
+  :py:func:`predict_harmonic_model` (`#882 <https://github.com/MESMER-group/mesmer/pull/882>`_ and `#893 <https://github.com/MESMER-group/mesmer/pull/893>`_).
+  By `Mathias Hauser`_ and `Victoria Bauer`_.
 - :py:func:`fit_auto_regression_monthly` now returns the parameters and residuals separately
   (`#880 <https://github.com/MESMER-group/mesmer/pull/880>`_).
   By `Mathias Hauser`_.

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -168,7 +168,7 @@ def _fit_fourier_coeffs_np(yearly_predictor, monthly_target, first_guess):
     coeffs : array-like of shape (4*order)
         Fitted coefficients of Fourier series.
 
-    mse : Float
+    mse : float
         Mean-squared error.
 
     """

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -168,8 +168,8 @@ def _fit_fourier_coeffs_np(yearly_predictor, monthly_target, first_guess):
     coeffs : array-like of shape (4*order)
         Fitted coefficients of Fourier series.
 
-    preds : array-like of shape (n_years*12,)
-        Predicted monthly values.
+    mse : Float
+        Mean-squared error.
 
     """
 
@@ -242,8 +242,6 @@ def _fit_fourier_order_np(yearly_predictor, monthly_target, max_order):
         Selected order of Fourier Series.
     coeffs : array-like of size (4 * max_order,)
         Fitted coefficients for the selected order of Fourier Series.
-    predictions : array-like of size (n_years*12,)
-        Predicted monthly values from final model.
     """
 
     current_min_score = float("inf")
@@ -267,15 +265,11 @@ def _fit_fourier_order_np(yearly_predictor, monthly_target, max_order):
         else:
             break
 
-    predictions = _generate_fourier_series_np(
-        yearly_predictor=yearly_predictor, coeffs=last_coeffs
-    )
-
     # need the coeff array to be the same size for all orders
     coeffs = np.full(max_order * 4, fill_value=np.nan)
     coeffs[: selected_order * 4] = last_coeffs
 
-    return selected_order, coeffs, predictions
+    return selected_order, coeffs
 
 
 def _fit_harmonic_model(
@@ -353,14 +347,14 @@ def _fit_harmonic_model(
     # subtract annual mean to have seasonal anomalies around 0
     seasonal_deviations = monthly_target - yearly_predictor
 
-    selected_order, coeffs, preds = xr.apply_ufunc(
+    selected_order, coeffs = xr.apply_ufunc(
         _fit_fourier_order_np,
         yearly_predictor,
         seasonal_deviations,
         input_core_dims=[[sample_dim], [sample_dim]],
-        output_core_dims=([], ["coeff"], [sample_dim]),
+        output_core_dims=([], ["coeff"]),
         vectorize=True,
-        output_dtypes=[int, float, float],
+        output_dtypes=[int, float],
         kwargs={"max_order": max_order},
     )
 
@@ -375,6 +369,7 @@ def _fit_harmonic_model(
 
 
 class HarmonicModel:
+    """HarmonicModel class to fit a Fourier Series to monthly data using yearly predictors."""
 
     def __init__(self):
 

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -244,7 +244,6 @@ def _fit_fourier_order_np(yearly_predictor, monthly_target, max_order):
         Fitted coefficients for the selected order of Fourier Series.
     predictions : array-like of size (n_years*12,)
         Predicted monthly values from final model.
-
     """
 
     current_min_score = float("inf")
@@ -285,7 +284,7 @@ def _fit_harmonic_model(
     *,
     max_order: int = 6,
     time_dim: str = "time",
-) -> tuple[xr.Dataset, xr.DataArray]:
+) -> xr.Dataset:
     """fit harmonic model i.e. a Fourier Series to every gridcell using BIC score to
     select the order and least squares to fit the coefficients for each order.
 
@@ -314,11 +313,6 @@ def _fit_harmonic_model(
 
         - the selected order of Fourier Series (`selected_order`),
         - the estimated coefficients of the Fourier Series (`coeffs`)
-
-    residuals : `xr.DataArray`
-        DataArray containing
-
-        - the residuals of the model (`residuals`)
     """
 
     _check_dataarray_form(
@@ -372,14 +366,12 @@ def _fit_harmonic_model(
 
     coeffs = coeffs.assign_coords({"coeff": np.arange(coeffs.sizes["coeff"])})
 
-    resids = monthly_target - (yearly_predictor + preds)
-
     data_vars = {
         "selected_order": selected_order,
         "coeffs": coeffs,
     }
 
-    return xr.Dataset(data_vars), resids.transpose(sample_dim, ...)
+    return xr.Dataset(data_vars)
 
 
 class HarmonicModel:
@@ -431,16 +423,9 @@ class HarmonicModel:
             data.
         time_dim: str, default: "time"
             Name of the time dimension on `yearly_predictor` and `monthly_target`.
-
-        Returns
-        -------
-        residuals : `xr.DataArray`
-            DataArray containing
-
-            - the residuals of the model (`residuals`)
         """
 
-        params, residuals = _fit_harmonic_model(
+        params = _fit_harmonic_model(
             yearly_predictor,
             monthly_target,
             max_order=max_order,
@@ -448,8 +433,6 @@ class HarmonicModel:
         )
 
         self._params = params
-
-        self._residuals = residuals
 
     def predict(
         self,
@@ -492,7 +475,7 @@ class HarmonicModel:
         monthly_target: xr.DataArray,
         *,
         time_dim: str = "time",
-    ):
+    ) -> xr.DataArray:
         """Calculate the residuals of the fitted harmonic model
 
         Parameters
@@ -512,9 +495,7 @@ class HarmonicModel:
         Returns
         -------
         residuals : `xr.DataArray`
-            DataArray containing
-
-            - the residuals of the model (`residuals`)
+            DataArray containing the residuals of the model (`residuals`)
         """
 
         pred = self.predict(

--- a/mesmer/stats/_harmonic_model.py
+++ b/mesmer/stats/_harmonic_model.py
@@ -369,9 +369,8 @@ def _fit_harmonic_model(
 
 
 class HarmonicModel:
-    """HarmonicModel class to fit a Fourier Series to monthly data using yearly predictors."""
-
     def __init__(self):
+        """HarmonicModel class to fit a Fourier Series to monthly data using yearly predictors."""
 
         self._params = None
 

--- a/mesmer/stats/_linear_regression.py
+++ b/mesmer/stats/_linear_regression.py
@@ -10,9 +10,8 @@ from mesmer.datatree import _datatree_wrapper
 
 
 class LinearRegression:
-    """Ordinary least squares Linear Regression for xr.DataArray objects."""
-
     def __init__(self):
+        """Ordinary least squares Linear Regression for xarray objects."""
         self._params = None
 
     @classmethod

--- a/tests/unit/test_harmonic_model.py
+++ b/tests/unit/test_harmonic_model.py
@@ -89,9 +89,10 @@ def test_fit_fourier_order_np(coefficients):
     yearly_predictor = np.repeat(yearly_predictor, 12)
     monthly_target = _generate_fourier_series_np(yearly_predictor, coefficients)
 
-    selected_order, estimated_coefficients, predictions = _fit_fourier_order_np(
+    selected_order, estimated_coefficients = _fit_fourier_order_np(
         yearly_predictor, monthly_target, max_order=max_order
     )
+    predictions = _generate_fourier_series_np(yearly_predictor, estimated_coefficients)
 
     np.testing.assert_equal(selected_order, int(len(coefficients) / 4))
 


### PR DESCRIPTION
The doctoring in `HarmonicModel.fit()` said it returns the residuals, but it didn't. This bothered me too much so I cleaned it up. Now the residuals are only calculated in `HarmonicModel.residuals()` and there is also no private property. Following #881 
