### PR TITLE
upstream dev CI script: strict mode

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+set -o pipefail
+
 # forcibly remove packages to avoid artifacts
 conda uninstall -y --force \
   dask \


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

The upstream dev CI should fail earlier if e.g., a package is not available in the nightlies.
