### PR TITLE
remove more pandas < 2.2 compat

### DIFF
--- a/mesmer/_core/utils.py
+++ b/mesmer/_core/utils.py
@@ -158,8 +158,7 @@ def _assert_annual_data(time):
         # pandas 3.1(?) will return a BaseOffset object
         freq = freq.freqstr
 
-    # pandas v2.2 and xarray v2023.11.0 changed the time freq string for year
-    if not (freq.startswith("A") or freq.startswith("Y") or freq == "365D"):
+    if not (freq.startswith("Y") or freq == "365D"):
         raise ValueError(
             f"Annual data is required but data with frequency {freq} was passed"
         )


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Forgotten because was not protected by a `__version__` clause.
