### PR TITLE
draw_auto_regression_correlated: name of covariance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,10 @@ New Features
 Breaking changes
 ^^^^^^^^^^^^^^^^
 
-- Removed the legacy mesmer code  (`#899 <https://github.com/MESMER-group/mesmer/pull/899>`_).
+- The ``covariance`` passed to ``draw_auto_regression_correlated`` must now be named `localized_covariance_adjusted`
+  to avoid passing the non-adjusted covariance (`#912 <https://github.com/MESMER-group/mesmer/pull/912>`_).
+  By `Mathias Hauser`_.
+- Removed the legacy mesmer code (`#899 <https://github.com/MESMER-group/mesmer/pull/899>`_).
   By `Mathias Hauser`_.
 
 Deprecations

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -577,6 +577,16 @@ def draw_auto_regression_correlated(
 
     """
 
+    if covariance.name != "localized_covariance_adjusted":
+        raise ValueError(
+            "Expected the covariance to be named `localized_covariance_adjusted` but got"
+            f" '{covariance.name=}'. In case only `localized_covariance` is available"
+            " it can be converted like so:\n"
+            "    localized_covariance_adjusted = mesmer.stats.adjust_covariance_ar1(\n"
+            "        localized_ecov.localized_covariance, local_ar.coeffs\n"
+            "    )\n"
+        )
+
     return _draw_auto_regression_correlated(
         seed,
         ar_params,

--- a/mesmer/stats/_auto_regression.py
+++ b/mesmer/stats/_auto_regression.py
@@ -534,7 +534,8 @@ def draw_auto_regression_correlated(
         - coeffs
 
     covariance : DataArray
-        The (co-)variance array. Must be symmetric and positive-semidefinite.
+        The (co-)variance array. Must be symmetric and positive-semidefinite and
+        named ``"localized_covariance_adjusted"``.
 
     time : int | DataArray | Index
         Defines the number of auto-correlated samples to draw and possibly its

--- a/mesmer/stats/_localized_covariance.py
+++ b/mesmer/stats/_localized_covariance.py
@@ -63,7 +63,9 @@ def adjust_covariance_ar1(
     """
 
     # pass ar_coefs.data - so it will 'just work'
-    return _adjust_ecov_ar1_np(covariance, ar_coefs.data)
+    covariance = _adjust_ecov_ar1_np(covariance, ar_coefs.data)
+    covariance.name = "localized_covariance_adjusted"
+    return covariance
 
 
 def _adjust_ecov_ar1_np(covariance, ar_coefs):

--- a/tests/unit/test_auto_regression.py
+++ b/tests/unit/test_auto_regression.py
@@ -107,6 +107,7 @@ def covariance():
     data = np.eye(2)
 
     covariance = xr.DataArray(data, dims=("gridcell_i", "gridcell_j"))
+    covariance.name = "localized_covariance_adjusted"
 
     return covariance
 
@@ -277,6 +278,25 @@ def test_draw_auto_regression_uncorrelated_coords(ar_params_1D, dim, coords):
 
     assert result[dim].size == coords.size
     np.testing.assert_equal(result[dim].values, coords.values)
+
+
+def test_draw_auto_regression_correlated_cov_wrong_name(ar_params_2D, covariance):
+
+    covariance.name = "covariance"
+
+    with pytest.raises(
+        ValueError,
+        match="Expected the covariance to be named `localized_covariance_adjusted`",
+    ):
+
+        mesmer.stats.draw_auto_regression_correlated(
+            ar_params_2D,
+            covariance,
+            time=1,
+            realisation=1,
+            seed=0,
+            buffer=0,
+        )
 
 
 @pytest.mark.parametrize("drop", ("intercept", "coeffs"))

--- a/tests/unit/test_localized_covariance.py
+++ b/tests/unit/test_localized_covariance.py
@@ -399,6 +399,7 @@ def test_adjust_covariance_ar1(random_data_5x3, shape, dims):
     cov = xr.DataArray(cov, dims=("cell_i", "cell_j"))
 
     result = mesmer.stats.adjust_covariance_ar1(cov, ar_coefs)
+    assert result.name == "localized_covariance_adjusted"
 
     expected = np.array(
         [


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Fully documented, including `CHANGELOG.rst`

@yquilcaille: requires the `covariance` in `draw_auto_regression_correlated` to be named _localized_covariance_adjusted_. Not nice but should help to avoid the problem of passing the wrong covariance. I think this is independent from what we do with the wrong uploaded data.

If you are ok with this change I suggest to release version 1.1.0 in the next days.